### PR TITLE
prototype(my-books): social activity feed — experimental design gallery

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -197,6 +197,7 @@ Deep-dive references for major system domains. Each covers production architectu
 - [Imports](imports/index.md) — import pipeline, DataProvider/DataProviderRecord pattern, batch import, importapi endpoints, adding new sources
 - [Tags](tag-system/index.md) — Tag objects (`/tags/OLnT`), legacy subject system, subject→Tag lookup, community tags/observations, Solr implications, Phase 3 integration checklist
 - [OPDS](opds/index.md) — OPDS 2.0 feed service (opds.openlibrary.org), pyopds2_openlibrary library, reader.archive.org integration, local dev setup
+- [Activity Feed](subsystems/activity-feed.md) — where patron activity actually lives (three unrelated stores), the unified stream, feed API, and how to get populated test data locally
 
 ## Key File Locations
 

--- a/docs/ai/subsystems/activity-feed.md
+++ b/docs/ai/subsystems/activity-feed.md
@@ -37,6 +37,8 @@ ActivityStream.attach_works(events)  # fills in each event's Solr work record
 
 `public_feed` restricts to patrons who opted into a public reading log and drops the viewer's own activity. `following_feed` restricts to who the viewer follows and **deliberately does not re-apply the public-reading-log filter** — following is consent, so a private log still reaches the people the patron chose to publish to.
 
+`popular` is a different shape from the other two feeds: the **latest single event** from each of the most-followed readers, ordered by follower count rather than by time. It is a "who is worth following" view, one card per patron, so it is a single page by definition -- `_hasMore` is always false for it, and it deliberately does *not* fall back to the public feed when empty, since it was an explicit choice.
+
 `ActivityStream.balance(events, limit)` trims a page while keeping every card type represented — strict newest-first can return a page of one type, which is fine for a real feed and useless for comparing card designs. The endpoint exposes it as `?balanced=true`, and asks the stream for a deeper pool first, since you cannot spread three types across a pool of three.
 
 ## API
@@ -47,7 +49,7 @@ ActivityStream.attach_works(events)  # fills in each event's Solr work record
 |---|---|---|
 | `limit` | 12 | 1–50 |
 | `page` | 1 | |
-| `scope` | `auto` | `auto` picks following-or-public from the viewer; `public` and `following` force it |
+| `scope` | `auto` | `auto` picks following-or-public from the viewer; `public`, `following` and `popular` force it |
 | `balanced` | `false` | Keep every card type represented instead of strict newest-first |
 
 Returns `{scope, following, page, activity: [...]}`. Every item carries `type`, `username`, `patron_url`, `avatar_url`, `created`, `label`, and optionally `shelf_url`, `rating`, `work`, `list`. One shape serves every rendering of the feed, so a card means the same thing wherever it appears.

--- a/docs/ai/subsystems/activity-feed.md
+++ b/docs/ai/subsystems/activity-feed.md
@@ -10,9 +10,20 @@ There is no single event table. Patron activity is spread across three unrelated
 |---|---|---|
 | Shelved a book | Postgres `bookshelves_books` | `Bookshelves.get_recently_logged_books()`, or `PubSub.get_feed()` for a follow graph |
 | Rated a book | Postgres `ratings` | `Ratings.get_recent_ratings()` |
-| Liked a list | Postgres `likes` | `Likes.get_recent_likes()` |
-| Created or changed a list | Infogami things (`/type/list`) | `site.get().things({"type": "/type/list", "sort": "-last_modified"})` |
+| Added a book to a list | Infogami things (`/type/list`) | `site.get().things({"type": "/type/list", "sort": "-last_modified"})`; `List.add_seed` appends, so the last work in `seeds` is the newest add |
 | Borrowed a book | Infogami store + archive.org | Per-user only. **No public global source.** |
+
+Hearting a list is an **action** offered on the list card (`POST /api/like`), not an activity type of its own.
+
+### The three card types
+
+| # | Type | Subject | Actions |
+|---|---|---|---|
+| 1 | `shelf_change` | the book shelved | follow, add to your reading log |
+| 2 | `rating` | the book rated | follow, add to your reading log |
+| 3 | `list_add` | the book added (list is context) | follow, add to your reading log, heart the list |
+
+Rating is its own card, **not** a star tacked onto the shelving — they are two distinct acts and folding them hid one. Card three shows the added book accented with up to two of its new list-mates blurred behind it.
 
 `openlibrary/core/activity.py` normalises each into one `ActivityEvent` and merges them time-ordered.
 
@@ -26,7 +37,7 @@ ActivityStream.attach_works(events)  # fills in each event's Solr work record
 
 `public_feed` restricts to patrons who opted into a public reading log and drops the viewer's own activity. `following_feed` restricts to who the viewer follows and **deliberately does not re-apply the public-reading-log filter** — following is consent, so a private log still reaches the people the patron chose to publish to.
 
-A rating on a book the same patron just shelved folds onto the shelving rather than emitting a second near-identical card.
+`ActivityStream.balance(events, limit)` trims a page while keeping every card type represented — strict newest-first can return a page of one type, which is fine for a real feed and useless for comparing card designs. The endpoint exposes it as `?balanced=true`, and asks the stream for a deeper pool first, since you cannot spread three types across a pool of three.
 
 ## API
 
@@ -37,6 +48,7 @@ A rating on a book the same patron just shelved folds onto the shelving rather t
 | `limit` | 12 | 1–50 |
 | `page` | 1 | |
 | `scope` | `auto` | `auto` picks following-or-public from the viewer; `public` and `following` force it |
+| `balanced` | `false` | Keep every card type represented instead of strict newest-first |
 
 Returns `{scope, following, page, activity: [...]}`. Every item carries `type`, `username`, `patron_url`, `avatar_url`, `created`, `label`, and optionally `shelf_url`, `rating`, `work`, `list`. One shape serves every rendering of the feed, so a card means the same thing wherever it appears.
 
@@ -63,6 +75,10 @@ Two consequences worth knowing:
 - A backtick anywhere inside the `css` tagged template silently ends the literal, and the build fails with a bare `Missing semicolon` pointing far from the cause. Do not put code ticks in CSS comments.
 
 **Not to be confused with `<ol-activity-feed>`**, which is the homepage "What's Happening Now" widget ([#12863](https://github.com/internetarchive/openlibrary/pull/12863)). Different surfaces, shared patterns.
+
+## Planned: a computed `activity_feed` table
+
+Everything above infers events at read time from tables built for other purposes, which is why "which book was added to this list" has to be approximated from seed order. The intended direction is an `activity_feed` table written by a FastAPI background worker every ~minute, recording each event as it happens. That turns the feed into a single indexed read, makes list-add events exact rather than inferred, and gives borrow events somewhere to live if they ever become shareable.
 
 ## Traps
 

--- a/docs/ai/subsystems/activity-feed.md
+++ b/docs/ai/subsystems/activity-feed.md
@@ -1,0 +1,87 @@
+# Activity Feed
+
+The social feed of what patrons publicly do with books. Backs the "My Feed" section on My Books and the standalone `/people/{username}/books/feed` page. Epic: [#10242](https://github.com/internetarchive/openlibrary/issues/10242).
+
+## Where the data lives
+
+There is no single event table. Patron activity is spread across three unrelated stores:
+
+| Event | Store | Read via |
+|---|---|---|
+| Shelved a book | Postgres `bookshelves_books` | `Bookshelves.get_recently_logged_books()`, or `PubSub.get_feed()` for a follow graph |
+| Rated a book | Postgres `ratings` | `Ratings.get_recent_ratings()` |
+| Liked a list | Postgres `likes` | `Likes.get_recent_likes()` |
+| Created or changed a list | Infogami things (`/type/list`) | `site.get().things({"type": "/type/list", "sort": "-last_modified"})` |
+| Borrowed a book | Infogami store + archive.org | Per-user only. **No public global source.** |
+
+`openlibrary/core/activity.py` normalises each into one `ActivityEvent` and merges them time-ordered.
+
+```python
+from openlibrary.core.activity import ActivityStream
+
+events = ActivityStream.public_feed(viewer="mekBot", limit=12)
+events = ActivityStream.following_feed("mekBot", limit=12)
+ActivityStream.attach_works(events)  # fills in each event's Solr work record
+```
+
+`public_feed` restricts to patrons who opted into a public reading log and drops the viewer's own activity. `following_feed` restricts to who the viewer follows and **deliberately does not re-apply the public-reading-log filter** — following is consent, so a private log still reaches the people the patron chose to publish to.
+
+A rating on a book the same patron just shelved folds onto the shelving rather than emitting a second near-identical card.
+
+## API
+
+`GET /api/internal/activity/feed.json` (`openlibrary/fastapi/activity.py`)
+
+| Param | Default | Notes |
+|---|---|---|
+| `limit` | 12 | 1–50 |
+| `page` | 1 | |
+| `scope` | `auto` | `auto` picks following-or-public from the viewer; `public` and `following` force it |
+
+Returns `{scope, following, page, activity: [...]}`. Every item carries `type`, `username`, `patron_url`, `avatar_url`, `created`, `label`, and optionally `shelf_url`, `rating`, `work`, `list`. One shape serves every rendering of the feed, so a card means the same thing wherever it appears.
+
+## Frontend
+
+`<ol-social-feed>` — `openlibrary/components/lit/OlSocialFeed.js`.
+
+**Not to be confused with `<ol-activity-feed>`**, which is the homepage "What's Happening Now" widget ([#12863](https://github.com/internetarchive/openlibrary/pull/12863)). Different surfaces, shared patterns.
+
+## Traps
+
+**Covers must come from the Solr record's `cover_i`.** Building a cover URL from a work OLID (`//covers.openlibrary.org/w/olid/OL{work_id}W-M.jpg`) renders the *wrong* books — a real bug on [#11391](https://github.com/internetarchive/openlibrary/pull/11391).
+
+**`PubSub.get_feed()` reads `bookshelves_books` only.** It is a reading-log query filtered by the follow graph, not a general feed. Any event type beyond shelving is new work for the following case too.
+
+**`likes.key` is a generic Infogami key** with no foreign key and no type validation — it can name a work, a list, an author, or nothing at all. Validate the shape and handle a deleted target.
+
+**`public_readlog` lives in the Infogami store**, at `/people/{username}/preferences`. There is no Postgres column for it.
+
+**In dev, web.py cannot reach FastAPI on the same origin.** Production nginx routes `/api/internal/*` to the FastAPI process; a local stack has no proxy between ports 8080 and 18080. Pass the FastAPI origin explicitly when a web.py-rendered page needs the endpoint locally.
+
+## Local test data
+
+The stock dev seed creates one account, so there is no social graph, and a fresh dev Solr has ~35 works with no cover ids — a populated feed still renders as grey boxes. This is why three prior UI attempts were closed without anyone seeing a real feed.
+
+```bash
+docker compose run --rm home python scripts/dev-instance/seed_social_feed.py
+docker compose run --rm home python scripts/dev-instance/seed_social_feed.py --no-follows  # public-feed mode
+```
+
+Seeds real cover-bearing works into Solr *and* Infogami, six patrons with public reading logs, plus shelvings, ratings, lists, likes, and a follow graph. Idempotent.
+
+Two things any script writing to Infogami needs to know, learned here:
+
+- **`setup_for_script` does not set `web.ctx.ip`.** Infogami writes it to `transaction.ip`, a Postgres `inet` column, and rejects the empty string — so the write 500s with `invalid input syntax for type inet`. Set `web.ctx.ip = "127.0.0.1"` after calling it.
+- **`User.new_list()` does not save**; the caller must `_save()`. Its seeds must point at works that exist as Infogami things, not just Solr docs, or the save fails with a bare `KeyError` on the seed key.
+
+## Tests
+
+```bash
+docker compose run --rm home python -m pytest openlibrary/core/tests/test_activity.py openlibrary/tests/fastapi/test_activity_feed.py
+
+# End to end, against seeded data. The dev stack has no web.py -> FastAPI proxy,
+# so the endpoint origin is passed in.
+OL_FEED_API=http://localhost:18080/api/internal/activity/feed.json npx playwright test tests/e2e/activity-feed.spec.ts
+```
+
+The Playwright suite asserts the **populated** state specifically. An empty feed passing as "it renders" is the failure mode that closed the prior attempts.

--- a/docs/ai/subsystems/activity-feed.md
+++ b/docs/ai/subsystems/activity-feed.md
@@ -44,6 +44,24 @@ Returns `{scope, following, page, activity: [...]}`. Every item carries `type`, 
 
 `<ol-social-feed>` — `openlibrary/components/lit/OlSocialFeed.js`.
 
+**Every activity type renders into one card skeleton**, following Goodreads' Updates panel:
+
+```
+avatar   Actor  verb  target                        when   [Follow]
+         ┌───────┐  Title
+         │ media │  subtitle
+         └───────┘  [primary action] [secondary]  ★★★★☆
+```
+
+A shelving fills `media` with a book cover and `verb` with the shelf; a list update fills `media` with a fan of three covers and `subtitle` with a book count; a like fills the same slots from the liked list. Nothing about the frame changes.
+
+`_present(item)` is the only place that knows how the types differ — it maps an event onto `{href, covers, title, subtitle, actions}`. **Adding an event type means one `_present` branch, not a new template.** Layout variants are CSS over that single markup, so a card means the same thing to a reader wherever it appears.
+
+Two consequences worth knowing:
+
+- Do not branch on `item.type` in the template. Branch on the *shape* (`item.list` vs `item.work`) inside `_present`, so a new type that produces a list card needs no template change — this is how likes reuse the list rendering.
+- A backtick anywhere inside the `css` tagged template silently ends the literal, and the build fails with a bare `Missing semicolon` pointing far from the cause. Do not put code ticks in CSS comments.
+
 **Not to be confused with `<ol-activity-feed>`**, which is the homepage "What's Happening Now" widget ([#12863](https://github.com/internetarchive/openlibrary/pull/12863)). Different surfaces, shared patterns.
 
 ## Traps

--- a/docs/ai/subsystems/activity-feed.md
+++ b/docs/ai/subsystems/activity-feed.md
@@ -74,7 +74,9 @@ A shelving fills `media` with a book cover and `verb` with the shelf; a list upd
 Two consequences worth knowing:
 
 - Do not branch on `item.type` in the template. Branch on the *shape* (`item.list` vs `item.work`) inside `_present`, so a new type that produces a list card needs no template change — this is how likes reuse the list rendering.
-- A backtick anywhere inside the `css` tagged template silently ends the literal, and the build fails with a bare `Missing semicolon` pointing far from the cause. Do not put code ticks in CSS comments.
+- A backtick anywhere inside the `css` tagged template ends the literal. An **odd** number fails the build with a bare `Missing semicolon` pointing far from the cause; an **even** number builds cleanly and breaks at runtime, so the component silently stops rendering. Do not put code ticks in CSS comments. This has bitten four times.
+- A blur filter paints outside its element's box. Clip it, or it reads as a smudge over whatever sits beside it.
+- Flex and grid items default to `min-width: auto`, i.e. min-content. A `white-space: nowrap` descendant then sets the card's minimum width and pushes it out of its track. Set `min-width: 0` on cards and slots.
 
 **Not to be confused with `<ol-activity-feed>`**, which is the homepage "What's Happening Now" widget ([#12863](https://github.com/internetarchive/openlibrary/pull/12863)). Different surfaces, shared patterns.
 

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -215,6 +215,7 @@ def create_app() -> FastAPI | None:
         return {"status": "ok"}
 
     from openlibrary.fastapi.account import router as account_router
+    from openlibrary.fastapi.activity import router as activity_router
     from openlibrary.fastapi.books import router as books_router
     from openlibrary.fastapi.cdn import router as cdn_router
     from openlibrary.fastapi.checkins import router as checkins_router
@@ -235,6 +236,7 @@ def create_app() -> FastAPI | None:
 
     # Include routers
     app.include_router(account_router)
+    app.include_router(activity_router)
     app.include_router(books_router)
     app.include_router(cdn_router)
     app.include_router(checkins_router)

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -41,9 +41,11 @@ import { LitElement, css, html } from 'lit';
  * @prop {String} apiUrl - Endpoint to fetch feed JSON from
  * @prop {Number} variant - Layout treatment, 1-10
  * @prop {Number} limit - Events to request per page
- * @prop {String} scope - `auto`, `public`, or `following`
+ * @prop {String} scope - `auto`, `public`, `following`, or `popular`
  * @prop {Boolean} balanced - Keep every card type on screen instead of strict newest-first
  * @prop {Boolean} controls - Show the refresh and older/newer controls
+ * @prop {Boolean} tabs - Show Discover / Following / Popular tabs that switch scope
+ * @prop {Boolean} infinite - Scroll in a fixed-height column, appending pages as you reach the end
  * @prop {String} viewerUsername - Logged-in patron, for follow state and self-filtering
  * @prop {Number} refreshInterval - Seconds between background refreshes; 0 disables
  * @prop {String} heading - Panel heading; omit to render the feed without a panel
@@ -67,6 +69,7 @@ export const FEED_VARIANTS = [
     { id: 9, slug: 'editorial', name: 'Editorial', blurb: 'Uppercase eyebrow, large type, almost no chrome. Actions on hover.' },
     { id: 10, slug: 'people', name: 'People first', blurb: 'Grouped by patron: who they are, then a strip of what they touched.' },
     { id: 11, slug: 'showcase', name: 'Showcase row', blurb: 'Three cards across on desktop, stacked on mobile. Refresh the whole row; swipe or press next for older activity.' },
+    { id: 12, slug: 'tabbed', name: 'Discover / Following / Popular', blurb: 'Bluesky shape: tabs over one scrolling column that loads more as you reach the end. Popular shows one card each from the most-followed readers.' },
 ];
 
 const VARIANT_BY_ID = new Map(FEED_VARIANTS.map((v) => [v.id, v]));
@@ -101,6 +104,8 @@ export class OlSocialFeed extends LitElement {
         scope: { type: String },
         balanced: { type: Boolean },
         controls: { type: Boolean },
+        tabs: { type: Boolean },
+        infinite: { type: Boolean },
         viewerUsername: { type: String, attribute: 'viewer-username' },
         refreshInterval: { type: Number, attribute: 'refresh-interval' },
         heading: { type: String },
@@ -114,6 +119,7 @@ export class OlSocialFeed extends LitElement {
         _page: { state: true },
         _hasMore: { state: true },
         _busy: { state: true },
+        _scope: { state: true },
     };
 
     constructor() {
@@ -124,6 +130,8 @@ export class OlSocialFeed extends LitElement {
         this.scope = 'auto';
         this.balanced = false;
         this.controls = false;
+        this.tabs = false;
+        this.infinite = false;
         this.viewerUsername = '';
         this.refreshInterval = 60;
         this.heading = '';
@@ -137,11 +145,16 @@ export class OlSocialFeed extends LitElement {
         this._page = 1;
         this._hasMore = false;
         this._busy = false;
+        this._scope = '';
         this._timer = null;
     }
 
     connectedCallback() {
         super.connectedCallback();
+        // `scope` is the configured default; `_scope` is what the tabs change.
+        // With tabs on, `auto` names no tab, so nothing would look selected --
+        // start on Discover instead.
+        this._scope = this.tabs && this.scope === 'auto' ? 'public' : this.scope;
         this._load();
         this._startTimer();
     }
@@ -149,6 +162,27 @@ export class OlSocialFeed extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
         this._stopTimer();
+        this._observer?.disconnect();
+    }
+
+    updated() {
+        this._watchForTheEnd();
+    }
+
+    /** Append the next page once the foot of the column comes into view. */
+    _watchForTheEnd() {
+        if (!this.infinite) return;
+        const sentinel = this.renderRoot.querySelector('.sentinel');
+        if (!sentinel || sentinel === this._watched) return;
+        this._observer?.disconnect();
+        this._observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) this._loadMore();
+            },
+            { root: this.renderRoot.querySelector('.scroller'), rootMargin: '300px' }
+        );
+        this._observer.observe(sentinel);
+        this._watched = sentinel;
     }
 
     _startTimer() {
@@ -169,9 +203,10 @@ export class OlSocialFeed extends LitElement {
         return `${item.type}:${item.username}:${item.work?.key || item.list?.key}:${item.created}`;
     }
 
-    async _load({ background = false } = {}) {
-        if (!background) this._loading = true;
-        const url = `${this.apiUrl}?limit=${this.limit}&page=${this._page}&scope=${this.scope}${this.balanced ? '&balanced=true' : ''}`;
+    async _load({ background = false, append = false } = {}) {
+        if (!background && !append) this._loading = true;
+        const scope = this._scope || this.scope;
+        const url = `${this.apiUrl}?limit=${this.limit}&page=${this._page}&scope=${scope}${this.balanced ? '&balanced=true' : ''}`;
         try {
             const response = await fetch(url, { headers: { Accept: 'application/json' } });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -185,9 +220,10 @@ export class OlSocialFeed extends LitElement {
                 this._freshKeys = new Set(items.map((item) => this._key(item)).filter((key) => !seen.has(key)));
             }
 
-            this._items = items;
-            // A short page means there is nothing older to turn to.
-            this._hasMore = items.length >= this.limit;
+            this._items = append ? [...this._items, ...items] : items;
+            // A short page means there is nothing older to turn to. Popular is
+            // one card per patron, so it is a single page by definition.
+            this._hasMore = data.scope !== 'popular' && items.length >= this.limit;
             this._error = false;
             this.dispatchEvent(
                 new CustomEvent('ol-social-feed-load', {
@@ -209,6 +245,51 @@ export class OlSocialFeed extends LitElement {
         this._busy = true;
         await this._load({ background: true });
         this._busy = false;
+        this._scope = '';
+    }
+
+    /** Pull the next page in beneath what is already on screen. */
+    async _loadMore() {
+        if (this._busy || !this._hasMore) return;
+        this._busy = true;
+        this._page += 1;
+        await this._load({ append: true });
+        this._busy = false;
+    }
+
+    /** Switch between Discover and Following, starting over at page one. */
+    async _selectScope(scope) {
+        if (this._scope === scope || this._busy) return;
+        this._scope = scope;
+        this._page = 1;
+        this._busy = true;
+        await this._load();
+        this._busy = false;
+    }
+
+    _renderTabs() {
+        if (!this.tabs) return '';
+        const tab = (scope, label) => html`<button
+            class="tab ${this._scope === scope ? 'is-current' : ''}"
+            type="button"
+            role="tab"
+            aria-selected=${this._scope === scope}
+            @click=${() => this._selectScope(scope)}
+        >${label}</button>`;
+        return html`<div class="tabs" role="tablist" aria-label="Feed">
+            ${tab('public', 'Discover')}${tab('following', 'Following')}${tab('popular', 'Popular')}
+        </div>`;
+    }
+
+    _renderMore() {
+        if (!this.infinite) return '';
+        return html`
+            <div class="sentinel" aria-hidden="true"></div>
+            ${this._hasMore
+        ? html`<button class="load-more" type="button" ?disabled=${this._busy}
+                    @click=${() => this._loadMore()}>${this._busy ? 'Loading\u2026' : 'Load more'}</button>`
+        : html`<p class="end">You are all caught up.</p>`}
+        `;
     }
 
     /** Turn to older or newer activity. */
@@ -218,6 +299,7 @@ export class OlSocialFeed extends LitElement {
         this._busy = true;
         await this._load();
         this._busy = false;
+        this._scope = '';
         this._startTimer();
     }
 
@@ -479,18 +561,23 @@ export class OlSocialFeed extends LitElement {
 
         let inner;
         if (this._loading) {
-            inner = html`<div class="state" aria-busy="true">Loading activity&hellip;</div>`;
+            inner = html`${this._renderTabs()}<div class="state" aria-busy="true">Loading activity&hellip;</div>`;
         } else if (this._error) {
             inner = html`<div class="state">
                 Could not load the activity feed.
                 <button class="btn btn--ghost" type="button" @click=${() => this._load()}>Retry</button>
             </div>`;
         } else if (!this._items.length) {
-            inner = html`<div class="state">
-                No recent activity yet. Follow other readers and their updates will show up here.
+            inner = html`${this._renderTabs()}<div class="state">
+                ${{
+        following: 'Nobody you follow has been active lately. Try Discover.',
+        popular: 'No activity yet from the most-followed readers.',
+    }[this._scope] || 'No recent activity yet. Follow other readers and their updates will show up here.'}
             </div>`;
         } else {
-            inner = html`<div class="feed feed--${variant.slug}" aria-live="polite" aria-busy=${this._busy}
+            inner = html`${this._renderTabs()}
+            <div class="${this.infinite ? 'scroller' : ''}">
+            <div class="feed feed--${variant.slug}" aria-live="polite" aria-busy=${this._busy}
                 @touchstart=${(e) => this._onTouchStart(e)} @touchend=${(e) => this._onTouchEnd(e)}>
                 ${this.variant === 10
         ? this._renderPeople()
@@ -499,6 +586,8 @@ export class OlSocialFeed extends LitElement {
                             ${this._renderCard(item)}
                         </div>`
         )}
+            </div>
+            ${this._renderMore()}
             </div>
             ${this._renderControls()}`;
         }
@@ -997,6 +1086,8 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+            .feed--tabbed .content { padding-left: 0; }
+            .scroller { max-height: 65vh; }
 
             /* Same cards, stacked. Refresh stays reachable at the top, and
                paging moves to a full-width control at the foot of the list. */
@@ -1095,6 +1186,77 @@ export class OlSocialFeed extends LitElement {
         .ctl:hover:not(:disabled) { border-color: var(--primary-blue, #0577b5); color: var(--primary-blue, #0577b5); }
         .ctl:disabled { opacity: 0.4; cursor: default; }
 
+        /* == 12. Discover / Following ===================================== */
+        /* One scrolling column under two tabs, appending as you reach the end. */
+
+        .tabs {
+            display: flex;
+            border-bottom: var(--border-width-thin, 1px) solid var(--feed-rule);
+            margin-bottom: 4px;
+        }
+        .tab {
+            font: inherit;
+            font-size: 0.92rem;
+            font-weight: 600;
+            flex: 1;
+            padding: 12px 8px;
+            background: none;
+            border: 0;
+            border-bottom: var(--border-width-heavy, 3px) solid transparent;
+            color: var(--feed-muted);
+            cursor: pointer;
+        }
+        .tab:hover { color: inherit; }
+        .tab.is-current {
+            color: inherit;
+            border-bottom-color: var(--primary-blue, #0577b5);
+        }
+
+        .scroller {
+            max-height: 70vh;
+            overflow-y: auto;
+            overscroll-behavior: contain;
+        }
+
+        .sentinel { height: 1px; }
+
+        .load-more {
+            font: inherit;
+            font-size: 0.88rem;
+            font-weight: 600;
+            display: block;
+            width: 100%;
+            padding: 14px;
+            margin-top: 4px;
+            background: none;
+            border: 0;
+            border-top: 1px solid var(--feed-rule);
+            color: var(--primary-blue, #0577b5);
+            cursor: pointer;
+        }
+        .load-more:hover:not(:disabled) { background: var(--grey-fafafa, #fafafa); }
+        .load-more:disabled { color: var(--feed-muted); cursor: default; }
+
+        .end {
+            margin: 0;
+            padding: 18px;
+            text-align: center;
+            color: var(--feed-muted);
+            font-size: 0.85rem;
+            border-top: 1px solid var(--feed-rule);
+        }
+
+        .feed--tabbed { display: flex; flex-direction: column; }
+        .feed--tabbed .card {
+            padding: 16px 4px;
+            border-bottom: 1px solid var(--feed-rule);
+        }
+        .feed--tabbed .content { padding-left: calc(var(--feed-gutter) + 8px); }
+        .feed--tabbed .avatar { width: var(--feed-gutter); height: var(--feed-gutter); }
+        .feed--tabbed .cover { width: 62px; height: 92px; }
+        .feed--tabbed .cover--group { width: 96px; }
+        .feed--tabbed .title { font-size: 1rem; }
+
         /* -- mobile ------------------------------------------------------- */
 
         @media (max-width: 767px) {
@@ -1119,6 +1281,8 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+            .feed--tabbed .content { padding-left: 0; }
+            .scroller { max-height: 65vh; }
 
             /* Same cards, stacked. Refresh stays reachable at the top, and
                paging moves to a full-width control at the foot of the list. */

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -246,7 +246,7 @@ export class OlSocialFeed extends LitElement {
     }
 
     _cover(item, size = 'M') {
-        if (item.type === 'list_update') return this._listCovers(item);
+        if (item.list) return this._listCovers(item);
         const work = item.work;
         return html`<a class="cover" href=${work.key}>
             <img
@@ -270,14 +270,14 @@ export class OlSocialFeed extends LitElement {
     }
 
     _title(item) {
-        if (item.type === 'list_update') {
+        if (item.list) {
             return html`<a class="title" href=${item.list.key}>${item.list.name}</a>`;
         }
         return html`<a class="title" href=${item.work.key}>${item.work.title}</a>`;
     }
 
     _byline(item) {
-        if (item.type === 'list_update') {
+        if (item.list) {
             return html`<span class="byline">${item.list.book_count} books</span>`;
         }
         const { author, author_key: authorKey } = item.work;
@@ -286,7 +286,7 @@ export class OlSocialFeed extends LitElement {
     }
 
     _actions(item) {
-        if (item.type === 'list_update') {
+        if (item.list) {
             return html`<a class="btn btn--primary" href=${item.list.key}>View List</a>`;
         }
         const action = primaryAction(item);
@@ -421,7 +421,7 @@ export class OlSocialFeed extends LitElement {
                 <p class="sentence">
                     <a class="handle" href=${item.patron_url}>${item.username}</a> ${this._action(item)}
                 </p>
-                <a class="chip" href=${item.type === 'list_update' ? item.list.key : item.work.key}>
+                <a class="chip" href=${item.list ? item.list.key : item.work.key}>
                     ${this._cover(item, 'S')}
                     <span class="chip__meta">${this._title(item)}${this._byline(item)}</span>
                 </a>

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -8,21 +8,28 @@ import { LitElement, css, html } from 'lit';
  * event carries the actions a reader would want next -- borrow or shelve the
  * book, open the list, follow the patron.
  *
- * ## One container for every activity type
+ * ## One container, three card types
  *
- * Following Goodreads' Updates panel, every event type renders into the *same*
- * card skeleton rather than getting its own bespoke layout:
+ * Following Goodreads' Updates panel, every activity type renders into the
+ * *same* card skeleton rather than getting its own bespoke layout:
  *
  *     avatar   Actor  verb  target                            when   [Follow]
  *              ┌───────┐  Title
  *              │ media │  subtitle
- *              └───────┘  [primary action] [secondary]  ★★★★☆
+ *              └───────┘  [add to reading log]  [type-specific action]
  *
- * A shelving fills `media` with a book cover and `target` with the shelf; a
- * list update fills `media` with a fan of three covers and `subtitle` with a
- * book count. Nothing about the frame changes. Adding an event type means
- * writing one `_present` branch, not a new template -- and a card means the
- * same thing to a reader wherever it appears.
+ * Three types fill it today, in the order they matter:
+ *
+ * 1. `shelf_change` -- shelved on Want to Read / Currently Reading /
+ *    Already Read. Actions: follow, add the book to your own reading log.
+ * 2. `rating` -- gave the book stars. Its own card, not a decoration on the
+ *    shelving. Same actions.
+ * 3. `list_add` -- added the book to one of their lists. The book is the
+ *    subject and the list is context, so the actions are the same two plus
+ *    hearting the list.
+ *
+ * Follow is offered on every card. `_present` is the only code that knows how
+ * the types differ -- a fourth type is one branch there, not a new template.
  *
  * The `variant` property then selects one of ten CSS treatments over that one
  * skeleton. Because they are the same markup and the same data, switching
@@ -35,6 +42,8 @@ import { LitElement, css, html } from 'lit';
  * @prop {Number} variant - Layout treatment, 1-10
  * @prop {Number} limit - Events to request per page
  * @prop {String} scope - `auto`, `public`, or `following`
+ * @prop {Boolean} balanced - Keep every card type on screen instead of strict newest-first
+ * @prop {Boolean} controls - Show the refresh and older/newer controls
  * @prop {String} viewerUsername - Logged-in patron, for follow state and self-filtering
  * @prop {Number} refreshInterval - Seconds between background refreshes; 0 disables
  * @prop {String} heading - Panel heading; omit to render the feed without a panel
@@ -57,6 +66,7 @@ export const FEED_VARIANTS = [
     { id: 8, slug: 'ticker', name: 'Ticker', blurb: 'One compact line each. Sized to sit under a heading as a teaser strip.' },
     { id: 9, slug: 'editorial', name: 'Editorial', blurb: 'Uppercase eyebrow, large type, almost no chrome. Actions on hover.' },
     { id: 10, slug: 'people', name: 'People first', blurb: 'Grouped by patron: who they are, then a strip of what they touched.' },
+    { id: 11, slug: 'showcase', name: 'Showcase row', blurb: 'Three cards across on desktop, stacked on mobile. Refresh the whole row; swipe or press next for older activity.' },
 ];
 
 const VARIANT_BY_ID = new Map(FEED_VARIANTS.map((v) => [v.id, v]));
@@ -89,6 +99,8 @@ export class OlSocialFeed extends LitElement {
         variant: { type: Number, reflect: true },
         limit: { type: Number },
         scope: { type: String },
+        balanced: { type: Boolean },
+        controls: { type: Boolean },
         viewerUsername: { type: String, attribute: 'viewer-username' },
         refreshInterval: { type: Number, attribute: 'refresh-interval' },
         heading: { type: String },
@@ -98,6 +110,10 @@ export class OlSocialFeed extends LitElement {
         _error: { state: true },
         _following: { state: true },
         _freshKeys: { state: true },
+        _hearted: { state: true },
+        _page: { state: true },
+        _hasMore: { state: true },
+        _busy: { state: true },
     };
 
     constructor() {
@@ -106,6 +122,8 @@ export class OlSocialFeed extends LitElement {
         this.variant = 1;
         this.limit = 12;
         this.scope = 'auto';
+        this.balanced = false;
+        this.controls = false;
         this.viewerUsername = '';
         this.refreshInterval = 60;
         this.heading = '';
@@ -115,6 +133,10 @@ export class OlSocialFeed extends LitElement {
         this._error = false;
         this._following = new Set();
         this._freshKeys = new Set();
+        this._hearted = new Set();
+        this._page = 1;
+        this._hasMore = false;
+        this._busy = false;
         this._timer = null;
     }
 
@@ -149,7 +171,7 @@ export class OlSocialFeed extends LitElement {
 
     async _load({ background = false } = {}) {
         if (!background) this._loading = true;
-        const url = `${this.apiUrl}?limit=${this.limit}&scope=${this.scope}`;
+        const url = `${this.apiUrl}?limit=${this.limit}&page=${this._page}&scope=${this.scope}${this.balanced ? '&balanced=true' : ''}`;
         try {
             const response = await fetch(url, { headers: { Accept: 'application/json' } });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -164,6 +186,8 @@ export class OlSocialFeed extends LitElement {
             }
 
             this._items = items;
+            // A short page means there is nothing older to turn to.
+            this._hasMore = items.length >= this.limit;
             this._error = false;
             this.dispatchEvent(
                 new CustomEvent('ol-social-feed-load', {
@@ -178,6 +202,55 @@ export class OlSocialFeed extends LitElement {
         } finally {
             this._loading = false;
         }
+    }
+
+    /** Reload the current page in place -- the refresh control. */
+    async _refresh() {
+        this._busy = true;
+        await this._load({ background: true });
+        this._busy = false;
+    }
+
+    /** Turn to older or newer activity. */
+    async _turnTo(page) {
+        if (page < 1 || this._busy) return;
+        this._page = page;
+        this._busy = true;
+        await this._load();
+        this._busy = false;
+        this._startTimer();
+    }
+
+    _onTouchStart(e) {
+        this._touchX = e.changedTouches[0].clientX;
+    }
+
+    _onTouchEnd(e) {
+        if (this._touchX === undefined) return;
+        const dx = e.changedTouches[0].clientX - this._touchX;
+        this._touchX = undefined;
+        // Swiping left pulls the next page in from the right, matching how the
+        // arrow beside the row reads.
+        if (dx < -60 && this._hasMore) this._turnTo(this._page + 1);
+        else if (dx > 60 && this._page > 1) this._turnTo(this._page - 1);
+    }
+
+    _renderControls() {
+        if (!this.controls) return '';
+        return html`<div class="controls">
+            <button class="ctl" type="button" ?disabled=${this._busy}
+                @click=${() => this._refresh()} aria-label="Refresh activity">
+                <span aria-hidden="true">↻</span>
+            </button>
+            <button class="ctl" type="button" ?disabled=${this._page <= 1 || this._busy}
+                @click=${() => this._turnTo(this._page - 1)} aria-label="Newer activity">
+                <span aria-hidden="true">‹</span>
+            </button>
+            <button class="ctl ctl--next" type="button" ?disabled=${!this._hasMore || this._busy}
+                @click=${() => this._turnTo(this._page + 1)} aria-label="Older activity">
+                <span class="ctl__text">Older</span> <span aria-hidden="true">›</span>
+            </button>
+        </div>`;
     }
 
     async _toggleFollow(username) {
@@ -221,38 +294,62 @@ export class OlSocialFeed extends LitElement {
      * all of them.
      */
     _present(item) {
-        const isList = Boolean(item.list);
+        const work = item.work;
+        // Adding the book to your own reading log is offered on all three
+        // card types, because all three are ultimately about a book.
+        const actions = [{ kind: 'shelve', label: 'Want to Read', href: work.key }];
 
-        if (isList) {
-            const ids = item.list.cover_ids.length ? item.list.cover_ids : [null];
-            return {
-                href: item.list.key,
-                covers: ids.slice(0, 3),
-                coverAlt: item.list.name,
-                title: item.list.name,
-                subtitle: `${item.list.book_count} ${item.list.book_count === 1 ? 'book' : 'books'}`,
-                subtitleHref: null,
-                actions: [{ label: 'View List', href: item.list.key, primary: true }],
-            };
+        if (item.list) {
+            actions.unshift({
+                kind: 'heart',
+                label: item.list.like_count ? `♥ ${item.list.like_count}` : '♥',
+                accessibleLabel: `Heart the list ${item.list.name}`,
+                listKey: item.list.key,
+            });
         }
 
-        const work = item.work;
-        // A borrowable book leads with Borrow; everything else leads with the shelf.
-        const borrowable = work.ebook_access === 'borrowable' || work.ebook_access === 'public';
+        // Card three shows what the book was filed alongside: the added book,
+        // accented, with up to two of its new shelf-mates behind it.
+        const others = item.list
+            ? (item.list.cover_ids || []).filter((id) => id !== work.cover_id).slice(0, 2)
+            : [];
+
         return {
             href: work.key,
-            covers: [work.cover_id],
+            coverId: work.cover_id,
             coverAlt: `Cover of ${work.title}`,
+            otherCoverIds: others,
             title: work.title,
-            subtitle: work.author ? `by ${work.author}` : 'Unknown author',
-            subtitleHref: work.author ? work.author_key : null,
-            actions: borrowable
-                ? [
-                    { label: 'Borrow', href: work.key, primary: true },
-                    { label: 'Want to Read', href: work.key, primary: false },
-                ]
-                : [{ label: 'Want to Read', href: work.key, primary: true }],
+            author: work.author,
+            authorKey: work.author_key,
+            actions,
         };
+    }
+
+    async _toggleHeart(listKey) {
+        if (!this.viewerUsername) {
+            window.location = `/account/login?redir_url=${encodeURIComponent(window.location.pathname)}`;
+            return;
+        }
+        const hearted = this._hearted.has(listKey);
+        const next = new Set(this._hearted);
+        if (hearted) next.delete(listKey);
+        else next.add(listKey);
+        this._hearted = next;
+
+        try {
+            const response = await fetch('/api/like', {
+                method: hearted ? 'DELETE' : 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ key: listKey, value: 1 }),
+            });
+            if (!response.ok) throw new Error('heart failed');
+        } catch {
+            const reverted = new Set(this._hearted);
+            if (hearted) reverted.add(listKey);
+            else reverted.delete(listKey);
+            this._hearted = reverted;
+        }
     }
 
     // -- the one card skeleton --------------------------------------------
@@ -261,7 +358,6 @@ export class OlSocialFeed extends LitElement {
         const slot = this._present(item);
         const following = this._following.has(item.username);
         const isViewer = item.username === this.viewerUsername;
-        const stacked = slot.covers.length > 1;
 
         return html`<article class="card" data-type=${item.type}>
             <div class="head">
@@ -274,6 +370,9 @@ export class OlSocialFeed extends LitElement {
                     ${item.shelf_url
         ? html`<a class="verb" href=${item.shelf_url}>${item.label}</a>`
         : html`<span class="verb">${item.label}</span>`}
+                    ${item.list
+        ? html`<a class="target" href=${item.list.key}>${item.list.name}</a>`
+        : ''}
                 </p>
                 <time class="when">${timeAgo(item.created)}</time>
                 ${isViewer
@@ -287,32 +386,45 @@ export class OlSocialFeed extends LitElement {
             </div>
 
             <div class="content">
-                <a class="cover ${stacked ? 'cover--stack' : ''}" href=${slot.href}
-                    aria-label=${stacked ? slot.coverAlt : ''}>
-                    ${slot.covers.map(
-        (id) => html`<img src=${coverUrl(id)} alt=${stacked ? '' : slot.coverAlt} loading="lazy"
+                <a class="cover ${slot.otherCoverIds.length ? 'cover--group' : ''}" href=${slot.href}>
+                    ${slot.otherCoverIds.map(
+        (id) => html`<img class="cover__mate" src=${coverUrl(id)} alt="" aria-hidden="true" loading="lazy"
                             @error=${(e) => { e.target.src = FALLBACK_COVER; }} />`
     )}
+                    <img class="cover__subject" src=${coverUrl(slot.coverId)} alt=${slot.coverAlt} loading="lazy"
+                        @error=${(e) => { e.target.src = FALLBACK_COVER; }} />
                 </a>
                 <div class="body">
                     <a class="title" href=${slot.href}>${slot.title}</a>
                     <span class="byline">
-                        ${slot.subtitleHref
-        ? html`by <a href=${slot.subtitleHref}>${slot.subtitle.replace(/^by /, '')}</a>`
-        : slot.subtitle}
+                        ${slot.author
+        ? html`by ${slot.authorKey ? html`<a href=${slot.authorKey}>${slot.author}</a>` : slot.author}`
+        : 'Unknown author'}
                     </span>
                     ${item.rating
         ? html`<span class="stars" aria-label="Rated ${item.rating} out of 5"
                             >${'★'.repeat(item.rating)}<span class="stars__empty">${'★'.repeat(5 - item.rating)}</span></span>`
         : ''}
                     <div class="actions">
-                        ${slot.actions.map(
-        (a) => html`<a class="btn ${a.primary ? 'btn--primary' : 'btn--ghost'}" href=${a.href}>${a.label}</a>`
-    )}
+                        ${slot.actions.map((action) => this._renderAction(action))}
                     </div>
                 </div>
             </div>
         </article>`;
+    }
+
+    _renderAction(action) {
+        if (action.kind === 'heart') {
+            const hearted = this._hearted.has(action.listKey);
+            return html`<button
+                class="btn btn--ghost heart ${hearted ? 'is-hearted' : ''}"
+                type="button"
+                aria-pressed=${hearted}
+                aria-label=${action.accessibleLabel}
+                @click=${() => this._toggleHeart(action.listKey)}
+            >${action.label}</button>`;
+        }
+        return html`<a class="btn btn--primary" href=${action.href}>${action.label}</a>`;
     }
 
     /**
@@ -351,7 +463,7 @@ export class OlSocialFeed extends LitElement {
         const slot = this._present(item);
         return html`<figure class="strip__item">
                             <a class="cover" href=${slot.href}>
-                                <img src=${coverUrl(slot.covers[0])} alt=${slot.coverAlt} loading="lazy"
+                                <img src=${coverUrl(slot.coverId)} alt=${slot.coverAlt} loading="lazy"
                                     @error=${(e) => { e.target.src = FALLBACK_COVER; }} />
                             </a>
                             <figcaption>${item.label}</figcaption>
@@ -378,7 +490,8 @@ export class OlSocialFeed extends LitElement {
                 No recent activity yet. Follow other readers and their updates will show up here.
             </div>`;
         } else {
-            inner = html`<div class="feed feed--${variant.slug}" aria-live="polite">
+            inner = html`<div class="feed feed--${variant.slug}" aria-live="polite" aria-busy=${this._busy}
+                @touchstart=${(e) => this._onTouchStart(e)} @touchend=${(e) => this._onTouchEnd(e)}>
                 ${this.variant === 10
         ? this._renderPeople()
         : this._items.map(
@@ -386,7 +499,8 @@ export class OlSocialFeed extends LitElement {
                             ${this._renderCard(item)}
                         </div>`
         )}
-            </div>`;
+            </div>
+            ${this._renderControls()}`;
         }
 
         // The panel is the outer common container: one frame around every
@@ -508,6 +622,16 @@ export class OlSocialFeed extends LitElement {
         .verb { color: var(--link-blue, #04618f); text-decoration: none; }
         a.verb:hover { text-decoration: underline; }
 
+        .target {
+            font-weight: 600;
+            text-decoration: none;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .target:hover { text-decoration: underline; }
+
         .when {
             color: var(--feed-muted);
             font-size: 0.8rem;
@@ -556,14 +680,29 @@ export class OlSocialFeed extends LitElement {
             background: var(--grey-f3f3f3, #f3f3f3);
         }
 
-        /* Three list covers fanned horizontally, overlapping, so each stays
-           legible in the footprint a single cover would take. */
-        .cover--stack { width: 90px; align-items: flex-start; }
-        .cover--stack img {
-            width: 60%;
-            border: var(--border-width, 1px) solid var(--white, #fff);
+
+        /* Card three: the added book sits proud of the list-mates it joined.
+           The mates are blurred and dimmed so they read as context, not as
+           three equal covers. */
+        .cover--group { position: relative; width: 96px; }
+        .cover--group .cover__mate {
+            position: absolute;
+            top: 8px;
+            width: 46px;
+            height: 68px;
+            filter: blur(1.5px);
+            opacity: 0.55;
+            border-radius: var(--border-radius-thumbnail, 6px);
         }
-        .cover--stack img + img { margin-left: -40%; }
+        .cover--group .cover__mate:nth-of-type(1) { right: 0; transform: rotate(4deg); }
+        .cover--group .cover__mate:nth-of-type(2) { right: 18px; transform: rotate(-3deg); }
+        .cover--group .cover__subject {
+            position: relative;
+            z-index: 1;
+            width: 62px;
+            outline: var(--border-width-thick, 2px) solid var(--primary-blue, #0577b5);
+            outline-offset: 1px;
+        }
 
         .body {
             min-width: 0;
@@ -609,6 +748,12 @@ export class OlSocialFeed extends LitElement {
             background: transparent;
             border-color: var(--feed-rule);
             color: inherit;
+        }
+
+        .heart { font: inherit; font-size: 0.85rem; font-weight: 600; }
+        .heart.is-hearted {
+            color: var(--red, #c0392b);
+            border-color: currentColor;
         }
 
         :focus-visible {
@@ -662,7 +807,6 @@ export class OlSocialFeed extends LitElement {
         }
         .feed--river .content { padding-left: calc(var(--feed-gutter) + 8px); }
         .feed--river .cover { width: 110px; height: 165px; }
-        .feed--river .cover--stack { width: 150px; height: 140px; }
         .feed--river .title { font-size: 1.15rem; }
         .feed--river .avatar { width: var(--feed-gutter); height: var(--feed-gutter); }
 
@@ -701,8 +845,6 @@ export class OlSocialFeed extends LitElement {
         .feed--cover-tiles .content { height: 100%; }
         .feed--cover-tiles .cover { width: 100%; height: 100%; }
         .feed--cover-tiles .cover img { border-radius: 0; box-shadow: none; }
-        .feed--cover-tiles .cover--stack { align-items: stretch; }
-        .feed--cover-tiles .cover--stack img { width: 33.34%; margin-left: 0; border: 0; }
         .feed--cover-tiles .body { display: none; }
 
         /* == 4. Dense timeline ============================================ */
@@ -731,7 +873,6 @@ export class OlSocialFeed extends LitElement {
         .feed--timeline .body { flex: 1; }
         .feed--timeline .avatar { width: 22px; height: 22px; }
         .feed--timeline .cover { width: 32px; height: 46px; }
-        .feed--timeline .cover--stack { width: 50px; }
         .feed--timeline .body { flex-direction: row; align-items: baseline; gap: 6px; min-width: 0; }
         .feed--timeline .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
         .feed--timeline .byline, .feed--timeline .actions, .feed--timeline .follow { display: none; }
@@ -752,7 +893,6 @@ export class OlSocialFeed extends LitElement {
         }
         .feed--thread .avatar { width: var(--feed-gutter); height: var(--feed-gutter); }
         .feed--thread .cover { width: 46px; height: 68px; }
-        .feed--thread .cover--stack { width: 72px; height: 68px; }
         .feed--thread .title { font-size: 0.92rem; }
 
         /* == 6. Magazine ================================================== */
@@ -767,7 +907,6 @@ export class OlSocialFeed extends LitElement {
         .feed--magazine .content { order: 1; flex-direction: column; }
         .feed--magazine .cover { width: 100%; height: 260px; }
         .feed--magazine .cover img { object-fit: contain; }
-        .feed--magazine .cover--stack { height: 140px; }
         .feed--magazine .title {
             font-family: var(--font-family-serif, Georgia, serif);
             font-size: 1.4rem;
@@ -791,7 +930,6 @@ export class OlSocialFeed extends LitElement {
             padding: 8px;
         }
         .feed--bubbles .cover { width: 34px; height: 50px; }
-        .feed--bubbles .cover--stack { width: 56px; }
         .feed--bubbles .title { font-size: 0.9rem; }
         .feed--bubbles .actions { display: none; }
 
@@ -820,7 +958,6 @@ export class OlSocialFeed extends LitElement {
         .feed--ticker .body { flex: 1; }
         .feed--ticker .avatar { width: 20px; height: 20px; }
         .feed--ticker .cover { width: 26px; height: 38px; }
-        .feed--ticker .cover--stack { width: 40px; }
         .feed--ticker .body { flex-direction: row; align-items: baseline; gap: 6px; min-width: 0; }
         .feed--ticker .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
         .feed--ticker .byline,
@@ -847,7 +984,6 @@ export class OlSocialFeed extends LitElement {
             color: var(--feed-muted);
         }
         .feed--editorial .cover { width: 70px; height: 104px; }
-        .feed--editorial .cover--stack { width: 110px; height: 104px; }
         .feed--editorial .title { font-size: 1.5rem; line-height: 1.1; }
         .feed--editorial .actions {
             opacity: 0;
@@ -861,6 +997,14 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+
+            /* Same cards, stacked. Refresh stays reachable at the top, and
+               paging moves to a full-width control at the foot of the list. */
+            .feed--showcase { grid-template-columns: 1fr; }
+            .feed--showcase .card { height: auto; }
+            .feed--showcase .content { flex: 0 1 auto; }
+            .controls { justify-content: stretch; }
+            .ctl--next { flex: 1; justify-content: center; }
         }
 
         /* == 10. People first ============================================= */
@@ -889,6 +1033,68 @@ export class OlSocialFeed extends LitElement {
             line-height: 1.2;
         }
 
+        /* == 11. Showcase row ============================================= */
+        /* Three across on desktop, the same cards stacked on mobile. Paging
+           rather than infinite scroll, so the row always holds three. */
+
+        .feed--showcase {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 16px;
+            align-items: stretch;
+        }
+        .feed--showcase .card {
+            background: var(--feed-card-bg);
+            border: var(--border-width-thin, 1px) solid var(--feed-rule);
+            border-radius: var(--border-radius-card, 9px);
+            box-shadow: var(--feed-shadow);
+            padding: 12px 14px 14px;
+            height: 100%;
+        }
+        .feed--showcase .head {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            grid-template-areas:
+                "gutter . follow"
+                "sentence sentence when";
+            row-gap: 6px;
+        }
+        .feed--showcase .gutter { grid-area: gutter; }
+        .feed--showcase .follow { grid-area: follow; }
+        .feed--showcase .sentence { grid-area: sentence; }
+        .feed--showcase .when { grid-area: when; margin-left: 0; align-self: baseline; }
+        .feed--showcase .content {
+            flex: 1;
+            border-top: 1px solid var(--feed-rule);
+            padding-top: 10px;
+        }
+        .feed--showcase .actions { margin-top: auto; }
+
+        .controls {
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            gap: 8px;
+            margin-top: 12px;
+        }
+        .ctl {
+            font: inherit;
+            font-size: 0.85rem;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            min-height: 36px;
+            padding: 0 12px;
+            border: var(--border-width-thin, 1px) solid var(--feed-rule);
+            border-radius: var(--border-radius-pill, 9999px);
+            background: var(--feed-card-bg);
+            color: inherit;
+            cursor: pointer;
+        }
+        .ctl:hover:not(:disabled) { border-color: var(--primary-blue, #0577b5); color: var(--primary-blue, #0577b5); }
+        .ctl:disabled { opacity: 0.4; cursor: default; }
+
         /* -- mobile ------------------------------------------------------- */
 
         @media (max-width: 767px) {
@@ -913,6 +1119,14 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+
+            /* Same cards, stacked. Refresh stays reachable at the top, and
+               paging moves to a full-width control at the foot of the list. */
+            .feed--showcase { grid-template-columns: 1fr; }
+            .feed--showcase .card { height: auto; }
+            .feed--showcase .content { flex: 0 1 auto; }
+            .controls { justify-content: stretch; }
+            .ctl--next { flex: 1; justify-content: center; }
         }
     `;
 }

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -1,0 +1,1020 @@
+import { LitElement, css, html } from 'lit';
+
+/**
+ * OlSocialFeed -- the social activity feed for My Books.
+ *
+ * Renders a stream of what other patrons are doing with books: shelving them,
+ * rating them, gathering them into lists. Every event carries the actions a
+ * reader would want next -- borrow or shelve the book, follow the patron.
+ *
+ * The `variant` property selects one of ten layout treatments. They are all
+ * driven off the same feed response and the same card content, so switching
+ * between them is an honest comparison of presentation rather than of data.
+ * Nine of them are scaffolding for a design decision and will be removed once
+ * one is chosen.
+ *
+ * @element ol-social-feed
+ *
+ * @prop {String} apiUrl - Endpoint to fetch feed JSON from
+ * @prop {Number} variant - Layout treatment, 1-10
+ * @prop {Number} limit - Events to request per page
+ * @prop {String} scope - `auto`, `public`, or `following`
+ * @prop {String} viewerUsername - Logged-in patron, for follow state and self-filtering
+ * @prop {Number} refreshInterval - Seconds between background refreshes; 0 disables
+ * @prop {String} heading - Optional heading rendered above the feed
+ * @fires ol-social-feed-load - Fired after each successful fetch. detail: { count: Number, scope: String }
+ */
+
+const COVERS_BASE = 'https://covers.openlibrary.org/b/id';
+const FALLBACK_COVER = '/static/images/icons/avatar_book-sm.png';
+
+/** Every layout treatment, in the order the gallery presents them. */
+export const FEED_VARIANTS = [
+    { id: 1, slug: 'spec-card', name: 'Spec card', blurb: 'The reviewed design: patron and follow above the rule, book and actions below. Three up on desktop.' },
+    { id: 2, slug: 'river', name: 'Goodreads river', blurb: 'Full-width rows, one continuous sentence, generous cover, text actions.' },
+    { id: 3, slug: 'cover-tiles', name: 'Cover tiles', blurb: 'The cover is the card. Caption strip overlays the bottom. Scrolls horizontally.' },
+    { id: 4, slug: 'timeline', name: 'Dense timeline', blurb: 'A rail of small avatars down the left. Maximum events per screen.' },
+    { id: 5, slug: 'thread', name: 'Social thread', blurb: 'Bluesky shape: avatar column, prose, and the book as an embedded quote card.' },
+    { id: 6, slug: 'magazine', name: 'Magazine', blurb: 'Two-column masonry, big covers, serif titles, lots of air.' },
+    { id: 7, slug: 'bubbles', name: 'Conversation', blurb: 'Activity as messages. Reads as live chatter rather than a log.' },
+    { id: 8, slug: 'ticker', name: 'Ticker', blurb: 'One compact line each. Sized to sit under a heading as a teaser strip.' },
+    { id: 9, slug: 'editorial', name: 'Editorial', blurb: 'Uppercase eyebrow, large type, almost no chrome. Actions on hover.' },
+    { id: 10, slug: 'people', name: 'People first', blurb: 'Grouped by patron: who they are, then a strip of what they touched.' },
+];
+
+const VARIANT_BY_ID = new Map(FEED_VARIANTS.map((v) => [v.id, v]));
+
+/** Compact relative time: `3d`, `2h`, `just now`. */
+export function timeAgo(iso) {
+    if (!iso) return '';
+    const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+    const units = [
+        ['y', 31536000],
+        ['mo', 2592000],
+        ['w', 604800],
+        ['d', 86400],
+        ['h', 3600],
+        ['m', 60],
+    ];
+    for (const [suffix, size] of units) {
+        if (seconds >= size) return `${Math.floor(seconds / size)}${suffix}`;
+    }
+    return 'just now';
+}
+
+function coverUrl(coverId, size = 'M') {
+    return coverId ? `${COVERS_BASE}/${coverId}-${size}.jpg` : FALLBACK_COVER;
+}
+
+/**
+ * The action most worth offering for a book, given how it can be read.
+ * A borrowable book leads with Borrow; everything else leads with the shelf.
+ */
+function primaryAction(item) {
+    const work = item.work;
+    if (!work) return null;
+    if (work.ebook_access === 'borrowable' || work.ebook_access === 'public') {
+        return { label: 'Borrow', href: work.key };
+    }
+    return { label: 'Want to Read', href: work.key };
+}
+
+export class OlSocialFeed extends LitElement {
+    static properties = {
+        apiUrl: { type: String, attribute: 'api-url' },
+        variant: { type: Number, reflect: true },
+        limit: { type: Number },
+        scope: { type: String },
+        viewerUsername: { type: String, attribute: 'viewer-username' },
+        refreshInterval: { type: Number, attribute: 'refresh-interval' },
+        heading: { type: String },
+        _items: { state: true },
+        _loading: { state: true },
+        _error: { state: true },
+        _following: { state: true },
+        _freshKeys: { state: true },
+    };
+
+    constructor() {
+        super();
+        this.apiUrl = '/api/internal/activity/feed.json';
+        this.variant = 1;
+        this.limit = 12;
+        this.scope = 'auto';
+        this.viewerUsername = '';
+        this.refreshInterval = 60;
+        this.heading = '';
+        this._items = [];
+        this._loading = true;
+        this._error = false;
+        this._following = new Set();
+        this._freshKeys = new Set();
+        this._timer = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._load();
+        this._startTimer();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._stopTimer();
+    }
+
+    _startTimer() {
+        this._stopTimer();
+        if (!this.refreshInterval) return;
+        this._timer = setInterval(() => this._load({ background: true }), this.refreshInterval * 1000);
+    }
+
+    _stopTimer() {
+        if (this._timer) {
+            clearInterval(this._timer);
+            this._timer = null;
+        }
+    }
+
+    /** Stable identity for an event, so a refresh can tell new from seen. */
+    _key(item) {
+        return `${item.type}:${item.username}:${item.work?.key || item.list?.key}:${item.created}`;
+    }
+
+    async _load({ background = false } = {}) {
+        if (!background) this._loading = true;
+        const url = `${this.apiUrl}?limit=${this.limit}&scope=${this.scope}`;
+        try {
+            const response = await fetch(url, { headers: { Accept: 'application/json' } });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const data = await response.json();
+            const items = data.activity || [];
+
+            // On a background refresh, mark what the patron has not seen yet so
+            // new arrivals can announce themselves instead of silently shuffling.
+            if (background) {
+                const seen = new Set(this._items.map((item) => this._key(item)));
+                this._freshKeys = new Set(items.map((item) => this._key(item)).filter((key) => !seen.has(key)));
+            }
+
+            this._items = items;
+            this._error = false;
+            this.dispatchEvent(
+                new CustomEvent('ol-social-feed-load', {
+                    detail: { count: items.length, scope: data.scope },
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+        } catch {
+            // A failed background refresh keeps whatever is already on screen.
+            if (!background) this._error = true;
+        } finally {
+            this._loading = false;
+        }
+    }
+
+    async _toggleFollow(username) {
+        if (!this.viewerUsername) {
+            window.location = `/account/login?redir_url=${encodeURIComponent(window.location.pathname)}`;
+            return;
+        }
+        const wasFollowing = this._following.has(username);
+        const next = new Set(this._following);
+        if (wasFollowing) next.delete(username);
+        else next.add(username);
+        this._following = next;
+
+        const body = new FormData();
+        body.append('publisher', username);
+        body.append('state', wasFollowing ? '1' : '0');
+        body.append('redir_url', window.location.pathname);
+
+        try {
+            const response = await fetch(`/people/${this.viewerUsername}/follows.json`, {
+                method: 'POST',
+                body,
+                redirect: 'manual',
+            });
+            if (!response.ok && response.type !== 'opaqueredirect') throw new Error('follow failed');
+        } catch {
+            const reverted = new Set(this._following);
+            if (wasFollowing) reverted.add(username);
+            else reverted.delete(username);
+            this._following = reverted;
+        }
+    }
+
+    // -- shared card pieces ----------------------------------------------
+    // Every variant composes these, so the same information is on offer in all
+    // ten and the comparison is about presentation only.
+
+    _avatar(item, size = 'md') {
+        return html`<img
+            class="avatar avatar--${size}"
+            src=${item.avatar_url}
+            alt=""
+            loading="lazy"
+            @error=${(e) => { e.target.src = FALLBACK_COVER; }}
+        />`;
+    }
+
+    _followButton(item) {
+        if (item.username === this.viewerUsername) return '';
+        const following = this._following.has(item.username);
+        return html`<button
+            class="follow ${following ? 'is-following' : ''}"
+            type="button"
+            aria-pressed=${following}
+            @click=${() => this._toggleFollow(item.username)}
+        >${following ? 'Following' : 'Follow'}</button>`;
+    }
+
+    _stars(rating) {
+        if (!rating) return '';
+        return html`<span class="stars" aria-label="Rated ${rating} out of 5">
+            ${'★'.repeat(rating)}<span class="stars__empty">${'★'.repeat(5 - rating)}</span>
+        </span>`;
+    }
+
+    /** "added to Want to Read", with the shelf linked when there is one. */
+    _action(item) {
+        if (item.shelf_url) {
+            return html`<a class="action-link" href=${item.shelf_url}>${item.label}</a>`;
+        }
+        return html`<span class="action-link">${item.label}</span>`;
+    }
+
+    _cover(item, size = 'M') {
+        if (item.type === 'list_update') return this._listCovers(item);
+        const work = item.work;
+        return html`<a class="cover" href=${work.key}>
+            <img
+                src=${coverUrl(work.cover_id, size)}
+                alt="Cover of ${work.title}"
+                loading="lazy"
+                @error=${(e) => { e.target.src = FALLBACK_COVER; }}
+            />
+        </a>`;
+    }
+
+    /** Three covers fanned out horizontally, per the reviewed list-card design. */
+    _listCovers(item) {
+        const ids = item.list.cover_ids.length ? item.list.cover_ids : [null];
+        return html`<a class="cover cover--stack" href=${item.list.key} aria-label=${item.list.name}>
+            ${ids.slice(0, 3).map(
+        (id) => html`<img src=${coverUrl(id, 'M')} alt="" loading="lazy"
+                    @error=${(e) => { e.target.src = FALLBACK_COVER; }} />`
+    )}
+        </a>`;
+    }
+
+    _title(item) {
+        if (item.type === 'list_update') {
+            return html`<a class="title" href=${item.list.key}>${item.list.name}</a>`;
+        }
+        return html`<a class="title" href=${item.work.key}>${item.work.title}</a>`;
+    }
+
+    _byline(item) {
+        if (item.type === 'list_update') {
+            return html`<span class="byline">${item.list.book_count} books</span>`;
+        }
+        const { author, author_key: authorKey } = item.work;
+        if (!author) return html`<span class="byline">Unknown author</span>`;
+        return html`<span class="byline">by ${authorKey ? html`<a href=${authorKey}>${author}</a>` : author}</span>`;
+    }
+
+    _actions(item) {
+        if (item.type === 'list_update') {
+            return html`<a class="btn btn--primary" href=${item.list.key}>View List</a>`;
+        }
+        const action = primaryAction(item);
+        return html`
+            <a class="btn btn--primary" href=${action.href}>${action.label}</a>
+            ${action.label === 'Borrow' ? html`<a class="btn btn--ghost" href=${item.work.key}>Want to Read</a>` : ''}
+        `;
+    }
+
+    // -- variants ---------------------------------------------------------
+
+    /** 1 -- the reviewed design: patron and follow above the rule, book below. */
+    _renderSpecCard(item) {
+        return html`<article class="card">
+            <header class="card__head">
+                <a class="patron" href=${item.patron_url}>${this._avatar(item)}<span class="handle">@${item.username}</span></a>
+                ${this._followButton(item)}
+            </header>
+            <p class="card__action">${this._action(item)} <span class="dot">&middot;</span> ${timeAgo(item.created)}</p>
+            <hr class="rule" />
+            <div class="card__body">
+                ${this._cover(item)}
+                <div class="meta">
+                    ${this._title(item)}
+                    ${this._byline(item)}
+                    ${this._stars(item.rating)}
+                </div>
+            </div>
+            <footer class="card__actions">${this._actions(item)}</footer>
+        </article>`;
+    }
+
+    /** 2 -- Goodreads' shape: one sentence, one big cover, text actions. */
+    _renderRiver(item) {
+        return html`<article class="card">
+            <header class="card__head">
+                <a class="patron" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item, 'lg')}</a>
+                <p class="sentence">
+                    <a class="handle" href=${item.patron_url}>${item.username}</a>
+                    ${this._action(item)}
+                    ${this._stars(item.rating)}
+                </p>
+                <time class="when">${timeAgo(item.created)}</time>
+            </header>
+            <div class="card__body">
+                ${this._cover(item, 'L')}
+                <div class="meta">
+                    ${this._title(item)}
+                    ${this._byline(item)}
+                    <div class="textactions">
+                        ${this._actions(item)}
+                        ${this._followButton(item)}
+                    </div>
+                </div>
+            </div>
+        </article>`;
+    }
+
+    /** 3 -- the cover is the card; the caption sits over its foot. */
+    _renderCoverTile(item) {
+        return html`<article class="card">
+            ${this._cover(item, 'L')}
+            <div class="caption">
+                <a class="patron" href=${item.patron_url}>${this._avatar(item, 'sm')}<span class="handle">${item.username}</span></a>
+                <span class="what">${item.label} &middot; ${timeAgo(item.created)}</span>
+            </div>
+        </article>`;
+    }
+
+    /** 4 -- maximum events per screen, on a rail. */
+    _renderTimeline(item) {
+        return html`<article class="card">
+            <a class="rail" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item, 'sm')}</a>
+            <div class="line">
+                <p class="sentence">
+                    <a class="handle" href=${item.patron_url}>${item.username}</a>
+                    ${this._action(item)}
+                    ${this._title(item)}
+                    ${this._stars(item.rating)}
+                    <time class="when">${timeAgo(item.created)}</time>
+                </p>
+            </div>
+            ${this._cover(item, 'S')}
+        </article>`;
+    }
+
+    /** 5 -- Bluesky's shape: prose, with the book as an embedded quote card. */
+    _renderThread(item) {
+        return html`<article class="card">
+            <a class="gutter" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item)}</a>
+            <div class="stream">
+                <p class="sentence">
+                    <a class="handle" href=${item.patron_url}>@${item.username}</a>
+                    <span class="dot">&middot;</span>
+                    <time class="when">${timeAgo(item.created)}</time>
+                    ${this._followButton(item)}
+                </p>
+                <p class="what">${this._action(item)} ${this._stars(item.rating)}</p>
+                <div class="quote">
+                    ${this._cover(item, 'S')}
+                    <div class="meta">
+                        ${this._title(item)}
+                        ${this._byline(item)}
+                    </div>
+                </div>
+                <div class="tray">${this._actions(item)}</div>
+            </div>
+        </article>`;
+    }
+
+    /** 6 -- covers given room to breathe, in two columns. */
+    _renderMagazine(item) {
+        return html`<article class="card">
+            ${this._cover(item, 'L')}
+            <div class="meta">
+                <p class="eyebrow">
+                    <a class="handle" href=${item.patron_url}>${item.username}</a> ${item.label}
+                </p>
+                ${this._title(item)}
+                ${this._byline(item)}
+                ${this._stars(item.rating)}
+                <footer class="card__actions">${this._actions(item)}</footer>
+            </div>
+        </article>`;
+    }
+
+    /** 7 -- activity as chatter rather than a log. */
+    _renderBubble(item) {
+        return html`<article class="card">
+            <a class="gutter" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item)}</a>
+            <div class="bubble">
+                <p class="sentence">
+                    <a class="handle" href=${item.patron_url}>${item.username}</a> ${this._action(item)}
+                </p>
+                <a class="chip" href=${item.type === 'list_update' ? item.list.key : item.work.key}>
+                    ${this._cover(item, 'S')}
+                    <span class="chip__meta">${this._title(item)}${this._byline(item)}</span>
+                </a>
+                <p class="foot">${this._stars(item.rating)}<time class="when">${timeAgo(item.created)}</time></p>
+            </div>
+        </article>`;
+    }
+
+    /** 8 -- one line each, sized to sit under a My Books heading. */
+    _renderTicker(item) {
+        return html`<article class="card">
+            ${this._cover(item, 'S')}
+            <p class="sentence">
+                <a class="handle" href=${item.patron_url}>${item.username}</a>
+                ${this._action(item)}
+                ${this._title(item)}
+            </p>
+            <time class="when">${timeAgo(item.created)}</time>
+        </article>`;
+    }
+
+    /** 9 -- big type, no chrome, actions only on hover or focus. */
+    _renderEditorial(item) {
+        return html`<article class="card">
+            ${this._cover(item, 'M')}
+            <div class="meta">
+                <p class="eyebrow">${item.label}</p>
+                ${this._title(item)}
+                ${this._byline(item)}
+                <p class="attrib">
+                    <a class="handle" href=${item.patron_url}>${item.username}</a>
+                    <span class="dot">&middot;</span>
+                    <time class="when">${timeAgo(item.created)}</time>
+                    ${this._stars(item.rating)}
+                </p>
+            </div>
+            <div class="reveal">${this._actions(item)}${this._followButton(item)}</div>
+        </article>`;
+    }
+
+    /**
+     * 10 -- regroups the same events by patron, to push following rather than
+     * individual books. Presentation-level grouping; the data is unchanged.
+     */
+    _renderPeople() {
+        const groups = new Map();
+        for (const item of this._items) {
+            if (!groups.has(item.username)) groups.set(item.username, []);
+            groups.get(item.username).push(item);
+        }
+        return html`${[...groups.entries()].map(
+            ([username, items]) => html`<article class="card">
+                <header class="card__head">
+                    <a class="patron" href=${items[0].patron_url}>
+                        ${this._avatar(items[0], 'lg')}
+                        <span class="handle">@${username}</span>
+                    </a>
+                    ${this._followButton(items[0])}
+                </header>
+                <p class="summary">
+                    ${items.length} recent ${items.length === 1 ? 'update' : 'updates'}
+                    <span class="dot">&middot;</span>
+                    ${timeAgo(items[0].created)}
+                </p>
+                <div class="strip">
+                    ${items.map(
+        (item) => html`<figure class="strip__item">
+                            ${this._cover(item, 'M')}
+                            <figcaption>${item.label}</figcaption>
+                        </figure>`
+    )}
+                </div>
+            </article>`
+        )}`;
+    }
+
+    _renderItem(item) {
+        switch (this.variant) {
+        case 2: return this._renderRiver(item);
+        case 3: return this._renderCoverTile(item);
+        case 4: return this._renderTimeline(item);
+        case 5: return this._renderThread(item);
+        case 6: return this._renderMagazine(item);
+        case 7: return this._renderBubble(item);
+        case 8: return this._renderTicker(item);
+        case 9: return this._renderEditorial(item);
+        default: return this._renderSpecCard(item);
+        }
+    }
+
+    render() {
+        const variant = VARIANT_BY_ID.get(this.variant) || FEED_VARIANTS[0];
+
+        if (this._loading) {
+            return html`<div class="state" aria-busy="true">Loading activity&hellip;</div>`;
+        }
+        if (this._error) {
+            return html`<div class="state">
+                Could not load the activity feed.
+                <button class="btn btn--ghost" type="button" @click=${() => this._load()}>Retry</button>
+            </div>`;
+        }
+        if (!this._items.length) {
+            return html`<div class="state">
+                No recent activity yet. Follow other readers and their updates will show up here.
+            </div>`;
+        }
+
+        return html`
+            ${this.heading ? html`<h2 class="heading">${this.heading}</h2>` : ''}
+            <div class="feed feed--${variant.slug}" aria-live="polite">
+                ${this.variant === 10
+        ? this._renderPeople()
+        : this._items.map(
+            (item) => html`<div class="slot ${this._freshKeys.has(this._key(item)) ? 'is-fresh' : ''}">
+                            ${this._renderItem(item)}
+                        </div>`
+        )}
+            </div>
+        `;
+    }
+
+    static styles = css`
+        :host {
+            display: block;
+            font-family: inherit;
+            color: var(--grey-464646, #464646);
+
+            --feed-card-bg: var(--white, #fff);
+            --feed-rule: var(--grey-e7e7e7, #e7e7e7);
+            --feed-muted: var(--grey, #666);
+            --feed-shadow: 2px 2px 4px hsla(0, 0%, 0%, 0.1);
+        }
+
+        .heading {
+            font-size: 1.15rem;
+            margin: 0 0 12px;
+        }
+
+        .state {
+            padding: 24px;
+            text-align: center;
+            color: var(--feed-muted);
+        }
+
+        /* A background refresh brings in new events; they fade rather than pop. */
+        .slot.is-fresh { animation: settle 900ms ease-out; }
+
+        @keyframes settle {
+            from { opacity: 0; transform: translateY(-6px); }
+            to { opacity: 1; transform: none; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .slot.is-fresh { animation: none; }
+        }
+
+        /* -- shared primitives -- */
+
+        a { color: inherit; }
+
+        .avatar {
+            border-radius: var(--border-radius-avatar, 50%);
+            object-fit: cover;
+            flex-shrink: 0;
+            background: var(--grey-f3f3f3, #f3f3f3);
+        }
+        .avatar--sm { width: 22px; height: 22px; }
+        .avatar--md { width: 32px; height: 32px; }
+        .avatar--lg { width: 44px; height: 44px; }
+
+        .patron {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            text-decoration: none;
+            min-width: 0;
+        }
+
+        .handle {
+            font-weight: 600;
+            text-decoration: none;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .handle:hover { text-decoration: underline; }
+
+        .follow {
+            border: var(--border-width-thin, 1px) solid var(--primary-blue, #0577b5);
+            background: var(--primary-blue, #0577b5);
+            color: var(--white, #fff);
+            border-radius: var(--border-radius-pill, 9999px);
+            padding: 4px 14px;
+            font: inherit;
+            font-size: 0.78rem;
+            font-weight: 600;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+        .follow:hover { background: var(--link-blue, #04618f); }
+        .follow.is-following {
+            background: transparent;
+            color: var(--primary-blue, #0577b5);
+        }
+
+        .action-link {
+            color: var(--link-blue, #04618f);
+            text-decoration: none;
+        }
+        .action-link:hover { text-decoration: underline; }
+
+        .cover {
+            display: block;
+            flex-shrink: 0;
+        }
+        .cover img {
+            display: block;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: var(--border-radius-thumbnail, 6px);
+            box-shadow: var(--feed-shadow);
+            background: var(--grey-f3f3f3, #f3f3f3);
+        }
+
+        /* Three list covers fanned out, per the reviewed list-card design. */
+        .cover--stack {
+            display: flex;
+            gap: 4px;
+        }
+        .cover--stack img { width: 33%; }
+
+        .title {
+            display: block;
+            font-weight: 700;
+            line-height: 1.25;
+            text-decoration: none;
+        }
+        .title:hover { text-decoration: underline; }
+
+        .byline {
+            display: block;
+            font-size: 0.82rem;
+            color: var(--feed-muted);
+        }
+        .byline a { text-decoration: none; }
+        .byline a:hover { text-decoration: underline; }
+
+        .stars { color: var(--orange, #e8a33d); white-space: nowrap; }
+        .stars__empty { color: var(--grey-e7e7e7, #ddd); }
+
+        .when, .dot { color: var(--feed-muted); font-size: 0.8rem; }
+
+        .btn {
+            display: inline-block;
+            text-align: center;
+            text-decoration: none;
+            border-radius: var(--border-radius-button, 6px);
+            padding: 7px 12px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            border: var(--border-width-thin, 1px) solid transparent;
+            cursor: pointer;
+        }
+        .btn--primary {
+            background: var(--primary-blue, #0577b5);
+            color: var(--white, #fff);
+        }
+        .btn--primary:hover { background: var(--link-blue, #04618f); }
+        .btn--ghost {
+            background: transparent;
+            border-color: var(--feed-rule);
+            color: inherit;
+        }
+
+        :focus-visible {
+            outline: var(--border-width-thick, 2px) solid var(--primary-blue, #0577b5);
+            outline-offset: 2px;
+        }
+
+        /* == 1. Spec card ================================================= */
+
+        .feed--spec-card {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        }
+        .feed--spec-card .card {
+            background: var(--feed-card-bg);
+            border: var(--border-width-thin, 1px) solid var(--feed-rule);
+            border-radius: var(--border-radius-card, 9px);
+            box-shadow: var(--feed-shadow);
+            padding: 12px 14px 14px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            height: 100%;
+        }
+        .feed--spec-card .card__head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+        }
+        .feed--spec-card .card__action { margin: 0; font-size: 0.82rem; }
+        .feed--spec-card .rule { border: 0; border-top: 1px solid var(--feed-rule); margin: 2px 0; width: 100%; }
+        .feed--spec-card .card__body { display: flex; gap: 12px; flex: 1; }
+        .feed--spec-card .cover { width: 62px; height: 90px; }
+        .feed--spec-card .cover--stack { width: 90px; height: 90px; }
+        .feed--spec-card .meta { min-width: 0; }
+        .feed--spec-card .title { font-size: 0.95rem; margin-bottom: 3px; }
+        .feed--spec-card .card__actions { display: flex; flex-direction: column; gap: 6px; }
+
+        /* == 2. Goodreads river =========================================== */
+
+        .feed--river { display: flex; flex-direction: column; }
+        .feed--river .card {
+            border-bottom: 1px solid var(--feed-rule);
+            padding: 20px 4px;
+        }
+        .feed--river .card__head {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+        .feed--river .sentence { margin: 0; }
+        .feed--river .card__body { display: flex; gap: 20px; padding-left: 56px; }
+        .feed--river .cover { width: 110px; height: 165px; }
+        .feed--river .cover--stack { width: 150px; height: 140px; }
+        .feed--river .title { font-size: 1.15rem; margin-bottom: 4px; }
+        .feed--river .textactions { display: flex; align-items: center; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
+
+        /* == 3. Cover tiles =============================================== */
+
+        .feed--cover-tiles {
+            display: grid;
+            grid-auto-flow: column;
+            grid-auto-columns: 190px;
+            gap: 14px;
+            overflow-x: auto;
+            padding-bottom: 10px;
+            scroll-snap-type: x mandatory;
+        }
+        .feed--cover-tiles .slot { scroll-snap-align: start; }
+        .feed--cover-tiles .card {
+            position: relative;
+            border-radius: var(--border-radius-card, 9px);
+            overflow: hidden;
+            box-shadow: var(--feed-shadow);
+            background: var(--grey-f3f3f3, #f3f3f3);
+            height: 280px;
+        }
+        .feed--cover-tiles .cover { width: 100%; height: 100%; }
+        .feed--cover-tiles .cover img { border-radius: 0; box-shadow: none; }
+        .feed--cover-tiles .cover--stack { align-items: stretch; }
+        .feed--cover-tiles .cover--stack img { width: 33.34%; margin-left: 0; border: 0; }
+        .feed--cover-tiles .caption {
+            position: absolute;
+            inset: auto 0 0 0;
+            padding: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            color: var(--white, #fff);
+            background: linear-gradient(to top, hsla(0, 0%, 0%, 0.85), hsla(0, 0%, 0%, 0));
+        }
+        .feed--cover-tiles .what { font-size: 0.75rem; opacity: 0.9; }
+        .feed--cover-tiles .handle { font-size: 0.85rem; }
+
+        /* == 4. Dense timeline ============================================ */
+
+        .feed--timeline { display: flex; flex-direction: column; }
+        .feed--timeline .card {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 4px;
+            border-bottom: 1px solid var(--feed-rule);
+        }
+        .feed--timeline .sentence {
+            margin: 0;
+            font-size: 0.88rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            align-items: baseline;
+        }
+        .feed--timeline .title { display: inline; font-size: 0.88rem; }
+        .feed--timeline .cover { width: 32px; height: 46px; }
+        .feed--timeline .cover--stack { width: 50px; }
+
+        /* == 5. Social thread ============================================= */
+
+        .feed--thread { display: flex; flex-direction: column; }
+        .feed--thread .card {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 12px;
+            padding: 16px 4px;
+            border-bottom: 1px solid var(--feed-rule);
+        }
+        .feed--thread .sentence,
+        .feed--thread .what { margin: 0 0 6px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+        .feed--thread .quote {
+            display: flex;
+            gap: 12px;
+            border: 1px solid var(--feed-rule);
+            border-radius: var(--border-radius-card, 9px);
+            padding: 10px;
+            margin: 4px 0 10px;
+        }
+        .feed--thread .cover { width: 46px; height: 68px; }
+        .feed--thread .cover--stack { width: 72px; height: 68px; }
+        .feed--thread .title { font-size: 0.92rem; }
+        .feed--thread .tray { display: flex; gap: 8px; }
+        .feed--thread .follow { margin-left: auto; }
+
+        /* == 6. Magazine ================================================== */
+
+        .feed--magazine {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 32px;
+        }
+        .feed--magazine .card { display: flex; flex-direction: column; gap: 14px; }
+        .feed--magazine .cover { width: 100%; height: 260px; }
+        .feed--magazine .cover img { object-fit: contain; }
+        .feed--magazine .cover--stack { height: 140px; }
+        .feed--magazine .eyebrow {
+            margin: 0 0 6px;
+            font-size: 0.76rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--feed-muted);
+        }
+        .feed--magazine .title {
+            font-family: var(--font-family-serif, Georgia, serif);
+            font-size: 1.4rem;
+            line-height: 1.15;
+            margin-bottom: 6px;
+        }
+        .feed--magazine .card__actions { display: flex; gap: 8px; margin-top: 14px; }
+
+        /* == 7. Conversation ============================================== */
+
+        .feed--bubbles { display: flex; flex-direction: column; gap: 14px; }
+        .feed--bubbles .card { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: start; }
+        .feed--bubbles .bubble {
+            background: var(--grey-f3f3f3, #f3f3f3);
+            border-radius: var(--border-radius-xl, 12px);
+            border-top-left-radius: var(--border-radius-sm, 3px);
+            padding: 12px 14px;
+        }
+        .feed--bubbles .sentence { margin: 0 0 8px; }
+        .feed--bubbles .chip {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            background: var(--white, #fff);
+            border-radius: var(--border-radius-md, 6px);
+            padding: 8px;
+            text-decoration: none;
+        }
+        .feed--bubbles .cover { width: 34px; height: 50px; }
+        .feed--bubbles .cover--stack { width: 56px; }
+        .feed--bubbles .title { font-size: 0.9rem; }
+        .feed--bubbles .foot { margin: 8px 0 0; display: flex; gap: 10px; align-items: center; }
+
+        /* == 8. Ticker ==================================================== */
+
+        .feed--ticker { display: flex; flex-direction: column; }
+        .feed--ticker .card {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+            gap: 10px;
+            padding: 6px 8px;
+            border-radius: var(--border-radius-md, 6px);
+        }
+        .feed--ticker .slot:nth-child(odd) .card { background: var(--grey-fafafa, #fafafa); }
+        .feed--ticker .cover { width: 26px; height: 38px; }
+        .feed--ticker .cover--stack { width: 40px; }
+        .feed--ticker .sentence {
+            margin: 0;
+            font-size: 0.85rem;
+            display: flex;
+            gap: 5px;
+            min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .feed--ticker .title { display: inline; font-weight: 700; }
+
+        /* == 9. Editorial ================================================= */
+
+        .feed--editorial { display: flex; flex-direction: column; }
+        .feed--editorial .card {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 20px;
+            align-items: center;
+            padding: 22px 4px;
+            border-bottom: 1px solid var(--feed-rule);
+            position: relative;
+        }
+        .feed--editorial .cover { width: 70px; height: 104px; }
+        .feed--editorial .cover--stack { width: 110px; height: 104px; }
+        .feed--editorial .eyebrow {
+            margin: 0 0 4px;
+            font-size: 0.7rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: var(--feed-muted);
+        }
+        .feed--editorial .title { font-size: 1.5rem; line-height: 1.1; }
+        .feed--editorial .attrib { margin: 8px 0 0; display: flex; gap: 8px; align-items: center; font-size: 0.82rem; }
+        .feed--editorial .reveal {
+            display: flex;
+            gap: 8px;
+            opacity: 0;
+            transition: opacity 150ms;
+            position: absolute;
+            right: 4px;
+            bottom: 22px;
+        }
+        .feed--editorial .card:hover .reveal,
+        .feed--editorial .card:focus-within .reveal { opacity: 1; }
+        /* Touch has no hover, so the actions must simply be present. */
+        @media (hover: none) {
+            .feed--editorial .reveal { opacity: 1; position: static; grid-column: 2; margin-top: 10px; }
+        }
+
+        /* == 10. People first ============================================= */
+
+        .feed--people { display: flex; flex-direction: column; gap: 20px; }
+        .feed--people .card {
+            border: 1px solid var(--feed-rule);
+            border-radius: var(--border-radius-card, 9px);
+            padding: 14px;
+            background: var(--feed-card-bg);
+        }
+        .feed--people .card__head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+        }
+        .feed--people .summary { margin: 6px 0 12px; font-size: 0.8rem; color: var(--feed-muted); }
+        .feed--people .strip {
+            display: flex;
+            gap: 12px;
+            overflow-x: auto;
+            padding-bottom: 6px;
+        }
+        .feed--people .strip__item { margin: 0; width: 78px; flex-shrink: 0; }
+        .feed--people .cover { width: 78px; height: 116px; }
+        .feed--people .cover--stack { height: 116px; }
+        .feed--people figcaption {
+            font-size: 0.7rem;
+            color: var(--feed-muted);
+            margin-top: 4px;
+            line-height: 1.2;
+        }
+
+        /* -- mobile ------------------------------------------------------- */
+
+        @media (max-width: 767px) {
+            .feed--spec-card { grid-template-columns: 1fr; }
+            /* One card per row means nothing needs to stretch to a shared
+               height, and stretching just opens a gap above the actions. */
+            .feed--spec-card .card { height: auto; }
+            .feed--spec-card .card__body { flex: 0 1 auto; }
+            .feed--river .card__body { padding-left: 0; gap: 14px; }
+            .feed--river .cover { width: 80px; height: 120px; }
+            .feed--river .title { font-size: 1rem; }
+            .feed--magazine { grid-template-columns: 1fr; gap: 24px; }
+            .feed--magazine .cover { height: 200px; }
+            .feed--magazine .title { font-size: 1.2rem; }
+            .feed--editorial .card { grid-template-columns: auto 1fr; gap: 14px; padding: 16px 4px; }
+            .feed--editorial .title { font-size: 1.1rem; }
+            .feed--editorial .cover { width: 54px; height: 80px; }
+            /* Absolutely positioned, the action tray is wider than a phone-width
+               card and pushes the page sideways. Do not rely on the hover:none
+               query alone -- device emulation does not always report it. */
+            .feed--editorial .reveal { opacity: 1; position: static; grid-column: 2; margin-top: 10px; flex-wrap: wrap; }
+            .feed--timeline .cover { width: 26px; height: 38px; }
+        }
+    `;
+}
+
+customElements.define('ol-social-feed', OlSocialFeed);

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -4,14 +4,30 @@ import { LitElement, css, html } from 'lit';
  * OlSocialFeed -- the social activity feed for My Books.
  *
  * Renders a stream of what other patrons are doing with books: shelving them,
- * rating them, gathering them into lists. Every event carries the actions a
- * reader would want next -- borrow or shelve the book, follow the patron.
+ * rating them, gathering them into lists, liking each other's lists. Every
+ * event carries the actions a reader would want next -- borrow or shelve the
+ * book, open the list, follow the patron.
  *
- * The `variant` property selects one of ten layout treatments. They are all
- * driven off the same feed response and the same card content, so switching
- * between them is an honest comparison of presentation rather than of data.
- * Nine of them are scaffolding for a design decision and will be removed once
- * one is chosen.
+ * ## One container for every activity type
+ *
+ * Following Goodreads' Updates panel, every event type renders into the *same*
+ * card skeleton rather than getting its own bespoke layout:
+ *
+ *     avatar   Actor  verb  target                            when   [Follow]
+ *              ┌───────┐  Title
+ *              │ media │  subtitle
+ *              └───────┘  [primary action] [secondary]  ★★★★☆
+ *
+ * A shelving fills `media` with a book cover and `target` with the shelf; a
+ * list update fills `media` with a fan of three covers and `subtitle` with a
+ * book count. Nothing about the frame changes. Adding an event type means
+ * writing one `_present` branch, not a new template -- and a card means the
+ * same thing to a reader wherever it appears.
+ *
+ * The `variant` property then selects one of ten CSS treatments over that one
+ * skeleton. Because they are the same markup and the same data, switching
+ * between them is an honest comparison of presentation. Nine are scaffolding
+ * for a design decision and get removed once one is chosen.
  *
  * @element ol-social-feed
  *
@@ -21,7 +37,8 @@ import { LitElement, css, html } from 'lit';
  * @prop {String} scope - `auto`, `public`, or `following`
  * @prop {String} viewerUsername - Logged-in patron, for follow state and self-filtering
  * @prop {Number} refreshInterval - Seconds between background refreshes; 0 disables
- * @prop {String} heading - Optional heading rendered above the feed
+ * @prop {String} heading - Panel heading; omit to render the feed without a panel
+ * @prop {String} headingHref - Makes the panel heading a link
  * @fires ol-social-feed-load - Fired after each successful fetch. detail: { count: Number, scope: String }
  */
 
@@ -31,7 +48,7 @@ const FALLBACK_COVER = '/static/images/icons/avatar_book-sm.png';
 /** Every layout treatment, in the order the gallery presents them. */
 export const FEED_VARIANTS = [
     { id: 1, slug: 'spec-card', name: 'Spec card', blurb: 'The reviewed design: patron and follow above the rule, book and actions below. Three up on desktop.' },
-    { id: 2, slug: 'river', name: 'Goodreads river', blurb: 'Full-width rows, one continuous sentence, generous cover, text actions.' },
+    { id: 2, slug: 'river', name: 'Goodreads river', blurb: 'Full-width rows, one continuous sentence, generous cover, actions beside the book.' },
     { id: 3, slug: 'cover-tiles', name: 'Cover tiles', blurb: 'The cover is the card. Caption strip overlays the bottom. Scrolls horizontally.' },
     { id: 4, slug: 'timeline', name: 'Dense timeline', blurb: 'A rail of small avatars down the left. Maximum events per screen.' },
     { id: 5, slug: 'thread', name: 'Social thread', blurb: 'Bluesky shape: avatar column, prose, and the book as an embedded quote card.' },
@@ -66,19 +83,6 @@ function coverUrl(coverId, size = 'M') {
     return coverId ? `${COVERS_BASE}/${coverId}-${size}.jpg` : FALLBACK_COVER;
 }
 
-/**
- * The action most worth offering for a book, given how it can be read.
- * A borrowable book leads with Borrow; everything else leads with the shelf.
- */
-function primaryAction(item) {
-    const work = item.work;
-    if (!work) return null;
-    if (work.ebook_access === 'borrowable' || work.ebook_access === 'public') {
-        return { label: 'Borrow', href: work.key };
-    }
-    return { label: 'Want to Read', href: work.key };
-}
-
 export class OlSocialFeed extends LitElement {
     static properties = {
         apiUrl: { type: String, attribute: 'api-url' },
@@ -88,6 +92,7 @@ export class OlSocialFeed extends LitElement {
         viewerUsername: { type: String, attribute: 'viewer-username' },
         refreshInterval: { type: Number, attribute: 'refresh-interval' },
         heading: { type: String },
+        headingHref: { type: String, attribute: 'heading-href' },
         _items: { state: true },
         _loading: { state: true },
         _error: { state: true },
@@ -104,6 +109,7 @@ export class OlSocialFeed extends LitElement {
         this.viewerUsername = '';
         this.refreshInterval = 60;
         this.heading = '';
+        this.headingHref = '';
         this._items = [];
         this._loading = true;
         this._error = false;
@@ -205,266 +211,114 @@ export class OlSocialFeed extends LitElement {
         }
     }
 
-    // -- shared card pieces ----------------------------------------------
-    // Every variant composes these, so the same information is on offer in all
-    // ten and the comparison is about presentation only.
+    // -- the presenter ----------------------------------------------------
 
-    _avatar(item, size = 'md') {
-        return html`<img
-            class="avatar avatar--${size}"
-            src=${item.avatar_url}
-            alt=""
-            loading="lazy"
-            @error=${(e) => { e.target.src = FALLBACK_COVER; }}
-        />`;
-    }
+    /**
+     * Map one event onto the card's slots.
+     *
+     * This is the only place that knows how event types differ. Everything
+     * downstream sees the same shape, which is what lets one skeleton serve
+     * all of them.
+     */
+    _present(item) {
+        const isList = Boolean(item.list);
 
-    _followButton(item) {
-        if (item.username === this.viewerUsername) return '';
-        const following = this._following.has(item.username);
-        return html`<button
-            class="follow ${following ? 'is-following' : ''}"
-            type="button"
-            aria-pressed=${following}
-            @click=${() => this._toggleFollow(item.username)}
-        >${following ? 'Following' : 'Follow'}</button>`;
-    }
-
-    _stars(rating) {
-        if (!rating) return '';
-        return html`<span class="stars" aria-label="Rated ${rating} out of 5">
-            ${'★'.repeat(rating)}<span class="stars__empty">${'★'.repeat(5 - rating)}</span>
-        </span>`;
-    }
-
-    /** "added to Want to Read", with the shelf linked when there is one. */
-    _action(item) {
-        if (item.shelf_url) {
-            return html`<a class="action-link" href=${item.shelf_url}>${item.label}</a>`;
+        if (isList) {
+            const ids = item.list.cover_ids.length ? item.list.cover_ids : [null];
+            return {
+                href: item.list.key,
+                covers: ids.slice(0, 3),
+                coverAlt: item.list.name,
+                title: item.list.name,
+                subtitle: `${item.list.book_count} ${item.list.book_count === 1 ? 'book' : 'books'}`,
+                subtitleHref: null,
+                actions: [{ label: 'View List', href: item.list.key, primary: true }],
+            };
         }
-        return html`<span class="action-link">${item.label}</span>`;
-    }
 
-    _cover(item, size = 'M') {
-        if (item.list) return this._listCovers(item);
         const work = item.work;
-        return html`<a class="cover" href=${work.key}>
-            <img
-                src=${coverUrl(work.cover_id, size)}
-                alt="Cover of ${work.title}"
-                loading="lazy"
-                @error=${(e) => { e.target.src = FALLBACK_COVER; }}
-            />
-        </a>`;
+        // A borrowable book leads with Borrow; everything else leads with the shelf.
+        const borrowable = work.ebook_access === 'borrowable' || work.ebook_access === 'public';
+        return {
+            href: work.key,
+            covers: [work.cover_id],
+            coverAlt: `Cover of ${work.title}`,
+            title: work.title,
+            subtitle: work.author ? `by ${work.author}` : 'Unknown author',
+            subtitleHref: work.author ? work.author_key : null,
+            actions: borrowable
+                ? [
+                    { label: 'Borrow', href: work.key, primary: true },
+                    { label: 'Want to Read', href: work.key, primary: false },
+                ]
+                : [{ label: 'Want to Read', href: work.key, primary: true }],
+        };
     }
 
-    /** Three covers fanned out horizontally, per the reviewed list-card design. */
-    _listCovers(item) {
-        const ids = item.list.cover_ids.length ? item.list.cover_ids : [null];
-        return html`<a class="cover cover--stack" href=${item.list.key} aria-label=${item.list.name}>
-            ${ids.slice(0, 3).map(
-        (id) => html`<img src=${coverUrl(id, 'M')} alt="" loading="lazy"
-                    @error=${(e) => { e.target.src = FALLBACK_COVER; }} />`
-    )}
-        </a>`;
-    }
+    // -- the one card skeleton --------------------------------------------
 
-    _title(item) {
-        if (item.list) {
-            return html`<a class="title" href=${item.list.key}>${item.list.name}</a>`;
-        }
-        return html`<a class="title" href=${item.work.key}>${item.work.title}</a>`;
-    }
+    _renderCard(item) {
+        const slot = this._present(item);
+        const following = this._following.has(item.username);
+        const isViewer = item.username === this.viewerUsername;
+        const stacked = slot.covers.length > 1;
 
-    _byline(item) {
-        if (item.list) {
-            return html`<span class="byline">${item.list.book_count} books</span>`;
-        }
-        const { author, author_key: authorKey } = item.work;
-        if (!author) return html`<span class="byline">Unknown author</span>`;
-        return html`<span class="byline">by ${authorKey ? html`<a href=${authorKey}>${author}</a>` : author}</span>`;
-    }
-
-    _actions(item) {
-        if (item.list) {
-            return html`<a class="btn btn--primary" href=${item.list.key}>View List</a>`;
-        }
-        const action = primaryAction(item);
-        return html`
-            <a class="btn btn--primary" href=${action.href}>${action.label}</a>
-            ${action.label === 'Borrow' ? html`<a class="btn btn--ghost" href=${item.work.key}>Want to Read</a>` : ''}
-        `;
-    }
-
-    // -- variants ---------------------------------------------------------
-
-    /** 1 -- the reviewed design: patron and follow above the rule, book below. */
-    _renderSpecCard(item) {
-        return html`<article class="card">
-            <header class="card__head">
-                <a class="patron" href=${item.patron_url}>${this._avatar(item)}<span class="handle">@${item.username}</span></a>
-                ${this._followButton(item)}
-            </header>
-            <p class="card__action">${this._action(item)} <span class="dot">&middot;</span> ${timeAgo(item.created)}</p>
-            <hr class="rule" />
-            <div class="card__body">
-                ${this._cover(item)}
-                <div class="meta">
-                    ${this._title(item)}
-                    ${this._byline(item)}
-                    ${this._stars(item.rating)}
-                </div>
-            </div>
-            <footer class="card__actions">${this._actions(item)}</footer>
-        </article>`;
-    }
-
-    /** 2 -- Goodreads' shape: one sentence, one big cover, text actions. */
-    _renderRiver(item) {
-        return html`<article class="card">
-            <header class="card__head">
-                <a class="patron" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item, 'lg')}</a>
+        return html`<article class="card" data-type=${item.type}>
+            <div class="head">
+                <a class="gutter" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>
+                    <img class="avatar" src=${item.avatar_url} alt="" loading="lazy"
+                        @error=${(e) => { e.target.src = FALLBACK_COVER; }} />
+                </a>
                 <p class="sentence">
                     <a class="handle" href=${item.patron_url}>${item.username}</a>
-                    ${this._action(item)}
-                    ${this._stars(item.rating)}
+                    ${item.shelf_url
+        ? html`<a class="verb" href=${item.shelf_url}>${item.label}</a>`
+        : html`<span class="verb">${item.label}</span>`}
                 </p>
                 <time class="when">${timeAgo(item.created)}</time>
-            </header>
-            <div class="card__body">
-                ${this._cover(item, 'L')}
-                <div class="meta">
-                    ${this._title(item)}
-                    ${this._byline(item)}
-                    <div class="textactions">
-                        ${this._actions(item)}
-                        ${this._followButton(item)}
-                    </div>
-                </div>
+                ${isViewer
+        ? ''
+        : html`<button
+                        class="follow ${following ? 'is-following' : ''}"
+                        type="button"
+                        aria-pressed=${following}
+                        @click=${() => this._toggleFollow(item.username)}
+                    >${following ? 'Following' : 'Follow'}</button>`}
             </div>
-        </article>`;
-    }
 
-    /** 3 -- the cover is the card; the caption sits over its foot. */
-    _renderCoverTile(item) {
-        return html`<article class="card">
-            ${this._cover(item, 'L')}
-            <div class="caption">
-                <a class="patron" href=${item.patron_url}>${this._avatar(item, 'sm')}<span class="handle">${item.username}</span></a>
-                <span class="what">${item.label} &middot; ${timeAgo(item.created)}</span>
-            </div>
-        </article>`;
-    }
-
-    /** 4 -- maximum events per screen, on a rail. */
-    _renderTimeline(item) {
-        return html`<article class="card">
-            <a class="rail" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item, 'sm')}</a>
-            <div class="line">
-                <p class="sentence">
-                    <a class="handle" href=${item.patron_url}>${item.username}</a>
-                    ${this._action(item)}
-                    ${this._title(item)}
-                    ${this._stars(item.rating)}
-                    <time class="when">${timeAgo(item.created)}</time>
-                </p>
-            </div>
-            ${this._cover(item, 'S')}
-        </article>`;
-    }
-
-    /** 5 -- Bluesky's shape: prose, with the book as an embedded quote card. */
-    _renderThread(item) {
-        return html`<article class="card">
-            <a class="gutter" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item)}</a>
-            <div class="stream">
-                <p class="sentence">
-                    <a class="handle" href=${item.patron_url}>@${item.username}</a>
-                    <span class="dot">&middot;</span>
-                    <time class="when">${timeAgo(item.created)}</time>
-                    ${this._followButton(item)}
-                </p>
-                <p class="what">${this._action(item)} ${this._stars(item.rating)}</p>
-                <div class="quote">
-                    ${this._cover(item, 'S')}
-                    <div class="meta">
-                        ${this._title(item)}
-                        ${this._byline(item)}
-                    </div>
-                </div>
-                <div class="tray">${this._actions(item)}</div>
-            </div>
-        </article>`;
-    }
-
-    /** 6 -- covers given room to breathe, in two columns. */
-    _renderMagazine(item) {
-        return html`<article class="card">
-            ${this._cover(item, 'L')}
-            <div class="meta">
-                <p class="eyebrow">
-                    <a class="handle" href=${item.patron_url}>${item.username}</a> ${item.label}
-                </p>
-                ${this._title(item)}
-                ${this._byline(item)}
-                ${this._stars(item.rating)}
-                <footer class="card__actions">${this._actions(item)}</footer>
-            </div>
-        </article>`;
-    }
-
-    /** 7 -- activity as chatter rather than a log. */
-    _renderBubble(item) {
-        return html`<article class="card">
-            <a class="gutter" href=${item.patron_url} aria-label=${`${item.username}'s profile`}>${this._avatar(item)}</a>
-            <div class="bubble">
-                <p class="sentence">
-                    <a class="handle" href=${item.patron_url}>${item.username}</a> ${this._action(item)}
-                </p>
-                <a class="chip" href=${item.list ? item.list.key : item.work.key}>
-                    ${this._cover(item, 'S')}
-                    <span class="chip__meta">${this._title(item)}${this._byline(item)}</span>
+            <div class="content">
+                <a class="cover ${stacked ? 'cover--stack' : ''}" href=${slot.href}
+                    aria-label=${stacked ? slot.coverAlt : ''}>
+                    ${slot.covers.map(
+        (id) => html`<img src=${coverUrl(id)} alt=${stacked ? '' : slot.coverAlt} loading="lazy"
+                            @error=${(e) => { e.target.src = FALLBACK_COVER; }} />`
+    )}
                 </a>
-                <p class="foot">${this._stars(item.rating)}<time class="when">${timeAgo(item.created)}</time></p>
+                <div class="body">
+                    <a class="title" href=${slot.href}>${slot.title}</a>
+                    <span class="byline">
+                        ${slot.subtitleHref
+        ? html`by <a href=${slot.subtitleHref}>${slot.subtitle.replace(/^by /, '')}</a>`
+        : slot.subtitle}
+                    </span>
+                    ${item.rating
+        ? html`<span class="stars" aria-label="Rated ${item.rating} out of 5"
+                            >${'★'.repeat(item.rating)}<span class="stars__empty">${'★'.repeat(5 - item.rating)}</span></span>`
+        : ''}
+                    <div class="actions">
+                        ${slot.actions.map(
+        (a) => html`<a class="btn ${a.primary ? 'btn--primary' : 'btn--ghost'}" href=${a.href}>${a.label}</a>`
+    )}
+                    </div>
+                </div>
             </div>
-        </article>`;
-    }
-
-    /** 8 -- one line each, sized to sit under a My Books heading. */
-    _renderTicker(item) {
-        return html`<article class="card">
-            ${this._cover(item, 'S')}
-            <p class="sentence">
-                <a class="handle" href=${item.patron_url}>${item.username}</a>
-                ${this._action(item)}
-                ${this._title(item)}
-            </p>
-            <time class="when">${timeAgo(item.created)}</time>
-        </article>`;
-    }
-
-    /** 9 -- big type, no chrome, actions only on hover or focus. */
-    _renderEditorial(item) {
-        return html`<article class="card">
-            ${this._cover(item, 'M')}
-            <div class="meta">
-                <p class="eyebrow">${item.label}</p>
-                ${this._title(item)}
-                ${this._byline(item)}
-                <p class="attrib">
-                    <a class="handle" href=${item.patron_url}>${item.username}</a>
-                    <span class="dot">&middot;</span>
-                    <time class="when">${timeAgo(item.created)}</time>
-                    ${this._stars(item.rating)}
-                </p>
-            </div>
-            <div class="reveal">${this._actions(item)}${this._followButton(item)}</div>
         </article>`;
     }
 
     /**
-     * 10 -- regroups the same events by patron, to push following rather than
-     * individual books. Presentation-level grouping; the data is unchanged.
+     * Variant 10 is the one treatment that regroups the data rather than
+     * restyling it -- one card per patron, with a strip of what they touched --
+     * so it cannot reuse the per-event skeleton.
      */
     _renderPeople() {
         const groups = new Map();
@@ -472,76 +326,81 @@ export class OlSocialFeed extends LitElement {
             if (!groups.has(item.username)) groups.set(item.username, []);
             groups.get(item.username).push(item);
         }
-        return html`${[...groups.entries()].map(
-            ([username, items]) => html`<article class="card">
-                <header class="card__head">
-                    <a class="patron" href=${items[0].patron_url}>
-                        ${this._avatar(items[0], 'lg')}
-                        <span class="handle">@${username}</span>
+        return html`${[...groups.entries()].map(([username, items]) => {
+            const first = items[0];
+            const following = this._following.has(username);
+            return html`<article class="card card--person">
+                <div class="head">
+                    <a class="gutter" href=${first.patron_url} aria-label=${`${username}'s profile`}>
+                        <img class="avatar" src=${first.avatar_url} alt="" loading="lazy"
+                            @error=${(e) => { e.target.src = FALLBACK_COVER; }} />
                     </a>
-                    ${this._followButton(items[0])}
-                </header>
+                    <p class="sentence"><a class="handle" href=${first.patron_url}>${username}</a></p>
+                    <time class="when">${timeAgo(first.created)}</time>
+                    ${username === this.viewerUsername
+        ? ''
+        : html`<button class="follow ${following ? 'is-following' : ''}" type="button"
+                            aria-pressed=${following} @click=${() => this._toggleFollow(username)}
+                        >${following ? 'Following' : 'Follow'}</button>`}
+                </div>
                 <p class="summary">
                     ${items.length} recent ${items.length === 1 ? 'update' : 'updates'}
-                    <span class="dot">&middot;</span>
-                    ${timeAgo(items[0].created)}
                 </p>
                 <div class="strip">
-                    ${items.map(
-        (item) => html`<figure class="strip__item">
-                            ${this._cover(item, 'M')}
+                    ${items.map((item) => {
+        const slot = this._present(item);
+        return html`<figure class="strip__item">
+                            <a class="cover" href=${slot.href}>
+                                <img src=${coverUrl(slot.covers[0])} alt=${slot.coverAlt} loading="lazy"
+                                    @error=${(e) => { e.target.src = FALLBACK_COVER; }} />
+                            </a>
                             <figcaption>${item.label}</figcaption>
-                        </figure>`
-    )}
+                        </figure>`;
+    })}
                 </div>
-            </article>`
-        )}`;
-    }
-
-    _renderItem(item) {
-        switch (this.variant) {
-        case 2: return this._renderRiver(item);
-        case 3: return this._renderCoverTile(item);
-        case 4: return this._renderTimeline(item);
-        case 5: return this._renderThread(item);
-        case 6: return this._renderMagazine(item);
-        case 7: return this._renderBubble(item);
-        case 8: return this._renderTicker(item);
-        case 9: return this._renderEditorial(item);
-        default: return this._renderSpecCard(item);
-        }
+            </article>`;
+        })}`;
     }
 
     render() {
         const variant = VARIANT_BY_ID.get(this.variant) || FEED_VARIANTS[0];
 
+        let inner;
         if (this._loading) {
-            return html`<div class="state" aria-busy="true">Loading activity&hellip;</div>`;
-        }
-        if (this._error) {
-            return html`<div class="state">
+            inner = html`<div class="state" aria-busy="true">Loading activity&hellip;</div>`;
+        } else if (this._error) {
+            inner = html`<div class="state">
                 Could not load the activity feed.
                 <button class="btn btn--ghost" type="button" @click=${() => this._load()}>Retry</button>
             </div>`;
-        }
-        if (!this._items.length) {
-            return html`<div class="state">
+        } else if (!this._items.length) {
+            inner = html`<div class="state">
                 No recent activity yet. Follow other readers and their updates will show up here.
             </div>`;
-        }
-
-        return html`
-            ${this.heading ? html`<h2 class="heading">${this.heading}</h2>` : ''}
-            <div class="feed feed--${variant.slug}" aria-live="polite">
+        } else {
+            inner = html`<div class="feed feed--${variant.slug}" aria-live="polite">
                 ${this.variant === 10
         ? this._renderPeople()
         : this._items.map(
             (item) => html`<div class="slot ${this._freshKeys.has(this._key(item)) ? 'is-fresh' : ''}">
-                            ${this._renderItem(item)}
+                            ${this._renderCard(item)}
                         </div>`
         )}
-            </div>
-        `;
+            </div>`;
+        }
+
+        // The panel is the outer common container: one frame around every
+        // activity type, the way Goodreads wraps its Updates column.
+        if (!this.heading) return inner;
+        return html`<section class="panel">
+            <header class="panel__head">
+                <h2>${this.headingHref
+        ? html`<a href=${this.headingHref}>${this.heading}</a>`
+        : this.heading}</h2>
+                <slot name="panel-action"></slot>
+            </header>
+            ${inner}
+        </section>`;
     }
 
     static styles = css`
@@ -554,12 +413,32 @@ export class OlSocialFeed extends LitElement {
             --feed-rule: var(--grey-e7e7e7, #e7e7e7);
             --feed-muted: var(--grey, #666);
             --feed-shadow: 2px 2px 4px hsla(0, 0%, 0%, 0.1);
+            --feed-gutter: 40px;
         }
 
-        .heading {
-            font-size: 1.15rem;
-            margin: 0 0 12px;
+        /* -- outer panel -- */
+
+        .panel {
+            border: var(--border-width-thin, 1px) solid var(--feed-rule);
+            border-radius: var(--border-radius-card, 9px);
+            background: var(--grey-fafafa, #fafafa);
+            padding: 14px 16px 16px;
         }
+        .panel__head {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+        .panel__head h2 {
+            margin: 0;
+            font-size: 0.95rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+        }
+        .panel__head a { text-decoration: none; }
+        .panel__head a:hover { text-decoration: underline; }
 
         .state {
             padding: 24px;
@@ -579,26 +458,42 @@ export class OlSocialFeed extends LitElement {
             .slot.is-fresh { animation: none; }
         }
 
-        /* -- shared primitives -- */
+        /* -- the one card skeleton --
+           Every event type renders this exact markup. Variants below restyle
+           it; none of them add or remove elements. */
 
         a { color: inherit; }
 
-        .avatar {
-            border-radius: var(--border-radius-avatar, 50%);
-            object-fit: cover;
-            flex-shrink: 0;
-            background: var(--grey-f3f3f3, #f3f3f3);
+        .card {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
         }
-        .avatar--sm { width: 22px; height: 22px; }
-        .avatar--md { width: 32px; height: 32px; }
-        .avatar--lg { width: 44px; height: 44px; }
 
-        .patron {
-            display: inline-flex;
+        .head {
+            display: flex;
             align-items: center;
             gap: 8px;
-            text-decoration: none;
+        }
+
+        .gutter { display: flex; flex-shrink: 0; }
+
+        .avatar {
+            width: 32px;
+            height: 32px;
+            border-radius: var(--border-radius-avatar, 50%);
+            object-fit: cover;
+            background: var(--grey-f3f3f3, #f3f3f3);
+        }
+
+        .sentence {
+            margin: 0;
             min-width: 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            align-items: baseline;
+            font-size: 0.88rem;
         }
 
         .handle {
@@ -609,6 +504,16 @@ export class OlSocialFeed extends LitElement {
             text-overflow: ellipsis;
         }
         .handle:hover { text-decoration: underline; }
+
+        .verb { color: var(--link-blue, #04618f); text-decoration: none; }
+        a.verb:hover { text-decoration: underline; }
+
+        .when {
+            color: var(--feed-muted);
+            font-size: 0.8rem;
+            margin-left: auto;
+            white-space: nowrap;
+        }
 
         .follow {
             border: var(--border-width-thin, 1px) solid var(--primary-blue, #0577b5);
@@ -628,15 +533,18 @@ export class OlSocialFeed extends LitElement {
             color: var(--primary-blue, #0577b5);
         }
 
-        .action-link {
-            color: var(--link-blue, #04618f);
-            text-decoration: none;
+        /* Indented to sit under the sentence, not under the avatar. */
+        .content {
+            display: flex;
+            gap: 12px;
+            min-width: 0;
         }
-        .action-link:hover { text-decoration: underline; }
 
         .cover {
-            display: block;
+            display: flex;
             flex-shrink: 0;
+            width: 62px;
+            height: 90px;
         }
         .cover img {
             display: block;
@@ -648,33 +556,38 @@ export class OlSocialFeed extends LitElement {
             background: var(--grey-f3f3f3, #f3f3f3);
         }
 
-        /* Three list covers fanned out, per the reviewed list-card design. */
-        .cover--stack {
-            display: flex;
-            gap: 4px;
+        /* Three list covers fanned horizontally, overlapping, so each stays
+           legible in the footprint a single cover would take. */
+        .cover--stack { width: 90px; align-items: flex-start; }
+        .cover--stack img {
+            width: 60%;
+            border: var(--border-width, 1px) solid var(--white, #fff);
         }
-        .cover--stack img { width: 33%; }
+        .cover--stack img + img { margin-left: -40%; }
+
+        .body {
+            min-width: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+        }
 
         .title {
-            display: block;
             font-weight: 700;
             line-height: 1.25;
             text-decoration: none;
+            font-size: 0.95rem;
         }
         .title:hover { text-decoration: underline; }
 
-        .byline {
-            display: block;
-            font-size: 0.82rem;
-            color: var(--feed-muted);
-        }
+        .byline { font-size: 0.82rem; color: var(--feed-muted); }
         .byline a { text-decoration: none; }
         .byline a:hover { text-decoration: underline; }
 
-        .stars { color: var(--orange, #e8a33d); white-space: nowrap; }
+        .stars { color: var(--orange, #e8a33d); white-space: nowrap; font-size: 0.85rem; }
         .stars__empty { color: var(--grey-e7e7e7, #ddd); }
 
-        .when, .dot { color: var(--feed-muted); font-size: 0.8rem; }
+        .actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 
         .btn {
             display: inline-block;
@@ -716,25 +629,29 @@ export class OlSocialFeed extends LitElement {
             border-radius: var(--border-radius-card, 9px);
             box-shadow: var(--feed-shadow);
             padding: 12px 14px 14px;
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
             height: 100%;
         }
-        .feed--spec-card .card__head {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 8px;
+        /* Per the June review: avatar, follow and the action all sit above the
+           separator, and the separator sits above the book. */
+        .feed--spec-card .head {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            grid-template-areas:
+                "gutter . follow"
+                "sentence sentence when";
+            row-gap: 6px;
         }
-        .feed--spec-card .card__action { margin: 0; font-size: 0.82rem; }
-        .feed--spec-card .rule { border: 0; border-top: 1px solid var(--feed-rule); margin: 2px 0; width: 100%; }
-        .feed--spec-card .card__body { display: flex; gap: 12px; flex: 1; }
-        .feed--spec-card .cover { width: 62px; height: 90px; }
-        .feed--spec-card .cover--stack { width: 90px; height: 90px; }
-        .feed--spec-card .meta { min-width: 0; }
-        .feed--spec-card .title { font-size: 0.95rem; margin-bottom: 3px; }
-        .feed--spec-card .card__actions { display: flex; flex-direction: column; gap: 6px; }
+        .feed--spec-card .gutter { grid-area: gutter; }
+        .feed--spec-card .follow { grid-area: follow; }
+        .feed--spec-card .sentence { grid-area: sentence; }
+        .feed--spec-card .when { grid-area: when; margin-left: 0; align-self: baseline; }
+        .feed--spec-card .content {
+            flex: 1;
+            border-top: 1px solid var(--feed-rule);
+            padding-top: 10px;
+        }
+        .feed--spec-card .actions { flex-direction: column; margin-top: auto; }
+        .feed--spec-card .actions .btn { width: 100%; box-sizing: border-box; }
 
         /* == 2. Goodreads river =========================================== */
 
@@ -743,19 +660,11 @@ export class OlSocialFeed extends LitElement {
             border-bottom: 1px solid var(--feed-rule);
             padding: 20px 4px;
         }
-        .feed--river .card__head {
-            display: grid;
-            grid-template-columns: auto 1fr auto;
-            align-items: center;
-            gap: 12px;
-            margin-bottom: 12px;
-        }
-        .feed--river .sentence { margin: 0; }
-        .feed--river .card__body { display: flex; gap: 20px; padding-left: 56px; }
+        .feed--river .content { padding-left: calc(var(--feed-gutter) + 8px); }
         .feed--river .cover { width: 110px; height: 165px; }
         .feed--river .cover--stack { width: 150px; height: 140px; }
-        .feed--river .title { font-size: 1.15rem; margin-bottom: 4px; }
-        .feed--river .textactions { display: flex; align-items: center; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
+        .feed--river .title { font-size: 1.15rem; }
+        .feed--river .avatar { width: var(--feed-gutter); height: var(--feed-gutter); }
 
         /* == 3. Cover tiles =============================================== */
 
@@ -776,72 +685,75 @@ export class OlSocialFeed extends LitElement {
             box-shadow: var(--feed-shadow);
             background: var(--grey-f3f3f3, #f3f3f3);
             height: 280px;
+            gap: 0;
         }
+        .feed--cover-tiles .head {
+            position: absolute;
+            inset: auto 0 0 0;
+            z-index: 1;
+            padding: 10px;
+            color: var(--white, #fff);
+            background: linear-gradient(to top, hsla(0, 0%, 0%, 0.85), hsla(0, 0%, 0%, 0));
+        }
+        .feed--cover-tiles .verb, .feed--cover-tiles .when { color: hsla(0, 0%, 100%, 0.85); }
+        .feed--cover-tiles .avatar { width: 22px; height: 22px; }
+        .feed--cover-tiles .follow { display: none; }
+        .feed--cover-tiles .content { height: 100%; }
         .feed--cover-tiles .cover { width: 100%; height: 100%; }
         .feed--cover-tiles .cover img { border-radius: 0; box-shadow: none; }
         .feed--cover-tiles .cover--stack { align-items: stretch; }
         .feed--cover-tiles .cover--stack img { width: 33.34%; margin-left: 0; border: 0; }
-        .feed--cover-tiles .caption {
-            position: absolute;
-            inset: auto 0 0 0;
-            padding: 10px;
-            display: flex;
-            flex-direction: column;
-            gap: 2px;
-            color: var(--white, #fff);
-            background: linear-gradient(to top, hsla(0, 0%, 0%, 0.85), hsla(0, 0%, 0%, 0));
-        }
-        .feed--cover-tiles .what { font-size: 0.75rem; opacity: 0.9; }
-        .feed--cover-tiles .handle { font-size: 0.85rem; }
+        .feed--cover-tiles .body { display: none; }
 
         /* == 4. Dense timeline ============================================ */
+        /* display:contents flattens the wrapper so head and content lay out
+           as one row without changing the markup. */
 
         .feed--timeline { display: flex; flex-direction: column; }
         .feed--timeline .card {
-            display: grid;
-            grid-template-columns: auto 1fr auto;
+            flex-direction: row;
             align-items: center;
             gap: 10px;
             padding: 8px 4px;
             border-bottom: 1px solid var(--feed-rule);
+            position: relative;
+            padding-right: 56px;
         }
-        .feed--timeline .sentence {
-            margin: 0;
-            font-size: 0.88rem;
-            display: flex;
-            flex-wrap: wrap;
-            gap: 5px;
-            align-items: baseline;
+        .feed--timeline .head { flex: 0 1 auto; min-width: 0; }
+        .feed--timeline .content { display: contents; }
+        .feed--timeline .when {
+            position: absolute;
+            right: 4px;
+            top: 50%;
+            transform: translateY(-50%);
+            margin-left: 0;
         }
-        .feed--timeline .title { display: inline; font-size: 0.88rem; }
+        .feed--timeline .body { flex: 1; }
+        .feed--timeline .avatar { width: 22px; height: 22px; }
         .feed--timeline .cover { width: 32px; height: 46px; }
         .feed--timeline .cover--stack { width: 50px; }
+        .feed--timeline .body { flex-direction: row; align-items: baseline; gap: 6px; min-width: 0; }
+        .feed--timeline .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .feed--timeline .byline, .feed--timeline .actions, .feed--timeline .follow { display: none; }
+        .feed--timeline .title { font-size: 0.88rem; }
 
         /* == 5. Social thread ============================================= */
 
         .feed--thread { display: flex; flex-direction: column; }
         .feed--thread .card {
-            display: grid;
-            grid-template-columns: auto 1fr;
-            gap: 12px;
             padding: 16px 4px;
             border-bottom: 1px solid var(--feed-rule);
         }
-        .feed--thread .sentence,
-        .feed--thread .what { margin: 0 0 6px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-        .feed--thread .quote {
-            display: flex;
-            gap: 12px;
+        .feed--thread .content {
+            margin-left: calc(var(--feed-gutter) + 8px);
             border: 1px solid var(--feed-rule);
             border-radius: var(--border-radius-card, 9px);
             padding: 10px;
-            margin: 4px 0 10px;
         }
+        .feed--thread .avatar { width: var(--feed-gutter); height: var(--feed-gutter); }
         .feed--thread .cover { width: 46px; height: 68px; }
         .feed--thread .cover--stack { width: 72px; height: 68px; }
         .feed--thread .title { font-size: 0.92rem; }
-        .feed--thread .tray { display: flex; gap: 8px; }
-        .feed--thread .follow { margin-left: auto; }
 
         /* == 6. Magazine ================================================== */
 
@@ -850,113 +762,105 @@ export class OlSocialFeed extends LitElement {
             grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
             gap: 32px;
         }
-        .feed--magazine .card { display: flex; flex-direction: column; gap: 14px; }
+        .feed--magazine .card { gap: 14px; }
+        .feed--magazine .head { order: 2; }
+        .feed--magazine .content { order: 1; flex-direction: column; }
         .feed--magazine .cover { width: 100%; height: 260px; }
         .feed--magazine .cover img { object-fit: contain; }
         .feed--magazine .cover--stack { height: 140px; }
-        .feed--magazine .eyebrow {
-            margin: 0 0 6px;
-            font-size: 0.76rem;
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
-            color: var(--feed-muted);
-        }
         .feed--magazine .title {
             font-family: var(--font-family-serif, Georgia, serif);
             font-size: 1.4rem;
             line-height: 1.15;
-            margin-bottom: 6px;
         }
-        .feed--magazine .card__actions { display: flex; gap: 8px; margin-top: 14px; }
 
         /* == 7. Conversation ============================================== */
 
         .feed--bubbles { display: flex; flex-direction: column; gap: 14px; }
-        .feed--bubbles .card { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: start; }
-        .feed--bubbles .bubble {
+        .feed--bubbles .card {
             background: var(--grey-f3f3f3, #f3f3f3);
             border-radius: var(--border-radius-xl, 12px);
-            border-top-left-radius: var(--border-radius-sm, 3px);
-            padding: 12px 14px;
+            padding: 12px 14px 12px 40px;
+            position: relative;
         }
-        .feed--bubbles .sentence { margin: 0 0 8px; }
-        .feed--bubbles .chip {
-            display: flex;
-            gap: 10px;
-            align-items: center;
+        /* Pull the avatar out of the bubble rather than restructuring the card. */
+        .feed--bubbles .gutter { position: absolute; left: -6px; top: 10px; }
+        .feed--bubbles .content {
             background: var(--white, #fff);
             border-radius: var(--border-radius-md, 6px);
             padding: 8px;
-            text-decoration: none;
         }
         .feed--bubbles .cover { width: 34px; height: 50px; }
         .feed--bubbles .cover--stack { width: 56px; }
         .feed--bubbles .title { font-size: 0.9rem; }
-        .feed--bubbles .foot { margin: 8px 0 0; display: flex; gap: 10px; align-items: center; }
+        .feed--bubbles .actions { display: none; }
 
         /* == 8. Ticker ==================================================== */
 
         .feed--ticker { display: flex; flex-direction: column; }
         .feed--ticker .card {
-            display: grid;
-            grid-template-columns: auto 1fr auto;
+            flex-direction: row;
             align-items: center;
             gap: 10px;
             padding: 6px 8px;
             border-radius: var(--border-radius-md, 6px);
+            position: relative;
+            padding-right: 52px;
         }
         .feed--ticker .slot:nth-child(odd) .card { background: var(--grey-fafafa, #fafafa); }
+        .feed--ticker .head { flex: 0 1 auto; min-width: 0; }
+        .feed--ticker .content { display: contents; }
+        .feed--ticker .when {
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            margin-left: 0;
+        }
+        .feed--ticker .body { flex: 1; }
+        .feed--ticker .avatar { width: 20px; height: 20px; }
         .feed--ticker .cover { width: 26px; height: 38px; }
         .feed--ticker .cover--stack { width: 40px; }
-        .feed--ticker .sentence {
-            margin: 0;
-            font-size: 0.85rem;
-            display: flex;
-            gap: 5px;
-            min-width: 0;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-        .feed--ticker .title { display: inline; font-weight: 700; }
+        .feed--ticker .body { flex-direction: row; align-items: baseline; gap: 6px; min-width: 0; }
+        .feed--ticker .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .feed--ticker .byline,
+        .feed--ticker .actions,
+        .feed--ticker .follow,
+        .feed--ticker .stars { display: none; }
+        .feed--ticker .title { font-size: 0.85rem; }
 
         /* == 9. Editorial ================================================= */
 
         .feed--editorial { display: flex; flex-direction: column; }
         .feed--editorial .card {
-            display: grid;
-            grid-template-columns: auto 1fr;
-            gap: 20px;
-            align-items: center;
             padding: 22px 4px;
             border-bottom: 1px solid var(--feed-rule);
             position: relative;
         }
-        .feed--editorial .cover { width: 70px; height: 104px; }
-        .feed--editorial .cover--stack { width: 110px; height: 104px; }
-        .feed--editorial .eyebrow {
-            margin: 0 0 4px;
-            font-size: 0.7rem;
+        .feed--editorial .head { order: 2; font-size: 0.8rem; }
+        .feed--editorial .content { order: 1; }
+        .feed--editorial .avatar { width: 22px; height: 22px; }
+        .feed--editorial .verb {
             letter-spacing: 0.12em;
             text-transform: uppercase;
+            font-size: 0.7rem;
             color: var(--feed-muted);
         }
+        .feed--editorial .cover { width: 70px; height: 104px; }
+        .feed--editorial .cover--stack { width: 110px; height: 104px; }
         .feed--editorial .title { font-size: 1.5rem; line-height: 1.1; }
-        .feed--editorial .attrib { margin: 8px 0 0; display: flex; gap: 8px; align-items: center; font-size: 0.82rem; }
-        .feed--editorial .reveal {
-            display: flex;
-            gap: 8px;
+        .feed--editorial .actions {
             opacity: 0;
             transition: opacity 150ms;
-            position: absolute;
-            right: 4px;
-            bottom: 22px;
         }
-        .feed--editorial .card:hover .reveal,
-        .feed--editorial .card:focus-within .reveal { opacity: 1; }
+        .feed--editorial .card:hover .actions,
+        .feed--editorial .card:focus-within .actions { opacity: 1; }
         /* Touch has no hover, so the actions must simply be present. */
         @media (hover: none) {
-            .feed--editorial .reveal { opacity: 1; position: static; grid-column: 2; margin-top: 10px; }
+            .feed--editorial .actions { opacity: 1; }
+            .feed--timeline .card { padding-right: 40px; gap: 6px; }
+            .feed--timeline .cover { width: 26px; height: 38px; }
+            .feed--ticker .card { padding-right: 38px; gap: 6px; }
         }
 
         /* == 10. People first ============================================= */
@@ -968,13 +872,8 @@ export class OlSocialFeed extends LitElement {
             padding: 14px;
             background: var(--feed-card-bg);
         }
-        .feed--people .card__head {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 10px;
-        }
-        .feed--people .summary { margin: 6px 0 12px; font-size: 0.8rem; color: var(--feed-muted); }
+        .feed--people .avatar { width: 44px; height: 44px; }
+        .feed--people .summary { margin: 0; font-size: 0.8rem; color: var(--feed-muted); }
         .feed--people .strip {
             display: flex;
             gap: 12px;
@@ -983,7 +882,6 @@ export class OlSocialFeed extends LitElement {
         }
         .feed--people .strip__item { margin: 0; width: 78px; flex-shrink: 0; }
         .feed--people .cover { width: 78px; height: 116px; }
-        .feed--people .cover--stack { height: 116px; }
         .feed--people figcaption {
             font-size: 0.7rem;
             color: var(--feed-muted);
@@ -998,21 +896,23 @@ export class OlSocialFeed extends LitElement {
             /* One card per row means nothing needs to stretch to a shared
                height, and stretching just opens a gap above the actions. */
             .feed--spec-card .card { height: auto; }
-            .feed--spec-card .card__body { flex: 0 1 auto; }
-            .feed--river .card__body { padding-left: 0; gap: 14px; }
+            .feed--spec-card .content { flex: 0 1 auto; }
+            .feed--river .content { padding-left: 0; }
             .feed--river .cover { width: 80px; height: 120px; }
             .feed--river .title { font-size: 1rem; }
             .feed--magazine { grid-template-columns: 1fr; gap: 24px; }
             .feed--magazine .cover { height: 200px; }
             .feed--magazine .title { font-size: 1.2rem; }
-            .feed--editorial .card { grid-template-columns: auto 1fr; gap: 14px; padding: 16px 4px; }
+            .feed--thread .content { margin-left: 0; }
             .feed--editorial .title { font-size: 1.1rem; }
             .feed--editorial .cover { width: 54px; height: 80px; }
             /* Absolutely positioned, the action tray is wider than a phone-width
                card and pushes the page sideways. Do not rely on the hover:none
                query alone -- device emulation does not always report it. */
-            .feed--editorial .reveal { opacity: 1; position: static; grid-column: 2; margin-top: 10px; flex-wrap: wrap; }
+            .feed--editorial .actions { opacity: 1; }
+            .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
+            .feed--ticker .card { padding-right: 38px; gap: 6px; }
         }
     `;
 }

--- a/openlibrary/components/lit/OlSocialFeed.js
+++ b/openlibrary/components/lit/OlSocialFeed.js
@@ -671,7 +671,10 @@ export class OlSocialFeed extends LitElement {
             display: flex;
             flex-direction: column;
             gap: 8px;
+            min-width: 0;
         }
+
+        .slot { min-width: 0; }
 
         .head {
             display: flex;
@@ -715,9 +718,11 @@ export class OlSocialFeed extends LitElement {
             font-weight: 600;
             text-decoration: none;
             min-width: 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            /* Wraps rather than truncates: "added a book to Speculative
+               fiction that earn..." loses the one thing the card is about.
+               overflow-wrap:anywhere keeps an unbroken title from
+               setting the min width. */
+            overflow-wrap: anywhere;
         }
         .target:hover { text-decoration: underline; }
 
@@ -771,26 +776,32 @@ export class OlSocialFeed extends LitElement {
 
 
         /* Card three: the added book sits proud of the list-mates it joined.
-           The mates are blurred and dimmed so they read as context, not as
-           three equal covers. */
-        .cover--group { position: relative; width: 96px; }
-        .cover--group .cover__mate {
-            position: absolute;
-            top: 8px;
-            width: 46px;
-            height: 68px;
-            filter: blur(1.5px);
-            opacity: 0.55;
+           Laid out with flex rather than absolute positioning so it scales to
+           whatever size a variant gives the cover box -- the absolute version broke
+           the moment the magazine and tile treatments resized the box. */
+        .cover--group {
+            width: 92px;
+            align-items: stretch;
+            /* A blur paints outside its element's box. Unclipped it reads as a
+               smudge over whatever sits beside the cover. */
+            overflow: hidden;
             border-radius: var(--border-radius-thumbnail, 6px);
         }
-        .cover--group .cover__mate:nth-of-type(1) { right: 0; transform: rotate(4deg); }
-        .cover--group .cover__mate:nth-of-type(2) { right: 18px; transform: rotate(-3deg); }
         .cover--group .cover__subject {
+            order: -1;
+            flex: 0 0 58%;
             position: relative;
             z-index: 1;
-            width: 62px;
-            outline: var(--border-width-thick, 2px) solid var(--primary-blue, #0577b5);
-            outline-offset: 1px;
+            /* A border rather than an outline: the group clips its overflow,
+               and an outline would be clipped away with the blur. */
+            border: var(--border-width-thick, 2px) solid var(--primary-blue, #0577b5);
+            box-sizing: border-box;
+        }
+        .cover--group .cover__mate {
+            flex: 0 0 40%;
+            margin-left: -20%;
+            filter: blur(1px);
+            opacity: 0.55;
         }
 
         .body {
@@ -923,10 +934,15 @@ export class OlSocialFeed extends LitElement {
         .feed--cover-tiles .head {
             position: absolute;
             inset: auto 0 0 0;
-            z-index: 1;
-            padding: 10px;
+            /* Above the cover: card three's accented cover is itself stacked,
+               and was painting straight over the caption. */
+            z-index: 2;
+            padding: 14px 10px 10px;
             color: var(--white, #fff);
-            background: linear-gradient(to top, hsla(0, 0%, 0%, 0.85), hsla(0, 0%, 0%, 0));
+            /* Covers are arbitrary artwork, so the scrim has to carry the text
+               on a light one too. */
+            background: linear-gradient(to top, hsla(0, 0%, 0%, 0.92) 40%, hsla(0, 0%, 0%, 0.6) 70%, hsla(0, 0%, 0%, 0));
+            text-shadow: 0 1px 2px hsla(0, 0%, 0%, 0.6);
         }
         .feed--cover-tiles .verb, .feed--cover-tiles .when { color: hsla(0, 0%, 100%, 0.85); }
         .feed--cover-tiles .avatar { width: 22px; height: 22px; }
@@ -996,6 +1012,8 @@ export class OlSocialFeed extends LitElement {
         .feed--magazine .content { order: 1; flex-direction: column; }
         .feed--magazine .cover { width: 100%; height: 260px; }
         .feed--magazine .cover img { object-fit: contain; }
+        .feed--magazine .cover__subject { flex-basis: 74%; }
+        .feed--magazine .cover__mate { flex-basis: 26%; margin-left: -6%; }
         .feed--magazine .title {
             font-family: var(--font-family-serif, Georgia, serif);
             font-size: 1.4rem;
@@ -1086,6 +1104,8 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+            .feed--ticker .head { flex: 1 1 50%; }
+            .feed--ticker .body { flex: 1 1 50%; }
             .feed--tabbed .content { padding-left: 0; }
             .scroller { max-height: 65vh; }
 
@@ -1281,6 +1301,8 @@ export class OlSocialFeed extends LitElement {
             .feed--timeline .card { padding-right: 40px; gap: 6px; }
             .feed--timeline .cover { width: 26px; height: 38px; }
             .feed--ticker .card { padding-right: 38px; gap: 6px; }
+            .feed--ticker .head { flex: 1 1 50%; }
+            .feed--ticker .body { flex: 1 1 50%; }
             .feed--tabbed .content { padding-left: 0; }
             .scroller { max-height: 65vh; }
 

--- a/openlibrary/components/lit/index.js
+++ b/openlibrary/components/lit/index.js
@@ -24,5 +24,6 @@ export { OlBanner } from './OlBanner.js';
 export { OlToast } from './OlToast.js';
 export { OlToastRegion, showToast } from './OlToastRegion.js';
 export { OpenLibraryOTP } from './OpenLibraryOTP.js';
+export { OlSocialFeed } from './OlSocialFeed.js';
 export { OlCarousel } from './OlCarousel.js';
 export { OlScorecard } from './OlScorecard.js';

--- a/openlibrary/core/activity.py
+++ b/openlibrary/core/activity.py
@@ -225,6 +225,37 @@ class ActivityStream:
         )
         return events[:limit]
 
+    @classmethod
+    def popular_feed(cls, viewer: str | None = None, limit: int = 25, page: int = 1) -> list[ActivityEvent]:
+        """The latest single event from each of the most-followed readers.
+
+        One card per patron rather than a stream, ordered by how many people
+        follow them -- a "who is worth following" view rather than a timeline.
+        """
+        ranked = [row["publisher"] for row in PubSub.most_followed(limit=limit * 2)]
+        usernames = [name for name in ranked if name != viewer]
+        if not usernames:
+            return []
+
+        fetch = limit * 4
+        shelf_rows = cls._shelf_rows_for(usernames, limit=fetch, page=page)
+        rating_rows = Ratings.get_recent_ratings(usernames=usernames, limit=fetch, page=page)
+        list_events = cls._recent_list_adds(limit=fetch, usernames=usernames)
+
+        allowed = set(usernames)
+        events = cls._build_events(
+            shelf_rows=[r for r in shelf_rows if r["username"] in allowed],
+            rating_rows=[r for r in rating_rows if r["username"] in allowed],
+            list_events=[e for e in list_events if e.username in allowed],
+        )
+
+        newest: dict[str, ActivityEvent] = {}
+        for event in events:  # already newest-first
+            newest.setdefault(event.username, event)
+
+        rank = {name: i for i, name in enumerate(usernames)}
+        return sorted(newest.values(), key=lambda e: rank[e.username])[:limit]
+
     # -- assembly ---------------------------------------------------------
 
     @classmethod

--- a/openlibrary/core/activity.py
+++ b/openlibrary/core/activity.py
@@ -18,9 +18,9 @@ Two feeds come out of it:
     consent, so this deliberately does *not* re-apply the public-reading-log
     filter.
 
-Only the sources that actually exist today are covered here. Borrow events have
-no public source to read from and are privacy-sensitive; list upvotes are not a
-feature. Neither is faked.
+Only the sources that actually exist today are covered here. Borrow events are
+the one thing the feed cannot show: loans have no public source to read from and
+are privacy-sensitive. That gap is left open rather than faked.
 """
 
 from __future__ import annotations
@@ -32,12 +32,13 @@ from typing import Any, Literal, cast
 
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
+from openlibrary.core.likes import Likes
 from openlibrary.core.ratings import Ratings
 from openlibrary.utils.request_context import site
 
 logger = logging.getLogger("openlibrary.activity")
 
-EventType = Literal["shelf_change", "rating", "list_update"]
+EventType = Literal["shelf_change", "rating", "list_update", "like"]
 
 # Phrasing is deliberately third-person and past-tense so it reads correctly
 # after a username: "ada_reads added to Want to Read".
@@ -145,6 +146,37 @@ class RatingEvent(ActivityEvent):
 
 
 @dataclass(kw_only=True)
+class LikeEvent(ActivityEvent):
+    """A patron liked something.
+
+    `likes.key` is a generic Infogami key rather than a typed id, so this only
+    accepts the two shapes the feed can actually render -- a patron list and a
+    work -- and drops anything else rather than guessing at a card for it.
+    """
+
+    type: EventType = "like"
+    liked_key: str = ""
+
+    @classmethod
+    def from_row(cls, row: dict) -> LikeEvent | None:
+        # Dislikes are recorded in the same table. "Someone disliked this" is
+        # not something to broadcast.
+        if row.get("value") != 1:
+            return None
+        key = row.get("key") or ""
+        created = row.get("created") or row.get("modified")
+
+        if "/lists/" in key:
+            return cls(username=row["username"], created=created, liked_key=key)
+
+        if key.startswith("/works/OL") and key.endswith("W"):
+            work_id = int(key.removeprefix("/works/OL").removesuffix("W"))
+            return cls(username=row["username"], created=created, liked_key=key, work_id=work_id, work_key=key)
+
+        return None
+
+
+@dataclass(kw_only=True)
 class ListEvent(ActivityEvent):
     type: EventType = "list_update"
     list_key: str = ""
@@ -169,9 +201,12 @@ class ActivityStream:
 
         shelf_rows = Bookshelves.get_recently_logged_books(shelf_ids=FEED_SHELF_IDS, limit=fetch, page=page)
         rating_rows = Ratings.get_recent_ratings(limit=fetch, page=page)
+        like_rows = Likes.get_recent_likes(limit=fetch, page=page)
         list_events = cls._recent_lists(limit=limit)
 
-        candidates = [r["username"] for r in shelf_rows] + [r["username"] for r in rating_rows] + [e.username for e in list_events]
+        candidates = (
+            [r["username"] for r in shelf_rows] + [r["username"] for r in rating_rows] + [r["username"] for r in like_rows] + [e.username for e in list_events]
+        )
         public = cls._public_usernames(candidates)
 
         def visible(username: str) -> bool:
@@ -180,6 +215,7 @@ class ActivityStream:
         events = cls._build_events(
             shelf_rows=[r for r in shelf_rows if visible(r["username"])],
             rating_rows=[r for r in rating_rows if visible(r["username"])],
+            like_rows=[r for r in like_rows if visible(r["username"])],
             list_events=[e for e in list_events if visible(e.username)],
         )
         return events[:limit]
@@ -195,12 +231,14 @@ class ActivityStream:
         fetch = limit * 2
         shelf_rows = cls._shelf_rows_for(usernames, limit=fetch, page=page)
         rating_rows = Ratings.get_recent_ratings(usernames=usernames, limit=fetch, page=page)
+        like_rows = Likes.get_recent_likes(usernames=usernames, limit=fetch, page=page)
         list_events = cls._recent_lists(limit=limit, usernames=usernames)
 
         followed = set(usernames)
         events = cls._build_events(
             shelf_rows=[r for r in shelf_rows if r["username"] in followed],
             rating_rows=[r for r in rating_rows if r["username"] in followed],
+            like_rows=[r for r in like_rows if r["username"] in followed],
             list_events=[e for e in list_events if e.username in followed],
         )
         return events[:limit]
@@ -208,7 +246,7 @@ class ActivityStream:
     # -- assembly ---------------------------------------------------------
 
     @classmethod
-    def _build_events(cls, shelf_rows: list, rating_rows: list, list_events: list) -> list[ActivityEvent]:
+    def _build_events(cls, shelf_rows: list, rating_rows: list, list_events: list, like_rows: list | None = None) -> list[ActivityEvent]:
         """Normalise, collapse duplicates, and sort newest first."""
         events: list[ActivityEvent] = [ShelfEvent.from_row(r) for r in shelf_rows]
 
@@ -224,6 +262,7 @@ class ActivityStream:
             else:
                 events.append(rating_event)
 
+        events.extend(e for row in (like_rows or []) if (e := LikeEvent.from_row(row)))
         events.extend(list_events)
         events = [e for e in events if e.created]
         events.sort(key=lambda e: cast(datetime, e.created), reverse=True)

--- a/openlibrary/core/activity.py
+++ b/openlibrary/core/activity.py
@@ -5,6 +5,17 @@ shelvings and star ratings live in Postgres, lists live in Infogami. The social
 feed needs one time-ordered stream across all of them, so this module normalises
 each source into a common event shape and merges them.
 
+Three card types come out of it, in the order they matter:
+
+1. ``shelf_change`` -- a book put on Want to Read, Currently Reading or
+   Already Read.
+2. ``rating`` -- a book given stars. Its own card, not a decoration on the
+   shelving, because rating is its own act.
+3. ``list_add`` -- a book added to one of the patron's lists. The book is the
+   subject; the list is context.
+
+Hearting a list is an *action* offered on card three, not a card of its own.
+
 Two feeds come out of it:
 
 ``public_feed``
@@ -32,13 +43,12 @@ from typing import Any, Literal, cast
 
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
-from openlibrary.core.likes import Likes
 from openlibrary.core.ratings import Ratings
 from openlibrary.utils.request_context import site
 
 logger = logging.getLogger("openlibrary.activity")
 
-EventType = Literal["shelf_change", "rating", "list_update", "like"]
+EventType = Literal["shelf_change", "rating", "list_add"]
 
 # Phrasing is deliberately third-person and past-tense so it reads correctly
 # after a username: "ada_reads added to Want to Read".
@@ -146,43 +156,21 @@ class RatingEvent(ActivityEvent):
 
 
 @dataclass(kw_only=True)
-class LikeEvent(ActivityEvent):
-    """A patron liked something.
+class ListAddEvent(ActivityEvent):
+    """A book added to a patron's list.
 
-    `likes.key` is a generic Infogami key rather than a typed id, so this only
-    accepts the two shapes the feed can actually render -- a patron list and a
-    work -- and drops anything else rather than guessing at a card for it.
+    The book is the subject -- it carries `work_id` like the other two card
+    types, so it enriches from Solr the same way and offers the same
+    add-to-reading-log action. The list is context, and supplies the extra
+    "heart this list" action.
     """
 
-    type: EventType = "like"
-    liked_key: str = ""
-
-    @classmethod
-    def from_row(cls, row: dict) -> LikeEvent | None:
-        # Dislikes are recorded in the same table. "Someone disliked this" is
-        # not something to broadcast.
-        if row.get("value") != 1:
-            return None
-        key = row.get("key") or ""
-        created = row.get("created") or row.get("modified")
-
-        if "/lists/" in key:
-            return cls(username=row["username"], created=created, liked_key=key)
-
-        if key.startswith("/works/OL") and key.endswith("W"):
-            work_id = int(key.removeprefix("/works/OL").removesuffix("W"))
-            return cls(username=row["username"], created=created, liked_key=key, work_id=work_id, work_key=key)
-
-        return None
-
-
-@dataclass(kw_only=True)
-class ListEvent(ActivityEvent):
-    type: EventType = "list_update"
+    type: EventType = "list_add"
     list_key: str = ""
     name: str = ""
     book_count: int = 0
     cover_ids: list[int] = field(default_factory=list)
+    like_count: int = 0
 
     @property
     def list_url(self) -> str:
@@ -201,12 +189,9 @@ class ActivityStream:
 
         shelf_rows = Bookshelves.get_recently_logged_books(shelf_ids=FEED_SHELF_IDS, limit=fetch, page=page)
         rating_rows = Ratings.get_recent_ratings(limit=fetch, page=page)
-        like_rows = Likes.get_recent_likes(limit=fetch, page=page)
-        list_events = cls._recent_lists(limit=limit)
+        list_events = cls._recent_list_adds(limit=limit)
 
-        candidates = (
-            [r["username"] for r in shelf_rows] + [r["username"] for r in rating_rows] + [r["username"] for r in like_rows] + [e.username for e in list_events]
-        )
+        candidates = [r["username"] for r in shelf_rows] + [r["username"] for r in rating_rows] + [e.username for e in list_events]
         public = cls._public_usernames(candidates)
 
         def visible(username: str) -> bool:
@@ -215,7 +200,6 @@ class ActivityStream:
         events = cls._build_events(
             shelf_rows=[r for r in shelf_rows if visible(r["username"])],
             rating_rows=[r for r in rating_rows if visible(r["username"])],
-            like_rows=[r for r in like_rows if visible(r["username"])],
             list_events=[e for e in list_events if visible(e.username)],
         )
         return events[:limit]
@@ -231,14 +215,12 @@ class ActivityStream:
         fetch = limit * 2
         shelf_rows = cls._shelf_rows_for(usernames, limit=fetch, page=page)
         rating_rows = Ratings.get_recent_ratings(usernames=usernames, limit=fetch, page=page)
-        like_rows = Likes.get_recent_likes(usernames=usernames, limit=fetch, page=page)
-        list_events = cls._recent_lists(limit=limit, usernames=usernames)
+        list_events = cls._recent_list_adds(limit=limit, usernames=usernames)
 
         followed = set(usernames)
         events = cls._build_events(
             shelf_rows=[r for r in shelf_rows if r["username"] in followed],
             rating_rows=[r for r in rating_rows if r["username"] in followed],
-            like_rows=[r for r in like_rows if r["username"] in followed],
             list_events=[e for e in list_events if e.username in followed],
         )
         return events[:limit]
@@ -246,23 +228,15 @@ class ActivityStream:
     # -- assembly ---------------------------------------------------------
 
     @classmethod
-    def _build_events(cls, shelf_rows: list, rating_rows: list, list_events: list, like_rows: list | None = None) -> list[ActivityEvent]:
-        """Normalise, collapse duplicates, and sort newest first."""
+    def _build_events(cls, shelf_rows: list, rating_rows: list, list_events: list) -> list[ActivityEvent]:
+        """Normalise every source into events and sort newest first.
+
+        Shelving and rating are separate cards even for the same book by the
+        same patron -- they are two of the three card types, and folding one
+        into the other hid an event the feed is meant to surface.
+        """
         events: list[ActivityEvent] = [ShelfEvent.from_row(r) for r in shelf_rows]
-
-        # Marking a book read and rating it is one act to a reader, so fold the
-        # star onto the shelving rather than emitting two near-identical cards.
-        by_work = {e.dedupe_key: e for e in events}
-        for row in rating_rows:
-            rating_event = RatingEvent.from_row(row)
-            if rating_event is None:
-                continue
-            if existing := by_work.get(rating_event.dedupe_key):
-                existing.rating = rating_event.rating
-            else:
-                events.append(rating_event)
-
-        events.extend(e for row in (like_rows or []) if (e := LikeEvent.from_row(row)))
+        events.extend(e for row in rating_rows if (e := RatingEvent.from_row(row)))
         events.extend(list_events)
         events = [e for e in events if e.created]
         events.sort(key=lambda e: cast(datetime, e.created), reverse=True)
@@ -303,13 +277,18 @@ class ActivityStream:
         return public
 
     @classmethod
-    def _recent_lists(cls, limit: int = 10, usernames: list[str] | None = None) -> list[ListEvent]:
-        """Recently touched patron lists, as feed events.
+    def _recent_list_adds(cls, limit: int = 10, usernames: list[str] | None = None) -> list[ListAddEvent]:
+        """Recently touched patron lists, as "added a book to a list" events.
 
         Lists are Infogami things rather than Postgres rows, so this is a
-        `things` query rather than part of the union above. There is no
-        "book added to list" event to read -- only the list's own
-        `last_modified` -- so a list appears once, as its most recent state.
+        `things` query rather than part of the union above, and there is no
+        per-book event to read. `List.add_seed` appends, though, so the last
+        work in `seeds` is the one most recently added -- which is enough to
+        name the book without diffing revisions.
+
+        That approximation is the reason a computed `activity_feed` table is
+        the right long-term home for this: a worker can record the real event
+        when it happens instead of inferring it afterwards.
         """
         query: dict[str, Any] = {
             "type": "/type/list",
@@ -322,7 +301,7 @@ class ActivityStream:
             logger.warning("could not query recent lists", exc_info=True)
             return []
 
-        events: list[ListEvent] = []
+        events: list[ListAddEvent] = []
         for key in keys:
             owner = cls._list_owner(key)
             if not owner or (usernames is not None and owner not in usernames):
@@ -330,19 +309,46 @@ class ActivityStream:
             doc = site.get().get(key)
             if not doc:
                 continue
+            work_id = cls._newest_work_seed(doc.seeds or [])
+            if work_id is None:
+                # A list of subjects or authors has no book to offer.
+                continue
             showcase = cls._list_showcase(doc)
             events.append(
-                ListEvent(
-                    type="list_update",
+                ListAddEvent(
                     username=owner,
                     created=cls._as_datetime(doc.last_modified),
+                    work_id=work_id,
+                    work_key=_work_key(work_id),
                     list_key=key,
                     name=showcase["title"],
                     book_count=showcase["count"],
                     cover_ids=showcase["cover_ids"],
+                    like_count=cls._like_count(key),
                 )
             )
         return events
+
+    @staticmethod
+    def _newest_work_seed(seeds) -> int | None:
+        """Numeric work id of the most recently added book seed, if any."""
+        for seed in reversed(list(seeds)):
+            key = getattr(seed, "key", None) or (seed.get("key") if isinstance(seed, dict) else None)
+            if isinstance(key, str) and key.startswith("/works/OL") and key.endswith("W"):
+                digits = key.removeprefix("/works/OL").removesuffix("W")
+                if digits.isdigit():
+                    return int(digits)
+        return None
+
+    @staticmethod
+    def _like_count(key: str) -> int:
+        from openlibrary.core.likes import Likes
+
+        try:
+            return Likes.get_count(key).get("likes", 0)
+        except Exception:  # noqa: BLE001 - a heart count is decoration, not the card
+            logger.warning("could not count likes for %s", key, exc_info=True)
+            return 0
 
     @staticmethod
     def _list_owner(key: str) -> str | None:
@@ -386,6 +392,37 @@ class ActivityStream:
             except ValueError:
                 return None
         return None
+
+    @staticmethod
+    def balance(events: list[ActivityEvent], limit: int) -> list[ActivityEvent]:
+        """Trim to `limit` while keeping every card type represented.
+
+        Strict newest-first can return a page of one type, which is fine for a
+        real feed and useless for comparing card designs. Round-robins across
+        types, then restores time order within the sample.
+        """
+        if len(events) <= limit:
+            return events
+
+        buckets: dict[str, list[ActivityEvent]] = {}
+        for event in events:
+            buckets.setdefault(event.type, []).append(event)
+
+        picked: list[ActivityEvent] = []
+        while len(picked) < limit:
+            took = False
+            for bucket in buckets.values():
+                if not bucket:
+                    continue
+                picked.append(bucket.pop(0))
+                took = True
+                if len(picked) == limit:
+                    break
+            if not took:
+                break
+
+        picked.sort(key=lambda e: cast(datetime, e.created), reverse=True)
+        return picked
 
     # -- enrichment -------------------------------------------------------
 

--- a/openlibrary/core/activity.py
+++ b/openlibrary/core/activity.py
@@ -1,0 +1,367 @@
+"""A unified activity stream over the things patrons publicly do with books.
+
+Open Library records patron activity in several unrelated places: reading-log
+shelvings and star ratings live in Postgres, lists live in Infogami. The social
+feed needs one time-ordered stream across all of them, so this module normalises
+each source into a common event shape and merges them.
+
+Two feeds come out of it:
+
+``public_feed``
+    Everything happening across the library, restricted to patrons who have
+    opted into a public reading log. This is what a patron who follows nobody
+    sees -- there is real value in the community's activity before you follow
+    anyone, so this is a browsable feed rather than a placeholder.
+
+``following_feed``
+    The same shape, restricted to the patrons the viewer follows. Following is
+    consent, so this deliberately does *not* re-apply the public-reading-log
+    filter.
+
+Only the sources that actually exist today are covered here. Borrow events have
+no public source to read from and are privacy-sensitive; list upvotes are not a
+feature. Neither is faked.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, cast
+
+from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.follows import PubSub
+from openlibrary.core.ratings import Ratings
+from openlibrary.utils.request_context import site
+
+logger = logging.getLogger("openlibrary.activity")
+
+EventType = Literal["shelf_change", "rating", "list_update"]
+
+# Phrasing is deliberately third-person and past-tense so it reads correctly
+# after a username: "ada_reads added to Want to Read".
+SHELF_LABELS: dict[int, str] = {
+    1: "added to Want to Read",
+    2: "is Currently Reading",
+    3: "finished reading",
+    4: "stopped reading",
+}
+
+SHELF_SLUGS: dict[int, str] = {
+    1: "want-to-read",
+    2: "currently-reading",
+    3: "already-read",
+    4: "stopped-reading",
+}
+
+FEED_SHELF_IDS = [1, 2, 3]
+
+
+def shelf_label(shelf_id: int) -> str:
+    """Human phrasing for a bookshelf id, safe for ids we do not recognise."""
+    return SHELF_LABELS.get(shelf_id, "logged")
+
+
+def _work_key(work_id: int | str) -> str:
+    return f"/works/OL{work_id}W"
+
+
+@dataclass(kw_only=True)
+class ActivityEvent:
+    """One thing a patron did, normalised across every source."""
+
+    type: EventType
+    username: str
+    # Rows can arrive without a usable timestamp; undated events are dropped
+    # during assembly rather than crashing the feed.
+    created: datetime | None = None
+
+    # Work-shaped events (shelvings, ratings) carry these; list events do not.
+    work_key: str | None = None
+    work_id: int | None = None
+    shelf_id: int | None = None
+    rating: int | None = None
+
+    # Populated later, from Solr, by `attach_works`.
+    work: dict[str, Any] | None = None
+
+    @property
+    def patron_url(self) -> str:
+        return f"/people/{self.username}"
+
+    @property
+    def label(self) -> str:
+        return shelf_label(self.shelf_id) if self.shelf_id else ""
+
+    @property
+    def shelf_url(self) -> str | None:
+        if not self.shelf_id or self.shelf_id not in SHELF_SLUGS:
+            return None
+        return f"/people/{self.username}/books/{SHELF_SLUGS[self.shelf_id]}"
+
+    @property
+    def dedupe_key(self) -> tuple:
+        """Identifies the same underlying act across sources."""
+        return (self.username, self.work_id)
+
+
+@dataclass(kw_only=True)
+class ShelfEvent(ActivityEvent):
+    type: EventType = "shelf_change"
+
+    @classmethod
+    def from_row(cls, row: dict) -> ShelfEvent:
+        work_id = row["work_id"]
+        return cls(
+            type="shelf_change",
+            username=row["username"],
+            created=row.get("created") or row.get("updated"),
+            work_id=work_id,
+            work_key=_work_key(work_id),
+            shelf_id=row.get("bookshelf_id"),
+        )
+
+
+@dataclass(kw_only=True)
+class RatingEvent(ActivityEvent):
+    type: EventType = "rating"
+
+    @classmethod
+    def from_row(cls, row: dict) -> RatingEvent | None:
+        # A row can exist with rating 0 meaning "rating cleared" -- not an event.
+        rating = row.get("rating")
+        if not rating:
+            return None
+        work_id = row["work_id"]
+        return cls(
+            type="rating",
+            username=row["username"],
+            created=row.get("created") or row.get("updated"),
+            work_id=work_id,
+            work_key=_work_key(work_id),
+            rating=rating,
+        )
+
+
+@dataclass(kw_only=True)
+class ListEvent(ActivityEvent):
+    type: EventType = "list_update"
+    list_key: str = ""
+    name: str = ""
+    book_count: int = 0
+    cover_ids: list[int] = field(default_factory=list)
+
+    @property
+    def list_url(self) -> str:
+        return self.list_key
+
+
+class ActivityStream:
+    """Builds the public and following feeds."""
+
+    @classmethod
+    def public_feed(cls, viewer: str | None = None, limit: int = 25, page: int = 1) -> list[ActivityEvent]:
+        """Recent activity from across the library, public reading logs only."""
+        # Over-fetch: filtering private patrons and the viewer's own rows both
+        # thin the result, and a short feed is worse than a slightly slower one.
+        fetch = limit * 4
+
+        shelf_rows = Bookshelves.get_recently_logged_books(shelf_ids=FEED_SHELF_IDS, limit=fetch, page=page)
+        rating_rows = Ratings.get_recent_ratings(limit=fetch, page=page)
+        list_events = cls._recent_lists(limit=limit)
+
+        candidates = [r["username"] for r in shelf_rows] + [r["username"] for r in rating_rows] + [e.username for e in list_events]
+        public = cls._public_usernames(candidates)
+
+        def visible(username: str) -> bool:
+            return username in public and username != viewer
+
+        events = cls._build_events(
+            shelf_rows=[r for r in shelf_rows if visible(r["username"])],
+            rating_rows=[r for r in rating_rows if visible(r["username"])],
+            list_events=[e for e in list_events if visible(e.username)],
+        )
+        return events[:limit]
+
+    @classmethod
+    def following_feed(cls, viewer: str, limit: int = 25, page: int = 1) -> list[ActivityEvent]:
+        """Recent activity from the patrons the viewer follows."""
+        following = PubSub.get_following(viewer, exclude_disabled=True)
+        usernames = [f["publisher"] for f in following]
+        if not usernames:
+            return []
+
+        fetch = limit * 2
+        shelf_rows = cls._shelf_rows_for(usernames, limit=fetch, page=page)
+        rating_rows = Ratings.get_recent_ratings(usernames=usernames, limit=fetch, page=page)
+        list_events = cls._recent_lists(limit=limit, usernames=usernames)
+
+        followed = set(usernames)
+        events = cls._build_events(
+            shelf_rows=[r for r in shelf_rows if r["username"] in followed],
+            rating_rows=[r for r in rating_rows if r["username"] in followed],
+            list_events=[e for e in list_events if e.username in followed],
+        )
+        return events[:limit]
+
+    # -- assembly ---------------------------------------------------------
+
+    @classmethod
+    def _build_events(cls, shelf_rows: list, rating_rows: list, list_events: list) -> list[ActivityEvent]:
+        """Normalise, collapse duplicates, and sort newest first."""
+        events: list[ActivityEvent] = [ShelfEvent.from_row(r) for r in shelf_rows]
+
+        # Marking a book read and rating it is one act to a reader, so fold the
+        # star onto the shelving rather than emitting two near-identical cards.
+        by_work = {e.dedupe_key: e for e in events}
+        for row in rating_rows:
+            rating_event = RatingEvent.from_row(row)
+            if rating_event is None:
+                continue
+            if existing := by_work.get(rating_event.dedupe_key):
+                existing.rating = rating_event.rating
+            else:
+                events.append(rating_event)
+
+        events.extend(list_events)
+        events = [e for e in events if e.created]
+        events.sort(key=lambda e: cast(datetime, e.created), reverse=True)
+        return events
+
+    @classmethod
+    def _shelf_rows_for(cls, usernames: list[str], limit: int, page: int = 1) -> list:
+        """Recent reading-log rows for a specific set of patrons."""
+        from openlibrary.core import db
+
+        oldb = db.get_db()
+        offset = limit * (max(page, 1) - 1)
+        query = "SELECT * FROM bookshelves_books WHERE username IN $usernames AND bookshelf_id IN $shelf_ids ORDER BY created DESC LIMIT $limit OFFSET $offset"
+        return list(
+            oldb.query(
+                query,
+                vars={"usernames": usernames, "shelf_ids": FEED_SHELF_IDS, "limit": limit, "offset": offset},
+            )
+        )
+
+    @classmethod
+    def _public_usernames(cls, usernames: list[str]) -> set[str]:
+        """Subset of the given patrons whose reading log is public.
+
+        Reads the preference store directly, one key per patron, rather than
+        unmarshalling a full account model each time.
+        """
+        public: set[str] = set()
+        store = site.get().store
+        for username in set(usernames):
+            try:
+                prefs = store.get(f"/people/{username}/preferences") or {}
+            except Exception:  # noqa: BLE001 - a single unreadable patron must not fail the feed
+                logger.warning("could not read preferences for %s", username, exc_info=True)
+                continue
+            if prefs.get("public_readlog") == "yes":
+                public.add(username)
+        return public
+
+    @classmethod
+    def _recent_lists(cls, limit: int = 10, usernames: list[str] | None = None) -> list[ListEvent]:
+        """Recently touched patron lists, as feed events.
+
+        Lists are Infogami things rather than Postgres rows, so this is a
+        `things` query rather than part of the union above. There is no
+        "book added to list" event to read -- only the list's own
+        `last_modified` -- so a list appears once, as its most recent state.
+        """
+        query: dict[str, Any] = {
+            "type": "/type/list",
+            "sort": "-last_modified",
+            "limit": limit,
+        }
+        try:
+            keys = site.get().things(query)
+        except Exception:  # noqa: BLE001 - lists are a bonus source; the feed still works without them
+            logger.warning("could not query recent lists", exc_info=True)
+            return []
+
+        events: list[ListEvent] = []
+        for key in keys:
+            owner = cls._list_owner(key)
+            if not owner or (usernames is not None and owner not in usernames):
+                continue
+            doc = site.get().get(key)
+            if not doc:
+                continue
+            showcase = cls._list_showcase(doc)
+            events.append(
+                ListEvent(
+                    type="list_update",
+                    username=owner,
+                    created=cls._as_datetime(doc.last_modified),
+                    list_key=key,
+                    name=showcase["title"],
+                    book_count=showcase["count"],
+                    cover_ids=showcase["cover_ids"],
+                )
+            )
+        return events
+
+    @staticmethod
+    def _list_owner(key: str) -> str | None:
+        """`/people/ada/lists/OL1L` -> `ada`. Non-patron lists have no owner."""
+        parts = key.split("/")
+        if len(parts) >= 3 and parts[1] == "people":
+            return parts[2]
+        return None
+
+    @staticmethod
+    def _list_showcase(doc) -> dict[str, Any]:
+        """Title, size, and up to three cover ids for a list card."""
+        covers: list[int] = []
+        count = 0
+        try:
+            cached = doc.get_patron_showcase()
+            count = cached.get("count", 0)
+            for url in cached.get("covers") or []:
+                # `get_patron_showcase` hands back cover URLs; the feed wants
+                # ids so the client can size the image itself.
+                if url and (cover_id := ActivityStream._cover_id_from_url(url)):
+                    covers.append(cover_id)
+        except Exception:  # noqa: BLE001 - a malformed list renders without covers rather than 500ing
+            logger.warning("could not build showcase for %s", doc.key, exc_info=True)
+        return {"title": doc.name or "", "count": count, "cover_ids": covers[:3]}
+
+    @staticmethod
+    def _cover_id_from_url(url: str) -> int | None:
+        """Pull the numeric id out of a `.../b/id/12345-S.jpg` cover URL."""
+        segment = url.rsplit("/", 1)[-1]
+        digits = segment.split("-", 1)[0]
+        return int(digits) if digits.isdigit() else None
+
+    @staticmethod
+    def _as_datetime(value) -> datetime | None:
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return None
+        return None
+
+    # -- enrichment -------------------------------------------------------
+
+    @classmethod
+    def attach_works(cls, events: list[ActivityEvent]) -> None:
+        """Fill in each event's Solr work record, in place.
+
+        Covers were rendered from guessed work-OLID URLs in an earlier attempt at
+        this feature and came out wrong; the cover id has to come off the Solr
+        record, which is what this fetches.
+        """
+        work_events = [e for e in events if e.work_id is not None]
+        if not work_events:
+            return
+        items: list[dict[str, Any]] = [{"work_id": e.work_id} for e in work_events]
+        Bookshelves.add_solr_works(items, fields=["key", "title", "author_name", "author_key", "cover_i", "first_publish_year", "ebook_access"])
+        for event, item in zip(work_events, items, strict=True):
+            event.work = item.get("work")

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -78,6 +78,27 @@ class Likes:
         return list(likes)
 
     @classmethod
+    def get_recent_likes(cls, usernames: list[str] | None = None, limit: int = 25, page: int = 1) -> list:
+        """Most recently liked keys, newest first.
+
+        Backs the social activity feed. Dislikes are excluded -- "someone
+        disliked this" is not something to broadcast. Pass `usernames` to
+        restrict the result to a specific set of patrons.
+        """
+        oldb = db.get_db()
+        page = int(page or 1)
+        where = "WHERE value = 1"
+        if usernames:
+            where += " AND username IN $usernames"
+        query = f"SELECT * FROM likes {where} ORDER BY created DESC LIMIT $limit OFFSET $offset"
+        return list(
+            oldb.query(
+                query,
+                vars={"usernames": usernames, "limit": limit, "offset": limit * (page - 1)},
+            )
+        )
+
+    @classmethod
     def patron_liked(cls, username: str, key: str) -> bool:
         """Return whether the patron has liked this key."""
         oldb = db.get_db()

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -78,27 +78,6 @@ class Likes:
         return list(likes)
 
     @classmethod
-    def get_recent_likes(cls, usernames: list[str] | None = None, limit: int = 25, page: int = 1) -> list:
-        """Most recently liked keys, newest first.
-
-        Backs the social activity feed. Dislikes are excluded -- "someone
-        disliked this" is not something to broadcast. Pass `usernames` to
-        restrict the result to a specific set of patrons.
-        """
-        oldb = db.get_db()
-        page = int(page or 1)
-        where = "WHERE value = 1"
-        if usernames:
-            where += " AND username IN $usernames"
-        query = f"SELECT * FROM likes {where} ORDER BY created DESC LIMIT $limit OFFSET $offset"
-        return list(
-            oldb.query(
-                query,
-                vars={"usernames": usernames, "limit": limit, "offset": limit * (page - 1)},
-            )
-        )
-
-    @classmethod
     def patron_liked(cls, username: str, key: str) -> bool:
         """Return whether the patron has liked this key."""
         oldb = db.get_db()

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -66,6 +66,24 @@ class Ratings(db.CommonExtras):
         return list(oldb.query(query, vars={"limit": limit, "since": since}))
 
     @classmethod
+    def get_recent_ratings(cls, usernames: list[str] | None = None, limit: int = 25, page: int = 1) -> list:
+        """Most recently submitted ratings, newest first.
+
+        Backs the social activity feed. Pass `usernames` to restrict the result
+        to a specific set of patrons (i.e. the ones a viewer follows).
+        """
+        oldb = db.get_db()
+        page = int(page or 1)
+        where = "WHERE username IN $usernames" if usernames else ""
+        query = f"SELECT * FROM ratings {where} ORDER BY created DESC LIMIT $limit OFFSET $offset"
+        return list(
+            oldb.query(
+                query,
+                vars={"usernames": usernames, "limit": limit, "offset": limit * (page - 1)},
+            )
+        )
+
+    @classmethod
     def get_users_ratings(cls, username) -> list:
         oldb = db.get_db()
         query = "select * from ratings where username=$username"

--- a/openlibrary/core/tests/test_activity.py
+++ b/openlibrary/core/tests/test_activity.py
@@ -7,8 +7,7 @@ import pytest
 
 from openlibrary.core.activity import (
     ActivityStream,
-    LikeEvent,
-    ListEvent,
+    ListAddEvent,
     RatingEvent,
     ShelfEvent,
     shelf_label,
@@ -95,8 +94,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
             events = ActivityStream.public_feed(limit=10)
@@ -112,8 +110,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value={"public_patron"}),
         ):
             events = ActivityStream.public_feed(limit=10)
@@ -131,8 +128,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
             events = ActivityStream.public_feed(viewer="me", limit=10)
@@ -146,31 +142,30 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
             events = ActivityStream.public_feed(limit=3)
 
         assert len(events) == 3
 
-    def test_collapses_a_rating_into_the_matching_shelf_event(self):
-        # Rating a book you just marked read is one act, not two feed entries.
+    def test_a_rating_is_its_own_card_not_folded_into_the_shelving(self):
+        # Shelving and rating are two of the three card types, so a patron who
+        # does both produces two cards.
         shelves = [shelf_row(username="ada", work_id=7, bookshelf_id=3, created=JAN)]
         ratings = [rating_row(username="ada", work_id=7, rating=5, created=JAN)]
 
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
             events = ActivityStream.public_feed(limit=10)
 
-        assert len(events) == 1
-        assert events[0].type == "shelf_change"
-        assert events[0].rating == 5
+        assert sorted(e.type for e in events) == ["rating", "shelf_change"]
+        assert next(e for e in events if e.type == "rating").rating == 5
+        assert next(e for e in events if e.type == "shelf_change").rating is None
 
 
 class TestActivityStreamFollowingFeed:
@@ -189,8 +184,7 @@ class TestActivityStreamFollowingFeed:
             patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
             patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
         ):
             events = ActivityStream.following_feed("viewer", limit=10)
 
@@ -206,8 +200,7 @@ class TestActivityStreamFollowingFeed:
             patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
             patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value=set()) as public_mock,
         ):
             events = ActivityStream.following_feed("viewer", limit=10)
@@ -216,51 +209,59 @@ class TestActivityStreamFollowingFeed:
         public_mock.assert_not_called()
 
 
-class TestLikeEvent:
-    def test_builds_from_a_liked_list_key(self):
-        event = LikeEvent.from_row({"username": "ada", "key": "/people/bo/lists/OL1L", "value": 1, "created": JAN})
-        assert event.type == "like"
-        assert event.liked_key == "/people/bo/lists/OL1L"
+class TestListAddEvent:
+    """Card three: a patron added a book to one of their lists."""
 
-    def test_ignores_dislikes(self):
-        # "Someone disliked this" is not worth broadcasting.
-        assert LikeEvent.from_row({"username": "ada", "key": "/people/bo/lists/OL1L", "value": -1, "created": JAN}) is None
-
-    def test_a_liked_work_key_becomes_a_work_event(self):
-        # `likes.key` is a generic Infogami key, so it may point at a work.
-        event = LikeEvent.from_row({"username": "ada", "key": "/works/OL59800W", "value": 1, "created": JAN})
-        assert event.work_id == 59800
-        assert event.work_key == "/works/OL59800W"
-
-    def test_an_unrecognised_key_is_dropped(self):
-        assert LikeEvent.from_row({"username": "ada", "key": "/authors/OL1A", "value": 1, "created": JAN}) is None
-
-
-class TestActivityStreamIncludesLikes:
-    def test_likes_join_the_public_feed(self):
-        likes = [{"username": "ada", "key": "/people/bo/lists/OL1L", "value": 1, "created": MAR}]
-
-        with (
-            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=[]),
-            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
-            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=likes),
-            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
-            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
-        ):
-            events = ActivityStream.public_feed(limit=10)
-
-        assert [e.type for e in events] == ["like"]
-
-
-class TestListEvent:
-    def test_builds_from_a_list_thing(self):
-        event = ListEvent(
+    def test_carries_both_the_book_and_the_list(self):
+        event = ListAddEvent(
             username="ada",
             created=JAN,
+            work_id=59800,
+            work_key="/works/OL59800W",
             list_key="/people/ada/lists/OL1L",
             name="Books that rewired my brain",
             book_count=4,
             cover_ids=[1, 2, 3],
         )
-        assert event.type == "list_update"
+        assert event.type == "list_add"
+        # The book is the subject, so it enriches from Solr like any other card.
+        assert event.work_id == 59800
         assert event.list_url == "/people/ada/lists/OL1L"
+
+    def test_the_newest_seed_is_the_one_that_was_just_added(self):
+        # `List.add_seed` appends, so the tail of `seeds` is the latest add.
+        seeds = [{"key": "/works/OL1W"}, {"key": "/works/OL2W"}, {"key": "/works/OL3W"}]
+        assert ActivityStream._newest_work_seed(seeds) == 3
+
+    def test_non_work_seeds_are_skipped(self):
+        seeds = [{"key": "/works/OL7W"}, "subject:love", {"key": "/authors/OL1A"}]
+        assert ActivityStream._newest_work_seed(seeds) == 7
+
+    def test_a_list_with_no_book_seeds_yields_nothing(self):
+        assert ActivityStream._newest_work_seed(["subject:love"]) is None
+        assert ActivityStream._newest_work_seed([]) is None
+
+
+class TestBalancedSample:
+    """The design gallery needs every card type visible in every variant."""
+
+    def _events(self):
+        return (
+            [ShelfEvent.from_row(shelf_row(work_id=i, created=MAR)) for i in range(8)]
+            + [RatingEvent.from_row(rating_row(work_id=i, created=FEB)) for i in range(8)]
+            + [ListAddEvent(username="ada", created=JAN, work_id=99, work_key="/works/OL99W", list_key="/people/ada/lists/OL1L", name="L", book_count=1)]
+        )
+
+    def test_every_type_survives_a_small_limit(self):
+        # Newest-first would return eight shelvings and nothing else.
+        picked = ActivityStream.balance(self._events(), limit=4)
+        assert {e.type for e in picked} == {"shelf_change", "rating", "list_add"}
+        assert len(picked) == 4
+
+    def test_order_stays_newest_first_within_the_sample(self):
+        picked = ActivityStream.balance(self._events(), limit=6)
+        assert picked == sorted(picked, key=lambda e: e.created, reverse=True)
+
+    def test_a_limit_larger_than_the_input_returns_everything(self):
+        events = self._events()
+        assert len(ActivityStream.balance(events, limit=100)) == len(events)

--- a/openlibrary/core/tests/test_activity.py
+++ b/openlibrary/core/tests/test_activity.py
@@ -7,6 +7,7 @@ import pytest
 
 from openlibrary.core.activity import (
     ActivityStream,
+    LikeEvent,
     ListEvent,
     RatingEvent,
     ShelfEvent,
@@ -94,6 +95,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
@@ -110,6 +112,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value={"public_patron"}),
         ):
@@ -128,6 +131,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
@@ -142,6 +146,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
@@ -157,6 +162,7 @@ class TestActivityStreamPublicFeed:
         with (
             patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
         ):
@@ -183,6 +189,7 @@ class TestActivityStreamFollowingFeed:
             patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
             patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
         ):
             events = ActivityStream.following_feed("viewer", limit=10)
@@ -199,6 +206,7 @@ class TestActivityStreamFollowingFeed:
             patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
             patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
             patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
             patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value=set()) as public_mock,
         ):
@@ -206,6 +214,42 @@ class TestActivityStreamFollowingFeed:
 
         assert [e.username for e in events] == ["ada"]
         public_mock.assert_not_called()
+
+
+class TestLikeEvent:
+    def test_builds_from_a_liked_list_key(self):
+        event = LikeEvent.from_row({"username": "ada", "key": "/people/bo/lists/OL1L", "value": 1, "created": JAN})
+        assert event.type == "like"
+        assert event.liked_key == "/people/bo/lists/OL1L"
+
+    def test_ignores_dislikes(self):
+        # "Someone disliked this" is not worth broadcasting.
+        assert LikeEvent.from_row({"username": "ada", "key": "/people/bo/lists/OL1L", "value": -1, "created": JAN}) is None
+
+    def test_a_liked_work_key_becomes_a_work_event(self):
+        # `likes.key` is a generic Infogami key, so it may point at a work.
+        event = LikeEvent.from_row({"username": "ada", "key": "/works/OL59800W", "value": 1, "created": JAN})
+        assert event.work_id == 59800
+        assert event.work_key == "/works/OL59800W"
+
+    def test_an_unrecognised_key_is_dropped(self):
+        assert LikeEvent.from_row({"username": "ada", "key": "/authors/OL1A", "value": 1, "created": JAN}) is None
+
+
+class TestActivityStreamIncludesLikes:
+    def test_likes_join_the_public_feed(self):
+        likes = [{"username": "ada", "key": "/people/bo/lists/OL1L", "value": 1, "created": MAR}]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=[]),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.Likes.get_recent_likes", return_value=likes),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
+        ):
+            events = ActivityStream.public_feed(limit=10)
+
+        assert [e.type for e in events] == ["like"]
 
 
 class TestListEvent:

--- a/openlibrary/core/tests/test_activity.py
+++ b/openlibrary/core/tests/test_activity.py
@@ -1,0 +1,222 @@
+"""Tests for the unified activity stream that backs the social feed."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from openlibrary.core.activity import (
+    ActivityStream,
+    ListEvent,
+    RatingEvent,
+    ShelfEvent,
+    shelf_label,
+)
+
+JAN = datetime(2026, 1, 10, 12, 0, 0)
+FEB = datetime(2026, 2, 10, 12, 0, 0)
+MAR = datetime(2026, 3, 10, 12, 0, 0)
+
+
+def shelf_row(username="reader", work_id=1, bookshelf_id=1, created=JAN, **extra):
+    return {
+        "username": username,
+        "work_id": work_id,
+        "bookshelf_id": bookshelf_id,
+        "edition_id": None,
+        "private": False,
+        "created": created,
+        "updated": created,
+        **extra,
+    }
+
+
+def rating_row(username="reader", work_id=1, rating=4, created=JAN):
+    return {
+        "username": username,
+        "work_id": work_id,
+        "rating": rating,
+        "edition_id": None,
+        "created": created,
+        "updated": created,
+    }
+
+
+class TestShelfLabel:
+    @pytest.mark.parametrize(
+        ("shelf_id", "expected"),
+        [
+            (1, "added to Want to Read"),
+            (2, "is Currently Reading"),
+            (3, "finished reading"),
+            (4, "stopped reading"),
+        ],
+    )
+    def test_known_shelves(self, shelf_id, expected):
+        assert shelf_label(shelf_id) == expected
+
+    def test_unknown_shelf_falls_back(self):
+        # An unrecognised shelf id must not blow up the whole feed.
+        assert shelf_label(99) == "logged"
+
+
+class TestShelfEvent:
+    def test_carries_shelf_url_for_the_acting_patron(self):
+        event = ShelfEvent.from_row(shelf_row(username="ada", bookshelf_id=2))
+        assert event.shelf_url == "/people/ada/books/currently-reading"
+
+    def test_work_key_is_built_from_the_numeric_work_id(self):
+        event = ShelfEvent.from_row(shelf_row(work_id=59800))
+        assert event.work_key == "/works/OL59800W"
+
+    def test_sorts_by_created(self):
+        older = ShelfEvent.from_row(shelf_row(created=JAN))
+        newer = ShelfEvent.from_row(shelf_row(created=MAR))
+        assert sorted([older, newer], key=lambda e: e.created, reverse=True)[0] is newer
+
+
+class TestRatingEvent:
+    def test_carries_the_star_rating(self):
+        event = RatingEvent.from_row(rating_row(rating=5))
+        assert event.rating == 5
+        assert event.type == "rating"
+
+    def test_rejects_ratings_outside_the_star_range(self):
+        # A 0 means "rating cleared", which is not a feed-worthy event.
+        assert RatingEvent.from_row(rating_row(rating=0)) is None
+
+
+class TestActivityStreamPublicFeed:
+    def test_merges_sources_newest_first(self):
+        shelves = [shelf_row(username="ada", work_id=1, created=JAN)]
+        ratings = [rating_row(username="bo", work_id=2, created=MAR)]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
+        ):
+            events = ActivityStream.public_feed(limit=10)
+
+        assert [e.type for e in events] == ["rating", "shelf_change"]
+
+    def test_excludes_patrons_with_private_reading_logs(self):
+        shelves = [
+            shelf_row(username="public_patron", work_id=1, created=MAR),
+            shelf_row(username="private_patron", work_id=2, created=FEB),
+        ]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value={"public_patron"}),
+        ):
+            events = ActivityStream.public_feed(limit=10)
+
+        assert [e.username for e in events] == ["public_patron"]
+
+    def test_excludes_the_viewers_own_activity(self):
+        # Your own shelvings are already all over My Books; seeing them again in
+        # the community feed is noise.
+        shelves = [
+            shelf_row(username="me", work_id=1, created=MAR),
+            shelf_row(username="someone_else", work_id=2, created=FEB),
+        ]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
+        ):
+            events = ActivityStream.public_feed(viewer="me", limit=10)
+
+        assert [e.username for e in events] == ["someone_else"]
+
+    def test_respects_the_limit_after_merging(self):
+        shelves = [shelf_row(username="ada", work_id=i, created=JAN) for i in range(10)]
+        ratings = [rating_row(username="bo", work_id=i, created=MAR) for i in range(10)]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
+        ):
+            events = ActivityStream.public_feed(limit=3)
+
+        assert len(events) == 3
+
+    def test_collapses_a_rating_into_the_matching_shelf_event(self):
+        # Rating a book you just marked read is one act, not two feed entries.
+        shelves = [shelf_row(username="ada", work_id=7, bookshelf_id=3, created=JAN)]
+        ratings = [rating_row(username="ada", work_id=7, rating=5, created=JAN)]
+
+        with (
+            patch("openlibrary.core.activity.Bookshelves.get_recently_logged_books", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=ratings),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", side_effect=set),
+        ):
+            events = ActivityStream.public_feed(limit=10)
+
+        assert len(events) == 1
+        assert events[0].type == "shelf_change"
+        assert events[0].rating == 5
+
+
+class TestActivityStreamFollowingFeed:
+    def test_returns_nothing_when_following_nobody(self):
+        with patch("openlibrary.core.activity.PubSub.get_following", return_value=[]):
+            assert ActivityStream.following_feed("lonely") == []
+
+    def test_only_includes_followed_patrons(self):
+        following = [{"publisher": "ada"}, {"publisher": "bo"}]
+        shelves = [
+            shelf_row(username="ada", work_id=1, created=MAR),
+            shelf_row(username="stranger", work_id=2, created=FEB),
+        ]
+
+        with (
+            patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
+            patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+        ):
+            events = ActivityStream.following_feed("viewer", limit=10)
+
+        assert [e.username for e in events] == ["ada"]
+
+    def test_does_not_filter_followed_patrons_by_public_readlog(self):
+        # Following is consent enough -- a private reading log still reaches the
+        # people the patron chose to publish to.
+        following = [{"publisher": "ada"}]
+        shelves = [shelf_row(username="ada", work_id=1, created=MAR)]
+
+        with (
+            patch("openlibrary.core.activity.PubSub.get_following", return_value=following),
+            patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_lists", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._public_usernames", return_value=set()) as public_mock,
+        ):
+            events = ActivityStream.following_feed("viewer", limit=10)
+
+        assert [e.username for e in events] == ["ada"]
+        public_mock.assert_not_called()
+
+
+class TestListEvent:
+    def test_builds_from_a_list_thing(self):
+        event = ListEvent(
+            username="ada",
+            created=JAN,
+            list_key="/people/ada/lists/OL1L",
+            name="Books that rewired my brain",
+            book_count=4,
+            cover_ids=[1, 2, 3],
+        )
+        assert event.type == "list_update"
+        assert event.list_url == "/people/ada/lists/OL1L"

--- a/openlibrary/core/tests/test_activity.py
+++ b/openlibrary/core/tests/test_activity.py
@@ -265,3 +265,48 @@ class TestBalancedSample:
     def test_a_limit_larger_than_the_input_returns_everything(self):
         events = self._events()
         assert len(ActivityStream.balance(events, limit=100)) == len(events)
+
+
+class TestPopularFeed:
+    """Latest event only, from the readers the most people follow."""
+
+    def test_one_event_per_patron_ranked_by_followers(self):
+        most_followed = [{"publisher": "famous"}, {"publisher": "known"}]
+        shelves = [
+            shelf_row(username="famous", work_id=1, created=JAN),
+            shelf_row(username="famous", work_id=2, created=MAR),
+            shelf_row(username="known", work_id=3, created=FEB),
+        ]
+
+        with (
+            patch("openlibrary.core.activity.PubSub.most_followed", return_value=most_followed),
+            patch("openlibrary.core.activity.ActivityStream._shelf_rows_for", return_value=shelves),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
+        ):
+            events = ActivityStream.popular_feed(limit=10)
+
+        # One card each, most-followed first, and the newest of that patron's.
+        assert [e.username for e in events] == ["famous", "known"]
+        assert events[0].work_id == 2
+
+    def test_excludes_the_viewer(self):
+        with (
+            patch("openlibrary.core.activity.PubSub.most_followed", return_value=[{"publisher": "me"}, {"publisher": "other"}]),
+            patch(
+                "openlibrary.core.activity.ActivityStream._shelf_rows_for",
+                return_value=[
+                    shelf_row(username="me", work_id=1, created=MAR),
+                    shelf_row(username="other", work_id=2, created=FEB),
+                ],
+            ),
+            patch("openlibrary.core.activity.Ratings.get_recent_ratings", return_value=[]),
+            patch("openlibrary.core.activity.ActivityStream._recent_list_adds", return_value=[]),
+        ):
+            events = ActivityStream.popular_feed(viewer="me", limit=10)
+
+        assert [e.username for e in events] == ["other"]
+
+    def test_no_followed_accounts_yields_nothing(self):
+        with patch("openlibrary.core.activity.PubSub.most_followed", return_value=[]):
+            assert ActivityStream.popular_feed(limit=10) == []

--- a/openlibrary/fastapi/activity.py
+++ b/openlibrary/fastapi/activity.py
@@ -13,10 +13,11 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from openlibrary.core.activity import ActivityEvent, ActivityStream, ListEvent
+from openlibrary.core.activity import ActivityEvent, ActivityStream, LikeEvent, ListEvent
 from openlibrary.core.follows import PubSub
 from openlibrary.core.models import User
 from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
+from openlibrary.utils.request_context import site
 
 router = APIRouter()
 
@@ -100,6 +101,11 @@ def _serialise(event: ActivityEvent) -> FeedItem | None:
             book_count=event.book_count,
             cover_ids=event.cover_ids,
         )
+    elif isinstance(event, LikeEvent) and "/lists/" in event.liked_key:
+        # A liked list is not part of the recent-lists query, so resolve it here.
+        feed_list = _resolve_list(event.liked_key)
+        if feed_list is None:
+            return None
 
     return FeedItem(
         type=event.type,
@@ -120,7 +126,23 @@ def _label(event: ActivityEvent) -> str:
         return "updated a list"
     if event.type == "rating":
         return "rated"
+    if event.type == "like":
+        return "liked a list" if isinstance(event, LikeEvent) and "/lists/" in event.liked_key else "liked"
     return event.label
+
+
+def _resolve_list(key: str) -> FeedList | None:
+    """Look up a liked list so its card can show a name and covers."""
+    doc = site.get().get(key)
+    if not doc:
+        return None
+    showcase = ActivityStream._list_showcase(doc)
+    return FeedList(
+        key=key,
+        name=showcase["title"],
+        book_count=showcase["count"],
+        cover_ids=showcase["cover_ids"],
+    )
 
 
 def _avatar_url(username: str) -> str:

--- a/openlibrary/fastapi/activity.py
+++ b/openlibrary/fastapi/activity.py
@@ -13,11 +13,10 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from openlibrary.core.activity import ActivityEvent, ActivityStream, LikeEvent, ListEvent
+from openlibrary.core.activity import ActivityEvent, ActivityStream, ListAddEvent
 from openlibrary.core.follows import PubSub
 from openlibrary.core.models import User
 from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
-from openlibrary.utils.request_context import site
 
 router = APIRouter()
 
@@ -37,12 +36,13 @@ class FeedWork(BaseModel):
 
 
 class FeedList(BaseModel):
-    """The list a feed event is about."""
+    """The list a book was added to. Context on card three, not its subject."""
 
     key: str
     name: str
     book_count: int
     cover_ids: list[int]
+    like_count: int = 0
 
 
 class FeedItem(BaseModel):
@@ -94,18 +94,14 @@ def _serialise(event: ActivityEvent) -> FeedItem | None:
         )
 
     feed_list = None
-    if isinstance(event, ListEvent):
+    if isinstance(event, ListAddEvent):
         feed_list = FeedList(
             key=event.list_key,
             name=event.name,
             book_count=event.book_count,
             cover_ids=event.cover_ids,
+            like_count=event.like_count,
         )
-    elif isinstance(event, LikeEvent) and "/lists/" in event.liked_key:
-        # A liked list is not part of the recent-lists query, so resolve it here.
-        feed_list = _resolve_list(event.liked_key)
-        if feed_list is None:
-            return None
 
     return FeedItem(
         type=event.type,
@@ -122,27 +118,11 @@ def _serialise(event: ActivityEvent) -> FeedItem | None:
 
 
 def _label(event: ActivityEvent) -> str:
-    if event.type == "list_update":
-        return "updated a list"
+    if event.type == "list_add":
+        return "added a book to"
     if event.type == "rating":
         return "rated"
-    if event.type == "like":
-        return "liked a list" if isinstance(event, LikeEvent) and "/lists/" in event.liked_key else "liked"
     return event.label
-
-
-def _resolve_list(key: str) -> FeedList | None:
-    """Look up a liked list so its card can show a name and covers."""
-    doc = site.get().get(key)
-    if not doc:
-        return None
-    showcase = ActivityStream._list_showcase(doc)
-    return FeedList(
-        key=key,
-        name=showcase["title"],
-        book_count=showcase["count"],
-        cover_ids=showcase["cover_ids"],
-    )
 
 
 def _avatar_url(username: str) -> str:
@@ -163,22 +143,29 @@ async def activity_feed(
     limit: Annotated[int, Query(ge=1, le=50)] = 12,
     page: Annotated[int, Query(ge=1)] = 1,
     scope: Annotated[Scope, Query()] = "auto",
+    balanced: Annotated[bool, Query(description="Keep every card type represented rather than strict newest-first.")] = False,
 ) -> FeedResponse:
     viewer = user.username if user else None
     following = bool(viewer) and PubSub.is_following(viewer)
+
+    # Balancing can only pick a spread of card types out of a pool that has
+    # them. The stream truncates to whatever it is asked for, so ask for more.
+    fetch = limit * 5 if balanced else limit
 
     events: list[ActivityEvent] = []
     resolved: Literal["public", "following"] = "public"
 
     if scope != "public" and following and viewer:
-        events = ActivityStream.following_feed(viewer, limit=limit, page=page)
+        events = ActivityStream.following_feed(viewer, limit=fetch, page=page)
         resolved = "following"
 
     # Following someone quiet should not leave the patron staring at nothing --
     # fall back to the community feed rather than an empty page.
     if not events:
-        events = ActivityStream.public_feed(viewer=viewer, limit=limit, page=page)
+        events = ActivityStream.public_feed(viewer=viewer, limit=fetch, page=page)
         resolved = "public"
+
+    events = ActivityStream.balance(events, limit) if balanced else events[:limit]
 
     ActivityStream.attach_works(events)
 

--- a/openlibrary/fastapi/activity.py
+++ b/openlibrary/fastapi/activity.py
@@ -20,7 +20,7 @@ from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
 
 router = APIRouter()
 
-Scope = Literal["auto", "public", "following"]
+Scope = Literal["auto", "public", "following", "popular"]
 
 
 class FeedWork(BaseModel):
@@ -59,7 +59,7 @@ class FeedItem(BaseModel):
 
 
 class FeedResponse(BaseModel):
-    scope: Literal["public", "following"]
+    scope: Literal["public", "following", "popular"]
     following: bool
     page: int
     activity: list[FeedItem]
@@ -153,15 +153,20 @@ async def activity_feed(
     fetch = limit * 5 if balanced else limit
 
     events: list[ActivityEvent] = []
-    resolved: Literal["public", "following"] = "public"
+    resolved: Literal["public", "following", "popular"] = "public"
 
-    if scope != "public" and following and viewer:
+    if scope == "popular":
+        events = ActivityStream.popular_feed(viewer=viewer, limit=fetch, page=page)
+        resolved = "popular"
+    elif scope != "public" and following and viewer:
         events = ActivityStream.following_feed(viewer, limit=fetch, page=page)
         resolved = "following"
 
     # Following someone quiet should not leave the patron staring at nothing --
-    # fall back to the community feed rather than an empty page.
-    if not events:
+    # fall back to the community feed rather than an empty page. Popular is an
+    # explicit choice, so it is allowed to come back empty rather than silently
+    # showing something else.
+    if not events and scope != "popular":
         events = ActivityStream.public_feed(viewer=viewer, limit=fetch, page=page)
         resolved = "public"
 

--- a/openlibrary/fastapi/activity.py
+++ b/openlibrary/fastapi/activity.py
@@ -1,0 +1,164 @@
+"""FastAPI endpoint backing the social activity feed.
+
+Serves one JSON shape for every rendering of the feed -- the My Books section,
+the standalone feed page, and the design gallery all read from here, so a card
+looks the same wherever it appears and there is only one place to change what a
+feed event means.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from openlibrary.core.activity import ActivityEvent, ActivityStream, ListEvent
+from openlibrary.core.follows import PubSub
+from openlibrary.core.models import User
+from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
+
+router = APIRouter()
+
+Scope = Literal["auto", "public", "following"]
+
+
+class FeedWork(BaseModel):
+    """The book a feed event is about."""
+
+    key: str
+    title: str
+    author: str | None = None
+    author_key: str | None = None
+    cover_id: int | None = None
+    first_publish_year: int | None = None
+    ebook_access: str | None = None
+
+
+class FeedList(BaseModel):
+    """The list a feed event is about."""
+
+    key: str
+    name: str
+    book_count: int
+    cover_ids: list[int]
+
+
+class FeedItem(BaseModel):
+    type: str
+    username: str
+    patron_url: str
+    avatar_url: str
+    created: str
+    label: str
+    shelf_url: str | None = None
+    rating: int | None = None
+    work: FeedWork | None = None
+    list: FeedList | None = None
+
+
+class FeedResponse(BaseModel):
+    scope: Literal["public", "following"]
+    following: bool
+    page: int
+    activity: list[FeedItem]
+
+
+def _first(values, prefix: str = "") -> str | None:
+    """First entry of a Solr multi-value field, optionally path-prefixed."""
+    if not values:
+        return None
+    return f"{prefix}{values[0]}"
+
+
+def _serialise(event: ActivityEvent) -> FeedItem | None:
+    """Turn one activity event into its wire shape, or None if unrenderable."""
+    if event.created is None:
+        return None
+
+    work = None
+    if event.work_id is not None:
+        # An event whose work Solr has never heard of would render as a blank
+        # card, so it is dropped rather than shown empty.
+        if not event.work or not event.work.get("title"):
+            return None
+        work = FeedWork(
+            key=event.work.get("key") or event.work_key or "",
+            title=event.work["title"],
+            author=_first(event.work.get("author_name")),
+            author_key=_first(event.work.get("author_key"), prefix="/authors/"),
+            cover_id=event.work.get("cover_i"),
+            first_publish_year=event.work.get("first_publish_year"),
+            ebook_access=event.work.get("ebook_access"),
+        )
+
+    feed_list = None
+    if isinstance(event, ListEvent):
+        feed_list = FeedList(
+            key=event.list_key,
+            name=event.name,
+            book_count=event.book_count,
+            cover_ids=event.cover_ids,
+        )
+
+    return FeedItem(
+        type=event.type,
+        username=event.username,
+        patron_url=event.patron_url,
+        avatar_url=_avatar_url(event.username),
+        created=event.created.isoformat(),
+        label=_label(event),
+        shelf_url=event.shelf_url,
+        rating=event.rating,
+        work=work,
+        list=feed_list,
+    )
+
+
+def _label(event: ActivityEvent) -> str:
+    if event.type == "list_update":
+        return "updated a list"
+    if event.type == "rating":
+        return "rated"
+    return event.label
+
+
+def _avatar_url(username: str) -> str:
+    """Avatar for a patron, falling back to the local route if unresolvable."""
+    try:
+        return User.get_avatar_url(username)
+    except Exception:  # noqa: BLE001 - an unlinked account still gets a card, just a default face
+        return f"/people/{username}/avatar"
+
+
+@router.get(
+    "/api/internal/activity/feed.json",
+    response_model=FeedResponse,
+    description="Recent community or personalised book activity, for the social activity feed.",
+)
+async def activity_feed(
+    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 12,
+    page: Annotated[int, Query(ge=1)] = 1,
+    scope: Annotated[Scope, Query()] = "auto",
+) -> FeedResponse:
+    viewer = user.username if user else None
+    following = bool(viewer) and PubSub.is_following(viewer)
+
+    events: list[ActivityEvent] = []
+    resolved: Literal["public", "following"] = "public"
+
+    if scope != "public" and following and viewer:
+        events = ActivityStream.following_feed(viewer, limit=limit, page=page)
+        resolved = "following"
+
+    # Following someone quiet should not leave the patron staring at nothing --
+    # fall back to the community feed rather than an empty page.
+    if not events:
+        events = ActivityStream.public_feed(viewer=viewer, limit=limit, page=page)
+        resolved = "public"
+
+    ActivityStream.attach_works(events)
+
+    activity = [item for event in events if (item := _serialise(event))]
+    return FeedResponse(scope=resolved, following=following, page=page, activity=activity)

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -126,6 +126,11 @@ class activity_feed_gallery(delegate.page):
         {"id": 8, "name": "Ticker", "blurb": "One compact line each. Sized to sit under a heading as a teaser strip."},
         {"id": 9, "name": "Editorial", "blurb": "Uppercase eyebrow, large type, almost no chrome. Actions on hover."},
         {"id": 10, "name": "People first", "blurb": "Grouped by patron: who they are, then a strip of what they touched."},
+        {
+            "id": 11,
+            "name": "Showcase row",
+            "blurb": "Three cards across on desktop, stacked on mobile. Refresh the whole row; swipe or press next for older activity.",
+        },
     )
 
     DEFAULT_API = "/api/internal/activity/feed.json"

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 
 import web
 
@@ -135,11 +136,34 @@ class activity_feed_gallery(delegate.page):
         scope = i.scope if i.scope in ("auto", "public", "following") else "auto"
         user = accounts.get_current_user()
         viewer = user.key.split("/")[-1] if user else ""
-        # In production nginx routes /api/internal to the FastAPI process, but a
-        # local dev stack has no proxy between the two servers -- so the origin
-        # is overridable, e.g. ?api=http://localhost:18080/api/internal/activity/feed.json
-        api = i.api if i.api and i.api.startswith(("/", "http://localhost:", "http://127.0.0.1:")) else self.DEFAULT_API
-        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, api)
+        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, self._api_url(i.api))
+
+    @classmethod
+    def _api_url(cls, requested: str | None) -> str:
+        """Resolve the feed endpoint the gallery should fetch from.
+
+        In production nginx routes /api/internal to the FastAPI process, but a
+        local dev stack has no proxy between the two servers -- so the origin is
+        overridable, e.g. ?api=http://localhost:18080/api/internal/activity/feed.json
+
+        Only a same-host origin is accepted. That covers localhost, 127.0.0.1,
+        and the machine's LAN address (so the gallery can be opened from a phone
+        or another desk) without letting the parameter point the page's fetch at
+        an arbitrary server.
+        """
+        if not requested:
+            return cls.DEFAULT_API
+        # `//host/path` is protocol-relative, not a path -- it points at another
+        # origin despite starting with a slash.
+        if requested.startswith("/") and not requested.startswith("//"):
+            return requested
+
+        parsed = urlparse(requested)
+        if parsed.scheme not in ("http", "https") or not parsed.path.startswith("/api/"):
+            return cls.DEFAULT_API
+        if parsed.hostname != urlparse(f"//{web.ctx.host}").hostname:
+            return cls.DEFAULT_API
+        return requested
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -2,8 +2,11 @@ import json
 import logging
 from pathlib import Path
 
+import web
+
 from infogami.utils import delegate
-from infogami.utils.view import render_template
+from infogami.utils.view import render_template, safeint
+from openlibrary import accounts
 
 logger = logging.getLogger("openlibrary.design")
 
@@ -98,6 +101,45 @@ class home(delegate.page):
 
     def GET(self):
         return render_template("design", load_components())
+
+
+class activity_feed_gallery(delegate.page):
+    """Side-by-side gallery of the activity feed's layout treatments.
+
+    Temporary scaffolding for #10242 -- it exists so a design direction can be
+    chosen from real, populated feed data rather than from mockups. It goes away
+    with the nine unchosen variants once that decision is made.
+    """
+
+    path = "/developers/design/activity-feed"
+
+    # Kept in step with FEED_VARIANTS in openlibrary/components/lit/OlSocialFeed.js.
+    VARIANTS = (
+        {"id": 1, "name": "Spec card", "blurb": "The reviewed design: patron and follow above the rule, book and actions below. Three up on desktop."},
+        {"id": 2, "name": "Goodreads river", "blurb": "Full-width rows, one continuous sentence, generous cover, text actions."},
+        {"id": 3, "name": "Cover tiles", "blurb": "The cover is the card. Caption strip overlays the bottom. Scrolls horizontally."},
+        {"id": 4, "name": "Dense timeline", "blurb": "A rail of small avatars down the left. Maximum events per screen."},
+        {"id": 5, "name": "Social thread", "blurb": "Bluesky shape: avatar column, prose, and the book as an embedded quote card."},
+        {"id": 6, "name": "Magazine", "blurb": "Two-column masonry, big covers, serif titles, lots of air."},
+        {"id": 7, "name": "Conversation", "blurb": "Activity as messages. Reads as live chatter rather than a log."},
+        {"id": 8, "name": "Ticker", "blurb": "One compact line each. Sized to sit under a heading as a teaser strip."},
+        {"id": 9, "name": "Editorial", "blurb": "Uppercase eyebrow, large type, almost no chrome. Actions on hover."},
+        {"id": 10, "name": "People first", "blurb": "Grouped by patron: who they are, then a strip of what they touched."},
+    )
+
+    DEFAULT_API = "/api/internal/activity/feed.json"
+
+    def GET(self):
+        i = web.input(design=None, scope="auto", api=None)
+        selected = safeint(i.design, 0)
+        scope = i.scope if i.scope in ("auto", "public", "following") else "auto"
+        user = accounts.get_current_user()
+        viewer = user.key.split("/")[-1] if user else ""
+        # In production nginx routes /api/internal to the FastAPI process, but a
+        # local dev stack has no proxy between the two servers -- so the origin
+        # is overridable, e.g. ?api=http://localhost:18080/api/internal/activity/feed.json
+        api = i.api if i.api and i.api.startswith(("/", "http://localhost:", "http://127.0.0.1:")) else self.DEFAULT_API
+        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, api)
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import web
 
@@ -136,7 +136,19 @@ class activity_feed_gallery(delegate.page):
         scope = i.scope if i.scope in ("auto", "public", "following") else "auto"
         user = accounts.get_current_user()
         viewer = user.key.split("/")[-1] if user else ""
-        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, self._api_url(i.api))
+        api = self._api_url(i.api)
+        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, api, self._api_param(api))
+
+    @classmethod
+    def _api_param(cls, api: str) -> str:
+        """The endpoint override as a query fragment, for links on the page.
+
+        Without this the nav chips drop the override and every variant renders
+        empty with nothing on screen to explain why.
+        """
+        if api == cls.DEFAULT_API:
+            return ""
+        return "&api=" + quote(api, safe="")
 
     @classmethod
     def _api_url(cls, requested: str | None) -> str:

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -115,6 +115,8 @@ class activity_feed_gallery(delegate.page):
     path = "/developers/design/activity-feed"
 
     # Kept in step with FEED_VARIANTS in openlibrary/components/lit/OlSocialFeed.js.
+    # `attrs` switches on the component chrome a treatment needs; `limit`
+    # overrides the page size where three cards would be too few.
     VARIANTS = (
         {"id": 1, "name": "Spec card", "blurb": "The reviewed design: patron and follow above the rule, book and actions below. Three up on desktop."},
         {"id": 2, "name": "Goodreads river", "blurb": "Full-width rows, one continuous sentence, generous cover, text actions."},
@@ -130,6 +132,16 @@ class activity_feed_gallery(delegate.page):
             "id": 11,
             "name": "Showcase row",
             "blurb": "Three cards across on desktop, stacked on mobile. Refresh the whole row; swipe or press next for older activity.",
+            "attrs": "controls",
+        },
+        {
+            "id": 12,
+            "name": "Discover / Following / Popular",
+            "blurb": (
+                "Bluesky shape: tabs over one scrolling column that loads more as you reach the end. Popular shows one card each from the most-followed readers."
+            ),
+            "attrs": "tabs infinite",
+            "limit": 8,
         },
     )
 
@@ -137,12 +149,13 @@ class activity_feed_gallery(delegate.page):
 
     def GET(self):
         i = web.input(design=None, scope="auto", api=None)
+        variants = [{"attrs": "", "limit": 3, **v} for v in self.VARIANTS]
         selected = safeint(i.design, 0)
-        scope = i.scope if i.scope in ("auto", "public", "following") else "auto"
+        scope = i.scope if i.scope in ("auto", "public", "following", "popular") else "auto"
         user = accounts.get_current_user()
         viewer = user.key.split("/")[-1] if user else ""
         api = self._api_url(i.api)
-        return render_template("design/activity_feed", list(self.VARIANTS), selected, scope, viewer, api, self._api_param(api))
+        return render_template("design/activity_feed", variants, selected, scope, viewer, api, self._api_param(api))
 
     @classmethod
     def _api_param(cls, api: str) -> str:

--- a/openlibrary/plugins/openlibrary/tests/test_design.py
+++ b/openlibrary/plugins/openlibrary/tests/test_design.py
@@ -1,6 +1,7 @@
 """Tests for the developer design pages."""
 
 from unittest.mock import patch
+from urllib.parse import unquote
 
 import pytest
 import web
@@ -71,6 +72,21 @@ class TestGalleryApiUrl:
         assert activity_feed_gallery._api_url("http://localhost:8080/account/login") == DEFAULT
 
 
+class TestGalleryApiParam:
+    """Links on the page must carry the override, or navigating empties the feed."""
+
+    def test_the_default_endpoint_needs_no_carrying(self):
+        assert activity_feed_gallery._api_param(DEFAULT) == ""
+
+    def test_an_override_is_carried_url_encoded(self):
+        api = "http://192.168.1.223:18087/api/internal/activity/feed.json"
+        param = activity_feed_gallery._api_param(api)
+        assert param.startswith("&api=")
+        # Unencoded, the :// and / would break out of the query parameter.
+        assert "://" not in param
+        assert unquote(param.removeprefix("&api=")) == api
+
+
 class TestGalleryVariants:
     def test_variant_ids_are_contiguous_and_match_the_component(self):
         ids = [v["id"] for v in activity_feed_gallery.VARIANTS]
@@ -87,8 +103,8 @@ class TestGalleryGet:
         host("localhost:8080")
         captured = {}
 
-        def fake_render(_template, variants, selected, scope, viewer, api):
-            captured.update(selected=selected, scope=scope, viewer=viewer, api=api)
+        def fake_render(_template, variants, selected, scope, viewer, api, api_param):
+            captured.update(selected=selected, scope=scope, viewer=viewer, api=api, api_param=api_param)
             return ""
 
         with (
@@ -102,3 +118,4 @@ class TestGalleryGet:
         assert captured["selected"] == 3
         assert captured["viewer"] == ""
         assert captured["api"] == DEFAULT
+        assert captured["api_param"] == ""

--- a/openlibrary/plugins/openlibrary/tests/test_design.py
+++ b/openlibrary/plugins/openlibrary/tests/test_design.py
@@ -1,0 +1,104 @@
+"""Tests for the developer design pages."""
+
+from unittest.mock import patch
+
+import pytest
+import web
+
+from openlibrary.plugins.openlibrary.design import activity_feed_gallery
+
+DEFAULT = activity_feed_gallery.DEFAULT_API
+
+
+@pytest.fixture
+def host():
+    """Pretend the gallery was served from a given host.
+
+    The original is captured before the test runs, not after -- restoring a
+    value the test itself set would leak between tests.
+    """
+    original = getattr(web.ctx, "host", None) or "localhost:8080"
+
+    def _set(value):
+        web.ctx.host = value
+
+    yield _set
+    web.ctx.host = original
+
+
+class TestGalleryApiUrl:
+    """The gallery's fetch origin is overridable because a local dev stack has no
+    proxy from web.py to FastAPI -- but only to the same machine."""
+
+    def test_no_override_uses_the_default_path(self, host):
+        host("localhost:8080")
+        assert activity_feed_gallery._api_url(None) == DEFAULT
+        assert activity_feed_gallery._api_url("") == DEFAULT
+
+    def test_relative_paths_pass_through(self, host):
+        host("localhost:8080")
+        assert activity_feed_gallery._api_url("/api/internal/activity/feed.json") == "/api/internal/activity/feed.json"
+
+    @pytest.mark.parametrize(
+        ("served_from", "requested"),
+        [
+            ("localhost:8080", "http://localhost:18080/api/internal/activity/feed.json"),
+            ("127.0.0.1:8087", "http://127.0.0.1:18087/api/internal/activity/feed.json"),
+            # Opening the gallery from a phone on the same network is the point.
+            ("192.168.1.223:8087", "http://192.168.1.223:18087/api/internal/activity/feed.json"),
+        ],
+    )
+    def test_same_host_on_another_port_is_allowed(self, host, served_from, requested):
+        host(served_from)
+        assert activity_feed_gallery._api_url(requested) == requested
+
+    @pytest.mark.parametrize(
+        "requested",
+        [
+            "http://evil.example.com/api/internal/activity/feed.json",
+            "//evil.example.com/api/internal/activity/feed.json",
+            "javascript:alert(1)",
+            "http://localhost.evil.example.com:18080/api/internal/activity/feed.json",
+        ],
+    )
+    def test_another_host_falls_back_to_the_default(self, host, requested):
+        host("localhost:8080")
+        assert activity_feed_gallery._api_url(requested) == DEFAULT
+
+    def test_a_same_host_url_outside_the_api_falls_back(self, host):
+        # The parameter drives a fetch, so keep it pointed at the API surface.
+        host("localhost:8080")
+        assert activity_feed_gallery._api_url("http://localhost:8080/account/login") == DEFAULT
+
+
+class TestGalleryVariants:
+    def test_variant_ids_are_contiguous_and_match_the_component(self):
+        ids = [v["id"] for v in activity_feed_gallery.VARIANTS]
+        assert ids == list(range(1, 11))
+
+    def test_every_variant_is_described(self):
+        for variant in activity_feed_gallery.VARIANTS:
+            assert variant["name"]
+            assert variant["blurb"]
+
+
+class TestGalleryGet:
+    def test_clamps_an_unknown_scope(self, host):
+        host("localhost:8080")
+        captured = {}
+
+        def fake_render(_template, variants, selected, scope, viewer, api):
+            captured.update(selected=selected, scope=scope, viewer=viewer, api=api)
+            return ""
+
+        with (
+            patch("openlibrary.plugins.openlibrary.design.render_template", side_effect=fake_render),
+            patch("openlibrary.plugins.openlibrary.design.accounts.get_current_user", return_value=None),
+            patch("openlibrary.plugins.openlibrary.design.web.input", return_value=web.storage(design="3", scope="bogus", api=None)),
+        ):
+            activity_feed_gallery().GET()
+
+        assert captured["scope"] == "auto"
+        assert captured["selected"] == 3
+        assert captured["viewer"] == ""
+        assert captured["api"] == DEFAULT

--- a/openlibrary/plugins/openlibrary/tests/test_design.py
+++ b/openlibrary/plugins/openlibrary/tests/test_design.py
@@ -90,7 +90,7 @@ class TestGalleryApiParam:
 class TestGalleryVariants:
     def test_variant_ids_are_contiguous_and_match_the_component(self):
         ids = [v["id"] for v in activity_feed_gallery.VARIANTS]
-        assert ids == list(range(1, 11))
+        assert ids == list(range(1, 12))
 
     def test_every_variant_is_described(self):
         for variant in activity_feed_gallery.VARIANTS:

--- a/openlibrary/plugins/openlibrary/tests/test_design.py
+++ b/openlibrary/plugins/openlibrary/tests/test_design.py
@@ -90,7 +90,7 @@ class TestGalleryApiParam:
 class TestGalleryVariants:
     def test_variant_ids_are_contiguous_and_match_the_component(self):
         ids = [v["id"] for v in activity_feed_gallery.VARIANTS]
-        assert ids == list(range(1, 12))
+        assert ids == list(range(1, 13))
 
     def test_every_variant_is_described(self):
         for variant in activity_feed_gallery.VARIANTS:

--- a/openlibrary/templates/design/activity_feed.html
+++ b/openlibrary/templates/design/activity_feed.html
@@ -69,7 +69,7 @@ $var title: Activity Feed Designs
   </nav>
 
   <nav class="feed-gallery__nav" aria-label="Feed scope">
-    $for s in ['auto', 'public', 'following']:
+    $for s in ['auto', 'public', 'following', 'popular']:
       $ suffix = ('&design=%d' % selected) if selected else ''
       <a class="feed-gallery__chip $('is-current' if scope == s else '')"
          href="?scope=$s$suffix$api_param">scope: $s</a>
@@ -84,7 +84,7 @@ $var title: Activity Feed Designs
           <a class="feed-gallery__permalink" href="?design=$v['id']&amp;scope=$scope$api_param">View alone &rsaquo;</a>
         </header>
         <div class="feed-gallery__stage">
-          <ol-social-feed variant="$v['id']" scope="$scope" limit="3" balanced controls refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>
+          <ol-social-feed variant="$v['id']" scope="$scope" limit="$v['limit']" balanced $:v['attrs'] refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>
         </div>
       </section>
 </div>

--- a/openlibrary/templates/design/activity_feed.html
+++ b/openlibrary/templates/design/activity_feed.html
@@ -50,19 +50,19 @@ $var title: Activity Feed Designs
   <header class="feed-gallery__intro">
     <h1>Activity feed &mdash; design gallery</h1>
     <p>
-      Ten layout treatments for the My Books social activity feed, all rendered from the
+      Every layout treatment for the My Books social activity feed, all rendered from the
       same live <code>/api/internal/activity/feed.json</code> response. Same books, same
       patrons, same timestamps &mdash; only the presentation differs.
     </p>
     <p class="feed-gallery__note">
       Narrow the browser to see each one at a mobile width. Development scaffolding for
       <a href="https://github.com/internetarchive/openlibrary/issues/10242">issue #10242</a>;
-      nine of these get deleted once a direction is picked.
+      all but the chosen one get deleted once a direction is picked.
     </p>
   </header>
 
   <nav class="feed-gallery__nav" aria-label="Design variants">
-    <a class="feed-gallery__chip $('is-current' if not selected else '')" href="?scope=$scope$api_param">All ten</a>
+    <a class="feed-gallery__chip $('is-current' if not selected else '')" href="?scope=$scope$api_param">All variants</a>
     $for v in variants:
       <a class="feed-gallery__chip $('is-current' if selected == v['id'] else '')"
          href="?design=$v['id']&amp;scope=$scope$api_param">$v['id']. $v['name']</a>
@@ -84,7 +84,7 @@ $var title: Activity Feed Designs
           <a class="feed-gallery__permalink" href="?design=$v['id']&amp;scope=$scope$api_param">View alone &rsaquo;</a>
         </header>
         <div class="feed-gallery__stage">
-          <ol-social-feed variant="$v['id']" scope="$scope" limit="9" refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>
+          <ol-social-feed variant="$v['id']" scope="$scope" limit="3" balanced controls refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>
         </div>
       </section>
 </div>

--- a/openlibrary/templates/design/activity_feed.html
+++ b/openlibrary/templates/design/activity_feed.html
@@ -1,0 +1,88 @@
+$def with (variants, selected, scope, viewer, api)
+
+$# Design gallery for the social activity feed (#10242).
+$#
+$# Renders every layout treatment off the same live feed response so they can be
+$# compared honestly. Temporary scaffolding: once a direction is chosen, this
+$# page and the nine unchosen variants go away. Styles are inline for the same
+$# reason -- nothing here should outlive the design decision.
+$#
+$# * variants (list)  -- dicts of id, slug, name, blurb
+$# * selected (int)   -- variant to show alone, or 0 for all of them
+$# * scope (string)   -- feed scope to request: auto, public, or following
+$# * viewer (string)  -- logged-in username, for follow state
+$# * api (string)     -- feed endpoint; overridable for dev stacks with no proxy
+
+$var title: Activity Feed Designs
+
+<style>
+.feed-gallery { max-width: 1100px; margin: 0 auto; padding: 24px 16px 80px; }
+.feed-gallery__intro h1 { margin: 0 0 8px; }
+.feed-gallery__intro p { max-width: 68ch; margin: 0 0 8px; }
+.feed-gallery__note { font-size: .875rem; color: var(--grey); }
+.feed-gallery__nav { display: flex; flex-wrap: wrap; gap: 6px; margin: 16px 0; }
+.feed-gallery__chip {
+  border: var(--border-width-thin) solid var(--grey-e7e7e7);
+  border-radius: var(--border-radius-pill);
+  padding: 4px 12px;
+  font-size: .8rem;
+  text-decoration: none;
+  color: inherit;
+  background: var(--white);
+}
+.feed-gallery__chip:hover { border-color: var(--primary-blue); }
+.feed-gallery__chip.is-current {
+  background: var(--primary-blue);
+  border-color: var(--primary-blue);
+  color: var(--white);
+}
+.feed-gallery__variant { margin: 40px 0; border-top: var(--border-width-thin) solid var(--grey-e7e7e7); padding-top: 20px; }
+.feed-gallery__head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 12px; margin-bottom: 16px; }
+.feed-gallery__head h2 { margin: 0; font-size: 1.1rem; }
+.feed-gallery__head p { margin: 0; flex: 1; min-width: 240px; color: var(--grey); font-size: .85rem; }
+.feed-gallery__permalink { font-size: .8rem; white-space: nowrap; }
+.feed-gallery__stage { background: var(--white); border-radius: var(--border-radius-card); padding: 16px; }
+</style>
+
+<div id="contentBody" class="feed-gallery">
+  <header class="feed-gallery__intro">
+    <h1>Activity feed &mdash; design gallery</h1>
+    <p>
+      Ten layout treatments for the My Books social activity feed, all rendered from the
+      same live <code>/api/internal/activity/feed.json</code> response. Same books, same
+      patrons, same timestamps &mdash; only the presentation differs.
+    </p>
+    <p class="feed-gallery__note">
+      Narrow the browser to see each one at a mobile width. Development scaffolding for
+      <a href="https://github.com/internetarchive/openlibrary/issues/10242">issue #10242</a>;
+      nine of these get deleted once a direction is picked.
+    </p>
+  </header>
+
+  <nav class="feed-gallery__nav" aria-label="Design variants">
+    <a class="feed-gallery__chip $('is-current' if not selected else '')" href="?scope=$scope">All ten</a>
+    $for v in variants:
+      <a class="feed-gallery__chip $('is-current' if selected == v['id'] else '')"
+         href="?design=$v['id']&amp;scope=$scope">$v['id']. $v['name']</a>
+  </nav>
+
+  <nav class="feed-gallery__nav" aria-label="Feed scope">
+    $for s in ['auto', 'public', 'following']:
+      $ suffix = ('&design=%d' % selected) if selected else ''
+      <a class="feed-gallery__chip $('is-current' if scope == s else '')"
+         href="?scope=$s$suffix">scope: $s</a>
+  </nav>
+
+  $for v in variants:
+    $if not selected or selected == v['id']:
+      <section class="feed-gallery__variant" id="design-$v['id']">
+        <header class="feed-gallery__head">
+          <h2>$v['id']. $v['name']</h2>
+          <p>$v['blurb']</p>
+          <a class="feed-gallery__permalink" href="?design=$v['id']&amp;scope=$scope">View alone &rsaquo;</a>
+        </header>
+        <div class="feed-gallery__stage">
+          <ol-social-feed variant="$v['id']" scope="$scope" limit="9" refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>
+        </div>
+      </section>
+</div>

--- a/openlibrary/templates/design/activity_feed.html
+++ b/openlibrary/templates/design/activity_feed.html
@@ -1,4 +1,4 @@
-$def with (variants, selected, scope, viewer, api)
+$def with (variants, selected, scope, viewer, api, api_param)
 
 $# Design gallery for the social activity feed (#10242).
 $#
@@ -11,7 +11,9 @@ $# * variants (list)  -- dicts of id, slug, name, blurb
 $# * selected (int)   -- variant to show alone, or 0 for all of them
 $# * scope (string)   -- feed scope to request: auto, public, or following
 $# * viewer (string)  -- logged-in username, for follow state
-$# * api (string)     -- feed endpoint; overridable for dev stacks with no proxy
+$# * api (string)       -- feed endpoint; overridable for dev stacks with no proxy
+$# * api_param (string) -- the same override as a query fragment, so navigating
+$#                         between variants does not drop it and empty the feed
 
 $var title: Activity Feed Designs
 
@@ -60,17 +62,17 @@ $var title: Activity Feed Designs
   </header>
 
   <nav class="feed-gallery__nav" aria-label="Design variants">
-    <a class="feed-gallery__chip $('is-current' if not selected else '')" href="?scope=$scope">All ten</a>
+    <a class="feed-gallery__chip $('is-current' if not selected else '')" href="?scope=$scope$api_param">All ten</a>
     $for v in variants:
       <a class="feed-gallery__chip $('is-current' if selected == v['id'] else '')"
-         href="?design=$v['id']&amp;scope=$scope">$v['id']. $v['name']</a>
+         href="?design=$v['id']&amp;scope=$scope$api_param">$v['id']. $v['name']</a>
   </nav>
 
   <nav class="feed-gallery__nav" aria-label="Feed scope">
     $for s in ['auto', 'public', 'following']:
       $ suffix = ('&design=%d' % selected) if selected else ''
       <a class="feed-gallery__chip $('is-current' if scope == s else '')"
-         href="?scope=$s$suffix">scope: $s</a>
+         href="?scope=$s$suffix$api_param">scope: $s</a>
   </nav>
 
   $for v in variants:
@@ -79,7 +81,7 @@ $var title: Activity Feed Designs
         <header class="feed-gallery__head">
           <h2>$v['id']. $v['name']</h2>
           <p>$v['blurb']</p>
-          <a class="feed-gallery__permalink" href="?design=$v['id']&amp;scope=$scope">View alone &rsaquo;</a>
+          <a class="feed-gallery__permalink" href="?design=$v['id']&amp;scope=$scope$api_param">View alone &rsaquo;</a>
         </header>
         <div class="feed-gallery__stage">
           <ol-social-feed variant="$v['id']" scope="$scope" limit="9" refresh-interval="0" api-url="$api" viewer-username="$viewer"></ol-social-feed>

--- a/openlibrary/tests/fastapi/test_activity_feed.py
+++ b/openlibrary/tests/fastapi/test_activity_feed.py
@@ -1,0 +1,176 @@
+"""Tests for the social activity feed endpoint."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from openlibrary.core.activity import ListEvent, RatingEvent, ShelfEvent
+
+JAN = datetime(2026, 1, 10, 12, 0, 0)
+
+
+def shelf_event(username="ada", work_id=59800, shelf_id=1, rating=None):
+    event = ShelfEvent(
+        username=username,
+        created=JAN,
+        work_id=work_id,
+        work_key=f"/works/OL{work_id}W",
+        shelf_id=shelf_id,
+        rating=rating,
+    )
+    event.work = {
+        "key": f"/works/OL{work_id}W",
+        "title": "The Left Hand of Darkness",
+        "author_name": ["Ursula K. Le Guin"],
+        "author_key": ["OL31353A"],
+        "cover_i": 10618463,
+        "first_publish_year": 1969,
+        "ebook_access": "borrowable",
+    }
+    return event
+
+
+@pytest.fixture
+def mock_avatar():
+    with patch("openlibrary.fastapi.activity.User.get_avatar_url", return_value="https://archive.org/services/img/@ada"):
+        yield
+
+
+class TestActivityFeedEndpoint:
+    def test_returns_normalised_shelf_events(self, fastapi_client, mock_avatar):
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event()]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["scope"] == "public"
+        assert body["following"] is False
+        (item,) = body["activity"]
+        assert item["type"] == "shelf_change"
+        assert item["username"] == "ada"
+        assert item["label"] == "added to Want to Read"
+        assert item["shelf_url"] == "/people/ada/books/want-to-read"
+        assert item["work"]["title"] == "The Left Hand of Darkness"
+        assert item["work"]["cover_id"] == 10618463
+        assert item["work"]["author"] == "Ursula K. Le Guin"
+        assert item["work"]["author_key"] == "/authors/OL31353A"
+
+    def test_rating_rides_along_on_a_shelf_event(self, fastapi_client, mock_avatar):
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event(shelf_id=3, rating=5)]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        (item,) = response.json()["activity"]
+        assert item["rating"] == 5
+        assert item["label"] == "finished reading"
+
+    def test_drops_events_whose_work_is_missing_from_solr(self, fastapi_client, mock_avatar):
+        # A work that Solr has no record of would render as a blank card.
+        orphan = shelf_event()
+        orphan.work = None
+
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[orphan]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        assert response.json()["activity"] == []
+
+    def test_serialises_list_events(self, fastapi_client, mock_avatar):
+        event = ListEvent(
+            username="ada",
+            created=JAN,
+            list_key="/people/ada/lists/OL1L",
+            name="Books that rewired my brain",
+            book_count=4,
+            cover_ids=[1, 2, 3],
+        )
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[event]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        (item,) = response.json()["activity"]
+        assert item["type"] == "list_update"
+        assert item["list"]["name"] == "Books that rewired my brain"
+        assert item["list"]["book_count"] == 4
+        assert item["list"]["cover_ids"] == [1, 2, 3]
+        assert item["work"] is None
+
+    def test_rating_only_event_serialises_without_a_shelf(self, fastapi_client, mock_avatar):
+        event = RatingEvent(username="ada", created=JAN, work_id=1, work_key="/works/OL1W", rating=4)
+        event.work = {"key": "/works/OL1W", "title": "Trust", "author_name": [], "cover_i": None}
+
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[event]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        (item,) = response.json()["activity"]
+        assert item["type"] == "rating"
+        assert item["shelf_url"] is None
+        assert item["work"]["author"] is None
+
+    def test_authenticated_follower_gets_the_following_feed(self, fastapi_client, mock_optional_authenticated_user, mock_avatar):
+        with (
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=True),
+            patch("openlibrary.fastapi.activity.ActivityStream.following_feed", return_value=[shelf_event()]) as following_mock,
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed") as public_mock,
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        assert response.json()["scope"] == "following"
+        following_mock.assert_called_once()
+        public_mock.assert_not_called()
+
+    def test_scope_can_be_forced_to_public(self, fastapi_client, mock_optional_authenticated_user, mock_avatar):
+        # The design gallery needs to show the public feed regardless of who is
+        # logged in, so scope is overridable.
+        with (
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=True),
+            patch("openlibrary.fastapi.activity.ActivityStream.following_feed") as following_mock,
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[]) as public_mock,
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json?scope=public")
+
+        assert response.json()["scope"] == "public"
+        public_mock.assert_called_once()
+        following_mock.assert_not_called()
+
+    def test_following_feed_falls_back_to_public_when_it_is_empty(self, fastapi_client, mock_optional_authenticated_user, mock_avatar):
+        # Following someone who has not logged anything recently should not
+        # produce a dead page.
+        with (
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=True),
+            patch("openlibrary.fastapi.activity.ActivityStream.following_feed", return_value=[]),
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event()]) as public_mock,
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        body = response.json()
+        assert body["scope"] == "public"
+        assert body["following"] is True
+        assert len(body["activity"]) == 1
+        public_mock.assert_called_once()
+
+    @pytest.mark.parametrize("limit", [0, 51])
+    def test_rejects_out_of_range_limits(self, fastapi_client, limit):
+        response = fastapi_client.get(f"/api/internal/activity/feed.json?limit={limit}")
+        assert response.status_code == 422

--- a/openlibrary/tests/fastapi/test_activity_feed.py
+++ b/openlibrary/tests/fastapi/test_activity_feed.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from openlibrary.core.activity import ListEvent, RatingEvent, ShelfEvent
+from openlibrary.core.activity import LikeEvent, ListEvent, RatingEvent, ShelfEvent
+from openlibrary.fastapi.activity import FeedList
 
 JAN = datetime(2026, 1, 10, 12, 0, 0)
 
@@ -174,3 +175,37 @@ class TestActivityFeedEndpoint:
     def test_rejects_out_of_range_limits(self, fastapi_client, limit):
         response = fastapi_client.get(f"/api/internal/activity/feed.json?limit={limit}")
         assert response.status_code == 422
+
+
+class TestLikeEvents:
+    """`likes` landed on master 2026-07-31, so list upvotes are now a real event."""
+
+    def _liked_list_event(self, key="/people/bo/lists/OL1L"):
+        return LikeEvent(username="ada", created=JAN, liked_key=key)
+
+    def test_a_liked_list_serialises_as_a_list_card(self, fastapi_client, mock_avatar):
+        feed_list = FeedList(key="/people/bo/lists/OL1L", name="Slow reads", book_count=5, cover_ids=[1, 2])
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[self._liked_list_event()]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity._resolve_list", return_value=feed_list),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        (item,) = response.json()["activity"]
+        assert item["type"] == "like"
+        assert item["label"] == "liked a list"
+        assert item["list"]["name"] == "Slow reads"
+
+    def test_a_like_on_a_vanished_list_is_dropped(self, fastapi_client, mock_avatar):
+        # `likes.key` has no foreign key, so the target can simply be gone.
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[self._liked_list_event()]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity._resolve_list", return_value=None),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json")
+
+        assert response.json()["activity"] == []

--- a/openlibrary/tests/fastapi/test_activity_feed.py
+++ b/openlibrary/tests/fastapi/test_activity_feed.py
@@ -5,8 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from openlibrary.core.activity import LikeEvent, ListEvent, RatingEvent, ShelfEvent
-from openlibrary.fastapi.activity import FeedList
+from openlibrary.core.activity import ListAddEvent, RatingEvent, ShelfEvent
 
 JAN = datetime(2026, 1, 10, 12, 0, 0)
 
@@ -61,17 +60,22 @@ class TestActivityFeedEndpoint:
         assert item["work"]["author"] == "Ursula K. Le Guin"
         assert item["work"]["author_key"] == "/authors/OL31353A"
 
-    def test_rating_rides_along_on_a_shelf_event(self, fastapi_client, mock_avatar):
+    def test_a_rating_is_its_own_card(self, fastapi_client, mock_avatar):
+        event = RatingEvent(username="ada", created=JAN, work_id=59800, work_key="/works/OL59800W", rating=5)
+        event.work = {"key": "/works/OL59800W", "title": "Beloved", "author_name": ["Toni Morrison"], "cover_i": 1}
+
         with (
-            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event(shelf_id=3, rating=5)]),
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[event]),
             patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
             patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
         ):
             response = fastapi_client.get("/api/internal/activity/feed.json")
 
         (item,) = response.json()["activity"]
+        assert item["type"] == "rating"
         assert item["rating"] == 5
-        assert item["label"] == "finished reading"
+        assert item["label"] == "rated"
+        assert item["shelf_url"] is None
 
     def test_drops_events_whose_work_is_missing_from_solr(self, fastapi_client, mock_avatar):
         # A work that Solr has no record of would render as a blank card.
@@ -87,15 +91,25 @@ class TestActivityFeedEndpoint:
 
         assert response.json()["activity"] == []
 
-    def test_serialises_list_events(self, fastapi_client, mock_avatar):
-        event = ListEvent(
+    def test_a_list_add_carries_both_the_book_and_the_list(self, fastapi_client, mock_avatar):
+        # Card three: the book is the subject, the list is context.
+        event = ListAddEvent(
             username="ada",
             created=JAN,
+            work_id=59800,
+            work_key="/works/OL59800W",
             list_key="/people/ada/lists/OL1L",
             name="Books that rewired my brain",
             book_count=4,
             cover_ids=[1, 2, 3],
+            like_count=7,
         )
+        event.work = {
+            "key": "/works/OL59800W",
+            "title": "The Left Hand of Darkness",
+            "author_name": ["Ursula K. Le Guin"],
+            "cover_i": 10618463,
+        }
         with (
             patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[event]),
             patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
@@ -104,11 +118,45 @@ class TestActivityFeedEndpoint:
             response = fastapi_client.get("/api/internal/activity/feed.json")
 
         (item,) = response.json()["activity"]
-        assert item["type"] == "list_update"
+        assert item["type"] == "list_add"
+        assert item["label"] == "added a book to"
+        assert item["work"]["title"] == "The Left Hand of Darkness"
         assert item["list"]["name"] == "Books that rewired my brain"
-        assert item["list"]["book_count"] == 4
-        assert item["list"]["cover_ids"] == [1, 2, 3]
-        assert item["work"] is None
+        assert item["list"]["like_count"] == 7
+
+    def test_balanced_sampling_is_opt_in(self, fastapi_client, mock_avatar):
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event()]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.ActivityStream.balance", side_effect=lambda e, limit: e) as balance,
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            fastapi_client.get("/api/internal/activity/feed.json")
+            balance.assert_not_called()
+            fastapi_client.get("/api/internal/activity/feed.json?balanced=true")
+            balance.assert_called_once()
+
+    def test_balancing_asks_the_stream_for_a_deeper_pool(self, fastapi_client, mock_avatar):
+        # Balancing three cards out of exactly three events cannot spread the
+        # types -- the stream has to be asked for more than the page size.
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[]) as feed,
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            fastapi_client.get("/api/internal/activity/feed.json?limit=3&balanced=true")
+
+        assert feed.call_args.kwargs["limit"] > 3
+
+    def test_an_unbalanced_page_is_still_capped_at_the_limit(self, fastapi_client, mock_avatar):
+        with (
+            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[shelf_event(work_id=i) for i in range(5)]),
+            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
+            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
+        ):
+            response = fastapi_client.get("/api/internal/activity/feed.json?limit=2")
+
+        assert len(response.json()["activity"]) == 2
 
     def test_rating_only_event_serialises_without_a_shelf(self, fastapi_client, mock_avatar):
         event = RatingEvent(username="ada", created=JAN, work_id=1, work_key="/works/OL1W", rating=4)
@@ -175,37 +223,3 @@ class TestActivityFeedEndpoint:
     def test_rejects_out_of_range_limits(self, fastapi_client, limit):
         response = fastapi_client.get(f"/api/internal/activity/feed.json?limit={limit}")
         assert response.status_code == 422
-
-
-class TestLikeEvents:
-    """`likes` landed on master 2026-07-31, so list upvotes are now a real event."""
-
-    def _liked_list_event(self, key="/people/bo/lists/OL1L"):
-        return LikeEvent(username="ada", created=JAN, liked_key=key)
-
-    def test_a_liked_list_serialises_as_a_list_card(self, fastapi_client, mock_avatar):
-        feed_list = FeedList(key="/people/bo/lists/OL1L", name="Slow reads", book_count=5, cover_ids=[1, 2])
-        with (
-            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[self._liked_list_event()]),
-            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
-            patch("openlibrary.fastapi.activity._resolve_list", return_value=feed_list),
-            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
-        ):
-            response = fastapi_client.get("/api/internal/activity/feed.json")
-
-        (item,) = response.json()["activity"]
-        assert item["type"] == "like"
-        assert item["label"] == "liked a list"
-        assert item["list"]["name"] == "Slow reads"
-
-    def test_a_like_on_a_vanished_list_is_dropped(self, fastapi_client, mock_avatar):
-        # `likes.key` has no foreign key, so the target can simply be gone.
-        with (
-            patch("openlibrary.fastapi.activity.ActivityStream.public_feed", return_value=[self._liked_list_event()]),
-            patch("openlibrary.fastapi.activity.ActivityStream.attach_works"),
-            patch("openlibrary.fastapi.activity._resolve_list", return_value=None),
-            patch("openlibrary.fastapi.activity.PubSub.is_following", return_value=False),
-        ):
-            response = fastapi_client.get("/api/internal/activity/feed.json")
-
-        assert response.json()["activity"] == []

--- a/scripts/dev-instance/seed_social_feed.py
+++ b/scripts/dev-instance/seed_social_feed.py
@@ -33,6 +33,7 @@ from openlibrary.accounts import RunAs
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.core import db
 from openlibrary.core.follows import PubSub
+from openlibrary.core.likes import Likes
 from openlibrary.setup import setup_for_script
 from openlibrary.utils.request_context import site
 
@@ -567,6 +568,30 @@ def seed_lists(rng, verbose=True):
         print(f"Seeded {created} lists")
 
 
+def seed_likes(rng, verbose=True):
+    """Have patrons like each other's lists, so the feed shows like events."""
+    lists = []
+    for patron in PATRONS:
+        if user := site.get().get(f"/people/{patron['username']}"):
+            lists.extend((patron["username"], lst.key) for lst in user.get_lists(limit=50))
+
+    if not lists:
+        if verbose:
+            print("No lists to like yet")
+        return
+
+    liked = 0
+    for patron in PATRONS:
+        # Nobody likes their own list.
+        candidates = [key for owner, key in lists if owner != patron["username"]]
+        for key in rng.sample(candidates, min(len(candidates), rng.randint(1, 2))):
+            if not Likes.patron_liked(patron["username"], key):
+                Likes.like(patron["username"], key)
+                liked += 1
+    if verbose:
+        print(f"Seeded {liked} likes")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -609,6 +634,7 @@ def main():
 
     print("Creating lists:")
     seed_lists(rng)
+    seed_likes(rng)
 
     if args.no_follows:
         clear_follows(args.viewer)

--- a/scripts/dev-instance/seed_social_feed.py
+++ b/scripts/dev-instance/seed_social_feed.py
@@ -580,14 +580,25 @@ def seed_likes(rng, verbose=True):
             print("No lists to like yet")
         return
 
+    oldb = db.get_db()
+    now = datetime.now(UTC).replace(tzinfo=None)
     liked = 0
     for patron in PATRONS:
         # Nobody likes their own list.
         candidates = [key for owner, key in lists if owner != patron["username"]]
         for key in rng.sample(candidates, min(len(candidates), rng.randint(1, 2))):
-            if not Likes.patron_liked(patron["username"], key):
-                Likes.like(patron["username"], key)
-                liked += 1
+            if Likes.patron_liked(patron["username"], key):
+                continue
+            Likes.like(patron["username"], key)
+            # `Likes.like` stamps CURRENT_TIMESTAMP, so without this every like
+            # lands in the same second and a whole page of them buries the
+            # reading-log events at the top of the feed.
+            created = now - timedelta(minutes=rng.randint(5, 60 * 24 * 21))
+            oldb.query(
+                "UPDATE likes SET created=$created, modified=$created WHERE username=$username AND key=$key",
+                vars={"created": created, "username": patron["username"], "key": key},
+            )
+            liked += 1
     if verbose:
         print(f"Seeded {liked} likes")
 

--- a/scripts/dev-instance/seed_social_feed.py
+++ b/scripts/dev-instance/seed_social_feed.py
@@ -1,0 +1,622 @@
+"""Seed a local dev instance with a populated social activity feed.
+
+The stock ``load-patron-data.sh`` seeds the ``openlibrary`` account only, so
+there is no second patron to follow and no social graph at all -- which makes
+the activity feed impossible to look at locally. On top of that, the ~35 works
+in a fresh dev Solr have no cover IDs, so even a populated feed renders as a
+column of grey boxes.
+
+This script fixes both: it indexes a set of real, cover-bearing works into the
+local Solr core, creates several patrons with public reading logs, and gives
+them reading-log events, ratings, lists, and a follow graph.
+
+Run it from inside a worktree once the stack is up::
+
+    docker compose run --rm home python scripts/dev-instance/seed_social_feed.py
+
+Pass ``--viewer`` to control who ends up following the seeded patrons (defaults
+to the ``openlibrary`` dev account), and ``--no-follows`` to leave the viewer
+following nobody, which is how you exercise the public/not-following feed.
+"""
+
+import argparse
+import json
+import random
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+import web
+
+from openlibrary.accounts import RunAs
+from openlibrary.accounts.model import OpenLibraryAccount
+from openlibrary.core import db
+from openlibrary.core.follows import PubSub
+from openlibrary.setup import setup_for_script
+from openlibrary.utils.request_context import site
+
+SOLR_URL = "http://solr:8983/solr/openlibrary"
+
+# Real works pulled from production, trimmed to the fields the feed renders.
+# Hard-coded rather than fetched so seeding works offline and is deterministic.
+WORKS = [
+    {
+        "key": "/works/OL59800W",
+        "title": "The Left Hand of Darkness",
+        "author_name": ["Ursula K. Le Guin"],
+        "author_key": ["OL31353A"],
+        "cover_i": 10618463,
+        "first_publish_year": 1969,
+        "ia": ["lefthandofdarkne0000ursu_l8k8"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL12509193M"],
+    },
+    {
+        "key": "/works/OL50548W",
+        "title": "Beloved",
+        "author_name": ["Toni Morrison"],
+        "author_key": ["OL31120A"],
+        "cover_i": 8261367,
+        "first_publish_year": 1987,
+        "ia": ["umiowana0000morr"],
+        "has_fulltext": True,
+        "ebook_access": "borrowable",
+        "edition_key": ["OL58886319M"],
+    },
+    {
+        "key": "/works/OL35616W",
+        "title": "Kindred",
+        "author_name": ["Octavia E. Butler", "SparkNotes"],
+        "author_key": ["OL30802A", "OL2964716A"],
+        "cover_i": 8745330,
+        "first_publish_year": 1979,
+        "ia": ["kindred00butl"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL40478931M"],
+    },
+    {
+        "key": "/works/OL17762217W",
+        "title": "Pachinko",
+        "author_name": ["Min Jin Lee"],
+        "author_key": ["OL2711131A"],
+        "cover_i": 8044605,
+        "first_publish_year": 2017,
+        "ia": ["pachinko0000leem"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL62183991M"],
+    },
+    {
+        "key": "/works/OL59038W",
+        "title": "Never Let Me Go",
+        "author_name": ["Kazuo Ishiguro"],
+        "author_key": ["OL28493A"],
+        "cover_i": 1047334,
+        "first_publish_year": 2005,
+        "ia": ["nuncameabandones0000ishi"],
+        "has_fulltext": True,
+        "ebook_access": "borrowable",
+        "edition_key": ["OL62330757M"],
+    },
+    {
+        "key": "/works/OL19074847W",
+        "title": "The Overstory",
+        "author_name": ["Richard Powers", "Richard Powers"],
+        "author_key": ["OL873686A", "OL13933197A"],
+        "cover_i": 8758252,
+        "first_publish_year": 2018,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL53265567M"],
+    },
+    {
+        "key": "/works/OL16819897W",
+        "title": "Braiding Sweetgrass",
+        "author_name": ["Robin Wall Kimmerer"],
+        "author_key": ["OL2937464A"],
+        "cover_i": 7281575,
+        "first_publish_year": 2013,
+        "ia": ["braidingsweetgra0000robi"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL51172427M"],
+    },
+    {
+        "key": "/works/OL20893680W",
+        "title": "Piranesi",
+        "author_name": ["Susanna Clarke"],
+        "author_key": ["OL1387961A"],
+        "cover_i": 10226290,
+        "first_publish_year": 2020,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL57673802M"],
+    },
+    {
+        "key": "/works/OL17202418W",
+        "title": "Station Eleven",
+        "author_name": ["Emily St. John Mandel"],
+        "author_key": ["OL6538530A"],
+        "cover_i": 7369961,
+        "first_publish_year": 2014,
+        "ia": ["stationeleven0000mand"],
+        "has_fulltext": False,
+        "ebook_access": "unclassified",
+        "edition_key": ["OL45686302M"],
+    },
+    {
+        "key": "/works/OL17363125W",
+        "title": "The Fifth Season",
+        "author_name": ["N. K. Jemisin"],
+        "author_key": ["OL6575473A"],
+        "cover_i": 8133598,
+        "first_publish_year": 2015,
+        "ia": ["fifthseason0000jemi_x1j4"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL26354343M"],
+    },
+    {
+        "key": "/works/OL20150260W",
+        "title": "Normal People",
+        "author_name": ["Sally Rooney"],
+        "author_key": ["OL7919580A"],
+        "cover_i": 8794265,
+        "first_publish_year": 2018,
+        "ia": ["normalpeople0000roon_o9w7"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL59102236M"],
+    },
+    {
+        "key": "/works/OL17797130W",
+        "title": "A Gentleman in Moscow",
+        "author_name": ["Amor Towles"],
+        "author_key": ["OL7018678A"],
+        "cover_i": 11326818,
+        "first_publish_year": 2016,
+        "ia": ["mosikeshenshigen0000towl"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL35368976M"],
+    },
+    {
+        "key": "/works/OL18139176W",
+        "title": "Educated",
+        "author_name": ["Tara Westover"],
+        "author_key": ["OL7421324A"],
+        "cover_i": 8314077,
+        "first_publish_year": 2018,
+        "ia": ["isbn_9780593091876"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL53223020M"],
+    },
+    {
+        "key": "/works/OL17345497W",
+        "title": "The Sympathizer",
+        "author_name": ["Viet Thanh Nguyen", "Francois Chau"],
+        "author_key": ["OL1603399A", "OL9108410A"],
+        "cover_i": 7913176,
+        "first_publish_year": 2015,
+        "ia": ["sympathizer0000nguy_o2a7"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL59214628M"],
+    },
+    {
+        "key": "/works/OL18012166W",
+        "title": "Circe",
+        "author_name": ["Madeline Miller"],
+        "author_key": ["OL1926056A"],
+        "cover_i": 8739376,
+        "first_publish_year": 2018,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL59123703M"],
+    },
+    {
+        "key": "/works/OL20883297W",
+        "title": "Klara and the Sun",
+        "author_name": ["Kazuo Ishiguro"],
+        "author_key": ["OL28493A"],
+        "cover_i": 10648686,
+        "first_publish_year": 2019,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL32165942M"],
+    },
+    {
+        "key": "/works/OL20149336W",
+        "title": "Exhalation",
+        "author_name": ["Ted Chiang"],
+        "author_key": ["OL1604887A"],
+        "cover_i": 8793546,
+        "first_publish_year": 2014,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL59886250M"],
+    },
+    {
+        "key": "/works/OL16809803W",
+        "title": "The Goldfinch",
+        "author_name": ["Donna Tartt", "Katia Benovich"],
+        "author_key": ["OL841112A", "OL15020935A"],
+        "cover_i": 8771366,
+        "first_publish_year": 2013,
+        "ia": ["eljilguero0000tart"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL59742038M"],
+    },
+    {
+        "key": "/works/OL25344431W",
+        "title": "Lessons in Chemistry",
+        "author_name": ["Bonnie Garmus"],
+        "author_key": ["OL9587269A"],
+        "cover_i": 12725772,
+        "first_publish_year": 2022,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL51144311M"],
+    },
+    {
+        "key": "/works/OL26004554W",
+        "title": "Tomorrow, and Tomorrow, and Tomorrow",
+        "author_name": ["Gabrielle Zevin"],
+        "author_key": ["OL1394023A"],
+        "cover_i": 12859975,
+        "first_publish_year": 2022,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL62085818M"],
+    },
+    {
+        "key": "/works/OL27052926W",
+        "title": "Demon Copperhead",
+        "author_name": ["Barbara Kingsolver"],
+        "author_key": ["OL221083A"],
+        "cover_i": 13141227,
+        "first_publish_year": 2022,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL52941158M"],
+    },
+    {
+        "key": "/works/OL25916696W",
+        "title": "Trust",
+        "author_name": ["Hernán Díaz"],
+        "author_key": ["OL7526140A"],
+        "cover_i": 12742248,
+        "first_publish_year": 2022,
+        "ia": [],
+        "has_fulltext": False,
+        "ebook_access": "no_ebook",
+        "edition_key": ["OL39551233M"],
+    },
+    {
+        "key": "/works/OL20799434W",
+        "title": "The Vanishing Half",
+        "author_name": ["Brit Bennett", "Brit Bennett"],
+        "author_key": ["OL7487872A", "OL13624874A"],
+        "cover_i": 10095692,
+        "first_publish_year": 2020,
+        "ia": ["isbn_9780349702803"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL60348427M"],
+    },
+    {
+        "key": "/works/OL17795349W",
+        "title": "Homegoing",
+        "author_name": ["Yaa Gyasi"],
+        "author_key": ["OL7400941A"],
+        "cover_i": 8081171,
+        "first_publish_year": 2016,
+        "ia": ["homegoingnovel0000gyas_e0x6"],
+        "has_fulltext": True,
+        "ebook_access": "printdisabled",
+        "edition_key": ["OL42965822M"],
+    },
+]
+
+
+# Patrons the viewer can follow. `itemname` drives the avatar URL; these are
+# real archive.org accounts so the images resolve instead of 404ing.
+PATRONS = [
+    {"username": "ada_reads", "displayname": "Ada", "itemname": "@mek"},
+    {"username": "marginalia", "displayname": "Marginalia", "itemname": "@jimchamp"},
+    {"username": "stacks_and_stacks", "displayname": "Stacks", "itemname": "@openlibrary"},
+    {"username": "nightowl_reader", "displayname": "Night Owl", "itemname": "@cdrini"},
+    {"username": "dogeared", "displayname": "Dog-eared", "itemname": "@scottbarnes"},
+    {"username": "quiet_shelf", "displayname": "Quiet Shelf", "itemname": "@seabelis"},
+]
+
+# Bookshelf ids, mirroring Bookshelves.PRESET_BOOKSHELVES.
+WANT_TO_READ = 1
+CURRENTLY_READING = 2
+ALREADY_READ = 3
+
+LISTS = [
+    ("Books that rewired my brain", 4),
+    ("Slow reads for a long winter", 5),
+    ("Speculative fiction that earns it", 4),
+]
+
+
+def solr_index(works, verbose=True):
+    """Index the work docs into the local Solr core so feed enrichment finds them."""
+    docs = [
+        {
+            "key": w["key"],
+            "type": "work",
+            "title": w["title"],
+            "author_name": w["author_name"],
+            "author_key": w["author_key"],
+            "cover_i": w["cover_i"],
+            "first_publish_year": w["first_publish_year"],
+            "ia": w["ia"],
+            "has_fulltext": w["has_fulltext"],
+            "ebook_access": w["ebook_access"],
+            "edition_key": w["edition_key"],
+            "seed": [w["key"]],
+        }
+        for w in WORKS
+    ]
+    payload = json.dumps(docs).encode()
+    req = urllib.request.Request(
+        f"{SOLR_URL}/update?commit=true",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            resp.read()
+    except urllib.error.URLError as e:
+        sys.exit(f"Could not reach Solr at {SOLR_URL}: {e}\nIs the solr service up?")
+    if verbose:
+        print(f"Indexed {len(docs)} works into Solr")
+
+
+def ensure_works(verbose=True):
+    """Create the Infogami author and work records for the seeded books.
+
+    Solr alone is enough to *render* a feed card, but not enough to link one:
+    the work pages 404, and saving a list whose seeds point at works Infogami
+    has never seen fails outright with a `KeyError` on the seed key.
+    """
+    docs = []
+    seen_authors = set()
+    for work in WORKS:
+        for name, key in zip(work["author_name"], work["author_key"], strict=False):
+            author_key = f"/authors/{key}"
+            if author_key in seen_authors or site.get().get(author_key):
+                continue
+            seen_authors.add(author_key)
+            docs.append({"key": author_key, "type": {"key": "/type/author"}, "name": name})
+
+        if site.get().get(work["key"]):
+            continue
+        docs.append(
+            {
+                "key": work["key"],
+                "type": {"key": "/type/work"},
+                "title": work["title"],
+                "covers": [work["cover_i"]],
+                "authors": [{"type": {"key": "/type/author_role"}, "author": {"key": f"/authors/{key}"}} for key in work["author_key"]],
+            }
+        )
+
+    if not docs:
+        if verbose:
+            print("Works and authors already present")
+        return
+
+    with RunAs("openlibrary"):
+        site.get().save_many(docs, comment="Seeded by seed_social_feed.py")
+    if verbose:
+        print(f"Created {len(docs)} author/work records")
+
+
+def work_id(work):
+    """`/works/OL59800W` -> 59800, the integer the reading-log tables store."""
+    return int(work["key"].removeprefix("/works/OL").removesuffix("W"))
+
+
+def ensure_patron(patron):
+    """Create the /people/<username> record and mark the reading log public."""
+    username = patron["username"]
+    email = f"{username}@example.com"
+
+    # Check the account rather than the /people/ record: a run that died between
+    # register and activate leaves an account with no thing behind it, and
+    # `create` would then raise `email_registered` forever after.
+    if account := OpenLibraryAccount.get_by_email(email):
+        print(f"  {username} already exists")
+    else:
+        OpenLibraryAccount.create(
+            username=username,
+            email=email,
+            password="openlibrary",
+            displayname=patron["displayname"],
+            verified=True,
+        )
+        account = OpenLibraryAccount.get_by_email(email)
+        print(f"  created {username}")
+
+    if account and account.status != "active":
+        site.get().activate_account(username=username)
+        print(f"  activated {username}")
+
+    # A patron whose reading log is private is filtered straight back out of the
+    # public feed, so this is not optional decoration. `create` already does this
+    # for brand new accounts; re-applying it keeps re-runs idempotent.
+    if user := site.get().get(f"/people/{username}"):
+        with RunAs(username):
+            user.save_preferences({"public_readlog": "yes"})
+
+    # Link an archive.org itemname so User.get_avatar_url resolves to a real image.
+    if account and not account.get("internetarchive_itemname"):
+        account.internetarchive_itemname = patron["itemname"]
+        account._save()
+
+
+def seed_events(rng, viewer, verbose=True):
+    """Write reading-log, rating, and follow rows for every seeded patron."""
+    oldb = db.get_db()
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    oldb.query(
+        "DELETE FROM bookshelves_books WHERE username IN $names",
+        vars={"names": [p["username"] for p in PATRONS]},
+    )
+    oldb.query(
+        "DELETE FROM ratings WHERE username IN $names",
+        vars={"names": [p["username"] for p in PATRONS]},
+    )
+
+    shelves = [WANT_TO_READ, CURRENTLY_READING, ALREADY_READ]
+    events = 0
+    ratings = 0
+
+    for patron in PATRONS:
+        username = patron["username"]
+        # Spread each patron's books across shelves so the feed shows a mix of
+        # event types rather than a wall of "added to Want to Read".
+        for work in rng.sample(WORKS, rng.randint(4, 7)):
+            shelf = rng.choice(shelves)
+            # Timestamps fan out over the last three weeks so relative dates
+            # ("2h", "3d", "1w") exercise every branch of the compact formatter.
+            minutes_ago = rng.randint(5, 60 * 24 * 21)
+            created = now - timedelta(minutes=minutes_ago)
+            oldb.insert(
+                "bookshelves_books",
+                username=username,
+                work_id=work_id(work),
+                bookshelf_id=shelf,
+                edition_id=None,
+                private=False,
+                created=created,
+                updated=created,
+            )
+            events += 1
+
+            # Only already-read books get a rating, which is the real-world shape.
+            if shelf == ALREADY_READ and rng.random() < 0.7:
+                oldb.insert(
+                    "ratings",
+                    username=username,
+                    work_id=work_id(work),
+                    rating=rng.randint(3, 5),
+                    edition_id=None,
+                    created=created + timedelta(minutes=5),
+                    updated=created + timedelta(minutes=5),
+                )
+                ratings += 1
+
+    if verbose:
+        print(f"Seeded {events} reading-log events and {ratings} ratings")
+
+
+def seed_follows(viewer, verbose=True):
+    for patron in PATRONS:
+        PubSub.subscribe(viewer, patron["username"])
+    if verbose:
+        print(f"{viewer} now follows {len(PATRONS)} patrons")
+
+
+def clear_follows(viewer, verbose=True):
+    for patron in PATRONS:
+        PubSub.unsubscribe(viewer, patron["username"])
+    if verbose:
+        print(f"{viewer} now follows nobody (public-feed mode)")
+
+
+def seed_lists(rng, verbose=True):
+    """Give a few patrons real lists, so list-shaped feed events have something to point at."""
+    created = 0
+    for idx, (name, size) in enumerate(LISTS):
+        patron = PATRONS[idx % len(PATRONS)]
+        username = patron["username"]
+        user = site.get().get(f"/people/{username}")
+        if not user:
+            continue
+        seeds = [{"key": w["key"]} for w in rng.sample(WORKS, size)]
+        with RunAs(username):
+            if any(lst.name == name for lst in user.get_lists(limit=50)):
+                print(f"  list {name!r} already exists")
+                continue
+            # `new_list` only builds the doc -- nothing is persisted until the
+            # caller saves it.
+            lst = user.new_list(name=name, description="", tags=[], seeds=seeds)
+            lst._save(comment="Seeded by seed_social_feed.py")
+            created += 1
+            print(f"  created list {name!r} for {username}")
+    if verbose:
+        print(f"Seeded {created} lists")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--viewer",
+        default="openlibrary",
+        help="Account that ends up following the seeded patrons (default: openlibrary)",
+    )
+    parser.add_argument(
+        "--no-follows",
+        action="store_true",
+        help="Leave the viewer following nobody, to exercise the public feed",
+    )
+    parser.add_argument("--seed", type=int, default=20242, help="RNG seed, for reproducible data")
+    parser.add_argument(
+        "--config",
+        default="conf/openlibrary.yml",
+        help="Path to the Open Library config (default: conf/openlibrary.yml)",
+    )
+    args = parser.parse_args()
+
+    # Scripts run outside a request, so the `site` ContextVar the models read
+    # from is unset until this runs.
+    setup_for_script(args.config)
+
+    # Infogami records the writer's IP into `transaction.ip`, a Postgres `inet`
+    # column. Outside a request that is the empty string, which Postgres rejects
+    # -- every write 500s with `invalid input syntax for type inet`.
+    web.ctx.ip = "127.0.0.1"
+
+    rng = random.Random(args.seed)
+
+    solr_index(WORKS)
+    ensure_works()
+
+    print("Creating patrons:")
+    for patron in PATRONS:
+        ensure_patron(patron)
+
+    seed_events(rng, args.viewer)
+
+    print("Creating lists:")
+    seed_lists(rng)
+
+    if args.no_follows:
+        clear_follows(args.viewer)
+    else:
+        seed_follows(args.viewer)
+
+    print(f"\nDone. Visit /people/{args.viewer}/books to see the feed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/activity-feed.spec.ts
+++ b/tests/e2e/activity-feed.spec.ts
@@ -18,7 +18,7 @@ import { collectConsoleErrors } from './helpers';
  */
 
 const FEED_API = process.env.OL_FEED_API || 'http://localhost:18080/api/internal/activity/feed.json';
-const VARIANT_COUNT = 10;
+const VARIANT_COUNT = 11;
 
 function galleryUrl(design?: number): string {
     const params = new URLSearchParams({ api: FEED_API, scope: 'public' });
@@ -116,9 +116,32 @@ test.describe('activity feed design gallery', () => {
         await page.getByRole('link', { name: 'scope: public' }).click();
         expect(await feedItemCount(page), 'feed emptied after clicking a scope chip').toBeGreaterThan(0);
 
-        await page.getByRole('link', { name: 'All ten' }).click();
+        await page.getByRole('link', { name: 'All variants' }).click();
         await expect(page.locator('ol-social-feed')).toHaveCount(VARIANT_COUNT);
         expect(await feedItemCount(page), 'feed emptied after returning to all ten').toBeGreaterThan(0);
+    });
+
+    test('the showcase row pages and refreshes', async ({ page }) => {
+        // Variant 11 is the only one with controls: three across, refresh the
+        // whole row, and turn to older activity rather than scrolling forever.
+        await page.goto(galleryUrl(11));
+        const feed = page.locator('ol-social-feed').first();
+        await expect(feed.locator('.feed')).toBeVisible({ timeout: 15_000 });
+
+        await expect(feed.locator('.card')).toHaveCount(3);
+        // Every card type should be on screen, or the row cannot be judged.
+        const types = await feed.locator('.card').evaluateAll((cards) => cards.map((c) => c.dataset.type));
+        expect(new Set(types).size).toBeGreaterThan(1);
+
+        const newer = feed.getByRole('button', { name: 'Newer activity' });
+        await expect(newer).toBeDisabled();
+
+        await feed.getByRole('button', { name: 'Older activity' }).click();
+        await expect(newer).toBeEnabled();
+        expect(await feed.locator('.card').count()).toBeGreaterThan(0);
+
+        await feed.getByRole('button', { name: 'Refresh activity' }).click();
+        await expect(feed.locator('.card').first()).toBeVisible();
     });
 
     test('captures every variant for review', async ({ page }, testInfo) => {

--- a/tests/e2e/activity-feed.spec.ts
+++ b/tests/e2e/activity-feed.spec.ts
@@ -18,7 +18,7 @@ import { collectConsoleErrors } from './helpers';
  */
 
 const FEED_API = process.env.OL_FEED_API || 'http://localhost:18080/api/internal/activity/feed.json';
-const VARIANT_COUNT = 11;
+const VARIANT_COUNT = 12;
 
 function galleryUrl(design?: number): string {
     const params = new URLSearchParams({ api: FEED_API, scope: 'public' });
@@ -142,6 +142,34 @@ test.describe('activity feed design gallery', () => {
 
         await feed.getByRole('button', { name: 'Refresh activity' }).click();
         await expect(feed.locator('.card').first()).toBeVisible();
+    });
+
+    test('the tabbed column switches scope and loads more', async ({ page }) => {
+        await page.goto(galleryUrl(12));
+        const feed = page.locator('ol-social-feed').first();
+        await expect(feed.locator('.feed')).toBeVisible({ timeout: 15_000 });
+
+        // `auto` names no tab, so Discover has to be the one selected on load.
+        await expect(feed.getByRole('tab', { name: 'Discover' })).toHaveAttribute('aria-selected', 'true');
+
+        const before = await feed.locator('.card').count();
+        expect(before).toBeGreaterThan(0);
+
+        // Popular is one card per patron, so it is a single page by definition.
+        await feed.getByRole('tab', { name: 'Popular' }).click();
+        await expect(feed.getByRole('tab', { name: 'Popular' })).toHaveAttribute('aria-selected', 'true');
+        await expect(feed.locator('.card').first()).toBeVisible();
+        const usernames = await feed.locator('.handle').evaluateAll((els) => els.map((e) => e.textContent.trim()));
+        expect(new Set(usernames).size, 'Popular repeated a patron').toBe(usernames.length);
+
+        await feed.getByRole('tab', { name: 'Discover' }).click();
+        await expect(feed.locator('.card').first()).toBeVisible();
+
+        const loadMore = feed.getByRole('button', { name: 'Load more' });
+        if (await loadMore.count()) {
+            await loadMore.click();
+            await expect.poll(() => feed.locator('.card').count()).toBeGreaterThan(before);
+        }
     });
 
     test('captures every variant for review', async ({ page }, testInfo) => {

--- a/tests/e2e/activity-feed.spec.ts
+++ b/tests/e2e/activity-feed.spec.ts
@@ -64,8 +64,11 @@ test.describe('activity feed design gallery', () => {
         // feature guessed work-OLID cover URLs and rendered the wrong books.
         const cover = card.locator('.cover img').first();
         await expect(cover).toHaveAttribute('src', /covers\.openlibrary\.org\/b\/id\/\d+/);
-        await expect(cover).toHaveJSProperty('naturalWidth', await cover.evaluate((img: HTMLImageElement) => img.naturalWidth));
-        expect(await cover.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+        // Poll rather than sampling once: the cover comes from the CDN and may
+        // not have decoded yet when the card first paints.
+        await expect
+            .poll(() => cover.evaluate((img: HTMLImageElement) => img.naturalWidth), { timeout: 15_000 })
+            .toBeGreaterThan(0);
     });
 
     test('follow button reflects pressed state', async ({ page }) => {
@@ -97,6 +100,25 @@ test.describe('activity feed design gallery', () => {
         });
 
         expect(unnamed, 'links/buttons without an accessible name').toEqual([]);
+    });
+
+    test('navigating between variants keeps the feed populated', async ({ page }) => {
+        // The endpoint override lives in the query string, so every link on the
+        // page has to carry it. Drop it and each variant renders empty with
+        // nothing on screen to say why.
+        await page.goto(galleryUrl());
+        await expect(page.locator('ol-social-feed .feed').first()).toBeVisible({ timeout: 15_000 });
+
+        await page.getByRole('link', { name: '5. Social thread' }).click();
+        await expect(page.locator('ol-social-feed')).toHaveCount(1);
+        expect(await feedItemCount(page), 'feed emptied after clicking a variant chip').toBeGreaterThan(0);
+
+        await page.getByRole('link', { name: 'scope: public' }).click();
+        expect(await feedItemCount(page), 'feed emptied after clicking a scope chip').toBeGreaterThan(0);
+
+        await page.getByRole('link', { name: 'All ten' }).click();
+        await expect(page.locator('ol-social-feed')).toHaveCount(VARIANT_COUNT);
+        expect(await feedItemCount(page), 'feed emptied after returning to all ten').toBeGreaterThan(0);
     });
 
     test('captures every variant for review', async ({ page }, testInfo) => {

--- a/tests/e2e/activity-feed.spec.ts
+++ b/tests/e2e/activity-feed.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+/**
+ * The social activity feed (#10242).
+ *
+ * Three previous attempts at this feature were closed without anyone verifying
+ * a real, populated, correctly-styled feed end to end. These tests assert the
+ * populated state specifically -- an empty feed passing as "it renders" is the
+ * exact failure mode to guard against -- and capture screenshots of every
+ * layout variant at both widths for design review.
+ *
+ * Requires seeded social data:
+ *   docker compose run --rm home python scripts/dev-instance/seed_social_feed.py
+ *
+ * A local dev stack has no proxy from web.py to FastAPI, so the feed endpoint's
+ * origin is passed explicitly. In production nginx routes /api/internal itself.
+ */
+
+const FEED_API = process.env.OL_FEED_API || 'http://localhost:18080/api/internal/activity/feed.json';
+const VARIANT_COUNT = 10;
+
+function galleryUrl(design?: number): string {
+    const params = new URLSearchParams({ api: FEED_API, scope: 'public' });
+    if (design) params.set('design', String(design));
+    return `/developers/design/activity-feed?${params}`;
+}
+
+/** Wait for a feed element to finish loading and report what it rendered. */
+async function feedItemCount(page, index = 0): Promise<number> {
+    const feed = page.locator('ol-social-feed').nth(index);
+    await expect(feed.locator('.feed')).toBeVisible({ timeout: 15_000 });
+    return feed.locator('.card').count();
+}
+
+test.describe('activity feed design gallery', () => {
+    test('renders every variant with populated data', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto(galleryUrl());
+
+        const feeds = page.locator('ol-social-feed');
+        await expect(feeds).toHaveCount(VARIANT_COUNT);
+
+        // Every variant must actually show events. A variant that silently
+        // renders nothing is the failure this whole test exists to catch.
+        for (let i = 0; i < VARIANT_COUNT; i++) {
+            expect(await feedItemCount(page, i), `variant ${i + 1} rendered no cards`).toBeGreaterThan(0);
+        }
+
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('cards carry a book, a patron, and a next action', async ({ page }) => {
+        await page.goto(galleryUrl(1));
+        const feed = page.locator('ol-social-feed').first();
+        await expect(feed.locator('.feed')).toBeVisible({ timeout: 15_000 });
+
+        const card = feed.locator('.card').first();
+        await expect(card.locator('.handle')).toBeVisible();
+        await expect(card.locator('.title')).toBeVisible();
+        await expect(card.locator('.btn--primary')).toBeVisible();
+
+        // Covers come off the Solr record's cover id. An earlier attempt at this
+        // feature guessed work-OLID cover URLs and rendered the wrong books.
+        const cover = card.locator('.cover img').first();
+        await expect(cover).toHaveAttribute('src', /covers\.openlibrary\.org\/b\/id\/\d+/);
+        await expect(cover).toHaveJSProperty('naturalWidth', await cover.evaluate((img: HTMLImageElement) => img.naturalWidth));
+        expect(await cover.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+    });
+
+    test('follow button reflects pressed state', async ({ page }) => {
+        await page.goto(galleryUrl(1));
+        const feed = page.locator('ol-social-feed').first();
+        await expect(feed.locator('.feed')).toBeVisible({ timeout: 15_000 });
+
+        const follow = feed.locator('.follow').first();
+        await expect(follow).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    test('every link and control in the feed has an accessible name', async ({ page }) => {
+        // Avatar-only links and the list-cover fan are images with no text, so
+        // they need an explicit label. axe flagged 66 of these before they got one.
+        await page.goto(galleryUrl());
+        await expect(page.locator('ol-social-feed .feed').first()).toBeVisible({ timeout: 15_000 });
+
+        const unnamed = await page.evaluate(() => {
+            const bad: string[] = [];
+            document.querySelectorAll('ol-social-feed').forEach((host: any) => {
+                const variant = host.getAttribute('variant');
+                host.shadowRoot.querySelectorAll('a, button').forEach((el: Element) => {
+                    const name = (el.getAttribute('aria-label') || el.textContent || '').trim()
+                        || [...el.querySelectorAll('img')].map((img) => img.getAttribute('alt')).join('').trim();
+                    if (!name) bad.push(`v${variant} <${el.tagName.toLowerCase()} class="${el.className}">`);
+                });
+            });
+            return bad;
+        });
+
+        expect(unnamed, 'links/buttons without an accessible name').toEqual([]);
+    });
+
+    test('captures every variant for review', async ({ page }, testInfo) => {
+        for (let design = 1; design <= VARIANT_COUNT; design++) {
+            await page.goto(galleryUrl(design));
+            await expect(page.locator('ol-social-feed .feed')).toBeVisible({ timeout: 15_000 });
+            // Covers load from the CDN; let them land before capturing.
+            await page.waitForLoadState('networkidle');
+            const shot = await page.locator('.feed-gallery__variant').screenshot();
+            await testInfo.attach(`variant-${design}-${testInfo.project.name}`, {
+                body: shot,
+                contentType: 'image/png',
+            });
+        }
+    });
+
+    test('@mobile every variant holds up at a phone width', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto(galleryUrl());
+
+        for (let i = 0; i < VARIANT_COUNT; i++) {
+            expect(await feedItemCount(page, i), `variant ${i + 1} rendered no cards`).toBeGreaterThan(0);
+        }
+
+        // Nothing may push the page into horizontal scroll on a phone.
+        const overflow = await page.evaluate(
+            () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+        );
+        expect(overflow, 'page scrolls horizontally on mobile').toBeLessThanOrEqual(1);
+
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('@mobile captures every variant for review', async ({ page }, testInfo) => {
+        for (let design = 1; design <= VARIANT_COUNT; design++) {
+            await page.goto(galleryUrl(design));
+            await expect(page.locator('ol-social-feed .feed')).toBeVisible({ timeout: 15_000 });
+            await page.waitForLoadState('networkidle');
+            const shot = await page.locator('.feed-gallery__variant').screenshot();
+            await testInfo.attach(`variant-${design}-${testInfo.project.name}`, {
+                body: shot,
+                contentType: 'image/png',
+            });
+        }
+    });
+});


### PR DESCRIPTION
> **Experimental prototype — not for merge.** This is a design spike for #10242. Most of what is here is scaffolding built to be deleted: twelve layout treatments exist so one can be chosen, and eleven of them plus the gallery route go away when it is. Please read it as a prototype, not a candidate.

## The ask

**Which treatment to build for real** — or which two, if the My Books section and the full `/feed` page should differ.

```
/developers/design/activity-feed              # every treatment, same data
/developers/design/activity-feed?design=11    # one at a time
/developers/design/activity-feed?scope=public # or following, or popular
```

In dev the page and the feed API are on different ports with no proxy between them, so pass the endpoint explicitly:
`?api=http://localhost:18080/api/internal/activity/feed.json`

## Three card types, one container

Following Goodreads' Updates panel, every activity type fills the *same* skeleton rather than getting its own layout. Adding a type is one branch in `_present`, not a new template.

| # | Card | Subject | Actions |
|---|---|---|---|
| 1 | Shelved a book | the book | Follow · Add to your reading log |
| 2 | Rated a book | the book | Follow · Add to your reading log |
| 3 | Added a book to a list | the book, list as context | Follow · Add to reading log · ♥ the list |

Rating is its own card, not a star on the shelving. Card three shows the added book accented with up to two of its new list-mates blurred behind it.

## Leading candidates

**11 — Showcase row.** Three cards across on desktop, stacked on mobile. Refresh acts on the row; older activity by swipe or next control. A fixed three-across row holds its height on a page with three other components.

**12 — Discover / Following / Popular.** Tabs over one scrolling column that appends as you reach the end. Popular is the latest single event from each of the most-followed readers — a "who is worth following" view. The only treatment that makes the not-following case a destination rather than a fallback.

The other ten are exploration.

## What is real underneath

- `openlibrary/core/activity.py` — one time-ordered stream over activity that lives in three unrelated stores (shelvings and ratings in Postgres, lists in Infogami).
- `openlibrary/fastapi/activity.py` — `GET /api/internal/activity/feed.json`. One shape every rendering reads from.
- `scripts/dev-instance/seed_social_feed.py` — the unblocker. The stock dev seed makes one account, so there is no social graph, and dev Solr works have no cover ids. This seeds real cover-bearing works into Solr *and* Infogami, six patrons, a follow graph, ratings, lists, likes.

## Event coverage

Shelvings, ratings, list-adds and list hearts all work against real seeded data. **Borrow events are absent and need a product call** — no public global source for loans, and privacy-sensitive.

"Which book was added to this list" is inferred from seed order rather than recorded. That is the clearest argument for the computed `activity_feed` table discussed in the thread: a worker writing events as they happen makes it exact, collapses the three-store union into one indexed read, and gives borrow events somewhere to live.

## Testing

56 Python tests, 10 Playwright tests across desktop and Pixel 5, all green.

The Playwright suite asserts the **populated** state specifically — an empty feed passing as "it renders" is what closed #11290, #11391 and #11645. It has caught real bugs throughout, including a visual QA pass over all twenty-four screenshots that found six layout defects.

axe reports no serious or critical violations from the component.

## Checklist

- [x] Unified activity stream + tests
- [x] Feed API + tests
- [x] Local seed data producing a genuinely populated feed
- [x] Twelve treatments, all showing all three card types
- [x] Playwright, populated state, mobile + desktop
- [x] Visual QA pass
- [x] Docs (`docs/ai/subsystems/activity-feed.md`) + `ol-kb` wiki
- [ ] **Design decision** ← blocked here, by design
- [ ] Rebuild the winner as a real PR; delete the gallery and the other eleven