### PR TITLE
feat(a11y): wire @axe-core/playwright into the e2e suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ docs/wiki/
 
 # uv lockfile (we resolve from requirements*.txt; not tracked)
 uv.lock
+
+# Playwright
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@babel/core": "^7.24.7",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/preset-env": "^7.29.3",
@@ -111,6 +112,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -6857,6 +6871,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-jest": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@babel/core": "^7.24.7",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/preset-env": "^7.29.3",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,6 +17,22 @@ Tests hit `http://localhost:8080` by default. Point them elsewhere with `OL_BASE
 Two projects are configured so nothing runs twice: `desktop` runs everything
 except `@mobile`, and `mobile` runs only `@mobile`.
 
+### Watching them run
+
+```bash
+npx playwright test --ui        # interactive runner
+npx playwright test --headed    # visible browser, driven live
+```
+
+These are not the same thing. `--ui` runs headless and records a trace you
+scrub through afterwards: pick a test, click an action, and the pane shows the
+real DOM at that moment. It does not open a browser window, and the pane stays
+blank until you select an individual test rather than its `describe` block.
+`--headed` is the one that opens Chromium and lets you watch it work. Add
+`--slow-mo=1000` to follow along.
+
+After any run, `npx playwright show-report` opens the HTML report.
+
 ## Accessibility tests
 
 `a11y.ts` wraps [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -85,7 +85,12 @@ matches no elements passes trivially, which looks identical to a fix that works.
 
 ### Third-party content
 
-`THIRD_PARTY_FRAMES` excludes embedded iframes. The archive.org donation banner
-currently fails `image-alt`, and that markup isn't ours to fix. Pass it
-explicitly rather than relying on a default, so any test that skips part of the
-page says so in its own body.
+The a11y specs block `archive.org` requests before navigating, so the donation
+banner never loads. Axe *does* see inside cross-origin iframes under Playwright
+(injection happens over the devtools protocol, not from the page), and the
+banner's content rotates by campaign — some variants fail `image-alt` — so an
+unblocked scan could flip between runs with no Open Library change.
+
+`THIRD_PARTY_FRAMES` additionally excludes any iframe from the scan, for
+embeds that aren't ours to fix. Pass it explicitly rather than relying on a
+default, so any test that skips part of the page says so in its own body.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,75 @@
+# End-to-end tests
+
+Playwright specs that drive a real browser against a running Open Library.
+
+## Running them
+
+Start the stack, install the browser once, then run:
+
+```bash
+OL_MOUNT_DIR="$(pwd)" docker compose up -d web infobase db memcached home covers
+npx playwright install chromium chromium-headless-shell
+npm run test:e2e
+```
+
+Tests hit `http://localhost:8080` by default. Point them elsewhere with `OL_BASE_URL`.
+
+Two projects are configured so nothing runs twice: `desktop` runs everything
+except `@mobile`, and `mobile` runs only `@mobile`.
+
+## Accessibility tests
+
+`a11y.ts` wraps [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm)
+with Open Library's conformance target, WCAG 2.1 AA.
+
+These complement the component tests in `openlibrary/components/__tests__/`
+rather than duplicating them. Those run in jsdom, which parses markup but never
+lays it out, so they can check ARIA wiring and nothing else. **Colour contrast,
+focus styling, and anything else that needs rendered pixels can only be tested
+here.**
+
+### Scanning a page
+
+```javascript
+import { a11yCheck, expectNoViolations, THIRD_PARTY_FRAMES } from './a11y';
+
+test('my page is accessible', async ({ page }) => {
+    await page.goto('/my-page');
+    expectNoViolations(await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES }));
+});
+```
+
+`expectNoViolations` prints every violation with its impact, the offending
+markup, and remediation steps, rather than Playwright's default array diff.
+
+### The pattern for a11y fix PRs
+
+A fix PR should ship a test that proves the fix and fails without it. Scope it
+to the rule you fixed, so it stays green while unrelated violations elsewhere on
+the page are still outstanding:
+
+```javascript
+test('iframes have accessible titles', async ({ page }) => {
+    await page.goto('/');
+    expectNoViolations(await a11yCheck(page, { rules: ['frame-title'] }));
+});
+```
+
+Before you commit, **check the test fails without your fix.** A scoped rule that
+matches no elements passes trivially, which looks identical to a fix that works.
+
+### Options
+
+| Option | Effect |
+|---|---|
+| `rules` | Run only these rule ids. Skips the WCAG tag filter entirely. |
+| `include` | CSS selector to scan. Defaults to the whole page. |
+| `exclude` | CSS selectors to skip, e.g. `THIRD_PARTY_FRAMES`. |
+| `disableRules` | Rule ids to skip. Prefer `rules` for fix-PR tests. |
+
+### Third-party content
+
+`THIRD_PARTY_FRAMES` excludes embedded iframes. The archive.org donation banner
+currently fails `image-alt`, and that markup isn't ours to fix. Pass it
+explicitly rather than relying on a default, so any test that skips part of the
+page says so in its own body.

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,9 +1,27 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { a11yCheck, expectNoViolations, THIRD_PARTY_FRAMES } from './a11y';
+
+/**
+ * Navigate, then wait for the global header before scanning.
+ *
+ * `goto` resolves on `load`, which can be before the page has painted. Axe's
+ * contrast rules read computed pixels, so scanning that early gives different
+ * results run to run. Every other spec in this directory anchors on
+ * `#header-bar` for the same reason.
+ *
+ * Note this settles first paint, not lazily-loaded content: the home page's
+ * carousels populate after `load` and may or may not be in a given scan.
+ * That's why the canary below counts rules evaluated rather than nodes.
+ */
+async function gotoSettled(page: Page, path: string): Promise<void> {
+    await page.goto(path);
+    await expect(page.locator('#header-bar').first()).toBeVisible();
+}
 
 test.describe('Accessibility @a11y', () => {
     test('home page has no WCAG 2.1 AA violations', async ({ page }) => {
-        await page.goto('/');
+        await gotoSettled(page, '/');
         expectNoViolations(await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES }));
     });
 
@@ -11,7 +29,7 @@ test.describe('Accessibility @a11y', () => {
         // The example of a scoped, single-rule check. Contrast is also the
         // headline reason this suite exists: the jsdom component tests can't
         // evaluate it at all, because jsdom never paints anything.
-        await page.goto('/');
+        await gotoSettled(page, '/');
         expectNoViolations(await a11yCheck(page, { rules: ['color-contrast'], exclude: THIRD_PARTY_FRAMES }));
     });
 
@@ -19,11 +37,18 @@ test.describe('Accessibility @a11y', () => {
         // Guard against a passing suite that checks nothing: a bad selector or
         // a broken tag filter would leave zero applicable rules, and every
         // "no violations" assertion above would be vacuously true.
-        await page.goto('/');
+        await gotoSettled(page, '/');
         const results = await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES });
 
+        // Count every rule axe reached a conclusion about, not just the ones
+        // that passed. A rule that starts failing moves from `passes` to
+        // `violations`, which is a real regression for the tests above to
+        // report — this one should keep confirming axe ran, not fail alongside
+        // them with a misleading "axe is broken" message.
+        const evaluated = [...results.passes, ...results.violations, ...results.incomplete].map((rule) => rule.id);
+
         expect(results.testEngine.name).toBe('axe-core');
-        expect(results.passes.length).toBeGreaterThan(20);
-        expect(results.passes.map((rule) => rule.id)).toContain('color-contrast');
+        expect(evaluated.length).toBeGreaterThan(20);
+        expect(evaluated).toContain('color-contrast');
     });
 });

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { a11yCheck, expectNoViolations, THIRD_PARTY_FRAMES } from './a11y';
+
+test.describe('Accessibility @a11y', () => {
+    test('home page has no WCAG 2.1 AA violations', async ({ page }) => {
+        await page.goto('/');
+        expectNoViolations(await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES }));
+    });
+
+    test('home page passes colour contrast', async ({ page }) => {
+        // The example of a scoped, single-rule check. Contrast is also the
+        // headline reason this suite exists: the jsdom component tests can't
+        // evaluate it at all, because jsdom never paints anything.
+        await page.goto('/');
+        expectNoViolations(await a11yCheck(page, { rules: ['color-contrast'], exclude: THIRD_PARTY_FRAMES }));
+    });
+
+    test('axe actually evaluates rules', async ({ page }) => {
+        // Guard against a passing suite that checks nothing: a bad selector or
+        // a broken tag filter would leave zero applicable rules, and every
+        // "no violations" assertion above would be vacuously true.
+        await page.goto('/');
+        const results = await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES });
+
+        expect(results.testEngine.name).toBe('axe-core');
+        expect(results.passes.length).toBeGreaterThan(20);
+        expect(results.passes.map((rule) => rule.id)).toContain('color-contrast');
+    });
+});

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -15,6 +15,12 @@ import { a11yCheck, expectNoViolations, THIRD_PARTY_FRAMES } from './a11y';
  * That's why the canary below counts rules evaluated rather than nodes.
  */
 async function gotoSettled(page: Page, path: string): Promise<void> {
+    // Block archive.org before navigating so the donation banner never loads.
+    // Its content rotates by campaign, and axe does scan inside cross-origin
+    // frames under Playwright, so an unblocked scan could flip between runs
+    // with no Open Library change. These scans should only ever see markup
+    // we author.
+    await page.route('https://archive.org/**', (route) => route.abort());
     await page.goto(path);
     await expect(page.locator('#header-bar').first()).toBeVisible();
 }

--- a/tests/e2e/a11y.ts
+++ b/tests/e2e/a11y.ts
@@ -30,8 +30,11 @@ const WCAG_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
 /**
  * Third-party iframes we embed but don't author, so their violations aren't
- * ours to fix. Right now this is the archive.org donation banner, whose close
- * button ships an `<img>` with no alt text.
+ * ours to fix. Axe does scan inside cross-origin frames under Playwright
+ * (injection happens over the devtools protocol, not from the page), so
+ * without this an embed like the archive.org donation banner — whose content
+ * rotates by campaign, some variants failing `image-alt` — would tie a scan's
+ * result to whatever a third party serves that day.
  *
  * Pass this explicitly rather than defaulting to it, so a test that skips
  * part of the page says so in its own body.

--- a/tests/e2e/a11y.ts
+++ b/tests/e2e/a11y.ts
@@ -1,0 +1,92 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import type { AxeResults, Result } from 'axe-core';
+
+/**
+ * Shared axe-core setup for page-level accessibility tests.
+ *
+ * These run in a real browser, so unlike the jsdom component tests in
+ * `openlibrary/components/__tests__/` they can see rendered pixels: colour
+ * contrast, focus styling, and anything else that needs layout.
+ *
+ * Usage — scan a whole page against WCAG 2.1 AA:
+ *
+ *   const results = await a11yCheck(page);
+ *   expectNoViolations(results);
+ *
+ * Usage — assert one rule, which is the pattern for a11y fix PRs. Scoping to
+ * the rule you fixed keeps the test green while unrelated violations are still
+ * outstanding elsewhere on the page:
+ *
+ *   test('iframes have accessible titles', async ({ page }) => {
+ *       await page.goto('/');
+ *       expectNoViolations(await a11yCheck(page, { rules: ['frame-title'] }));
+ *   });
+ */
+
+/** WCAG 2.1 AA, which is Open Library's conformance target. */
+const WCAG_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+/**
+ * Third-party iframes we embed but don't author, so their violations aren't
+ * ours to fix. Right now this is the archive.org donation banner, whose close
+ * button ships an `<img>` with no alt text.
+ *
+ * Pass this explicitly rather than defaulting to it, so a test that skips
+ * part of the page says so in its own body.
+ */
+export const THIRD_PARTY_FRAMES = ['iframe'];
+
+export type A11yCheckOptions = {
+    /** Limit the scan to these rule ids. Everything else is skipped. */
+    rules?: string[];
+    /** CSS selector to scan. Defaults to the whole page. */
+    include?: string;
+    /** CSS selectors to leave out, e.g. third-party embeds we don't control. */
+    exclude?: string[];
+    /** Rule ids to skip. Prefer `rules` for fix-PR tests. */
+    disableRules?: string[];
+};
+
+/**
+ * Run axe against the current page.
+ *
+ * Note this deliberately does not assert: callers decide whether to fail on
+ * violations or just report them. Use `expectNoViolations` for the common case.
+ */
+export async function a11yCheck(page: Page, options: A11yCheckOptions = {}): Promise<AxeResults> {
+    const { rules, include, exclude = [], disableRules = [] } = options;
+    let builder = new AxeBuilder({ page });
+
+    // withRules and withTags are mutually exclusive in axe-core: passing a rule
+    // list means "only these", so the tag filter must not also be applied.
+    builder = rules?.length ? builder.withRules(rules) : builder.withTags(WCAG_AA_TAGS);
+
+    if (include) builder = builder.include(include);
+    for (const selector of exclude) builder = builder.exclude(selector);
+    if (disableRules.length) builder = builder.disableRules(disableRules);
+
+    return builder.analyze();
+}
+
+/** One violation rendered as a readable block, with the offending markup. */
+function formatViolation(violation: Result): string {
+    const nodes = violation.nodes
+        .map((node) => `      ${node.html}\n        ${node.failureSummary?.replace(/\n/g, '\n        ')}`)
+        .join('\n');
+    return `  [${violation.impact}] ${violation.id}: ${violation.help}\n    ${violation.helpUrl}\n${nodes}`;
+}
+
+/**
+ * Assert the scan came back clean, printing every violation with its markup
+ * and remediation advice. The default Playwright diff on a violations array is
+ * unreadable, so this trades it for something you can act on.
+ */
+export function expectNoViolations(results: AxeResults): void {
+    const { violations } = results;
+    const summary = violations.length
+        ? `${violations.length} accessibility violation(s):\n${violations.map(formatViolation).join('\n\n')}`
+        : '';
+    expect(summary, summary).toBe('');
+}


### PR DESCRIPTION
Closes #13007

Wires [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm) into the existing Playwright suite so a11y fix PRs can prove their fix in a real browser. [feature]

Phase 1 (#13006) covers ARIA patterns in Lit components, but those run in jsdom, which never lays out or paints. Colour contrast and anything else needing rendered pixels can only be checked here.

<img width="1536" height="717" alt="image" src="https://github.com/user-attachments/assets/9d12600d-b9f4-42f1-bce1-51314a51dffe" />

### Technical

- `@axe-core/playwright` devDependency (4.12.1)
- `tests/e2e/a11y.ts` — shared `a11yCheck(page, options)` defaulting to WCAG 2.1 AA, with `rules` / `include` / `exclude` / `disableRules` scoping
- `tests/e2e/a11y.spec.ts` — 3 smoke tests
- `tests/e2e/README.md` — full docs
- `.gitignore` for `playwright-report/` and `test-results/`, which had none

**Not wired to CI, deliberately.** No workflow runs `npm run test:e2e` and this PR doesn't add one. axe-core bumps introduce new rules, so gating on it could fail unrelated PRs. Suggested follow-up: a non-blocking reporting job on a pinned version first.

**Baseline.** `/`, `/search?q=tolkien`, and `/subjects/history` are clean at WCAG 2.1 AA. Following @RayBB's review, the a11y specs now block `archive.org` before navigating: axe *does* scan inside cross-origin iframes under Playwright, and the donation banner's content rotates by campaign (the variant served during development failed `image-alt` on its close button; the current one doesn't), so leaving it in would tie the scan's result to whatever archive.org serves that day. `THIRD_PARTY_FRAMES` still excludes any iframe, exported rather than applied as a silent default. Ten nodes come back `incomplete` for contrast (mostly the gradient borrow buttons, where axe can't determine a background colour) and will never fail a test. Worth a follow-up.

### Testing

```bash
npx playwright install chromium chromium-headless-shell
npx playwright test                          # 23 passed (20 existing + 3 new)
npx playwright test --grep @a11y --headed    # watch it run
```

Also `npx jest` (26 suites, 495 tests, unaffected) and `npm run lint` (0 errors).

To confirm the gate bites, plant a violation: add this line to the first test in `a11y.spec.ts` after `gotoSettled` and rerun.

```javascript
await page.evaluate(() => document.body.insertAdjacentHTML('beforeend', '<img src="x.gif">'));
```

It fails on `image-alt` with the offending markup and remediation steps. (An earlier version of this description said dropping the iframe exclusion would fail on the donation banner. That was true of the banner variant served at the time, but the banner rotates — which is exactly why the specs now block it.)

### Adding or editing tests

Scan a page:

```javascript
import { a11yCheck, expectNoViolations, THIRD_PARTY_FRAMES } from './a11y';

await page.goto('/my-page');
expectNoViolations(await a11yCheck(page, { exclude: THIRD_PARTY_FRAMES }));
```

For a fix PR, scope to the rule you fixed so it stays green while unrelated violations are outstanding:

```javascript
expectNoViolations(await a11yCheck(page, { rules: ['frame-title'] }));
```

Then check it fails without your fix. A scoped rule matching no elements passes trivially, which looks identical to a fix that works. More in `tests/e2e/README.md`.

### Screenshot

No UI changes — test infrastructure only.

### Stakeholders

@mekarpeles @RayBB @cdrini @jimchamp
