### PR TITLE
feat(core): read-only Matomo client + offline mock (groundwork for #11956)

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -80,14 +80,6 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
-# Matomo Reporting API token, read by openlibrary/core/matomo.py.
-# Should be a view-only Matomo user: the read-only allowlist in that module
-# guards against mistakes, not against a token that can write. The real value
-# lives in olsystem's copy of this file; left blank here so local dev simply
-# skips retention scoring. To run the scripts locally, export MATOMO_TOKEN
-# rather than filling this in.
-matomo_api:
-
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
       filter: all

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -80,10 +80,12 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
-# Matomo Reporting API token, for Core Vitals retention scoring
-# (openlibrary/admin/vitals.py). The real value lives in olsystem's copy of this
-# file; left blank here so local dev simply skips retention scoring. To run the
-# on-demand script locally, export MATOMO_TOKEN rather than filling this in.
+# Matomo Reporting API token, read by openlibrary/core/matomo.py.
+# Should be a view-only Matomo user: the read-only allowlist in that module
+# guards against mistakes, not against a token that can write. The real value
+# lives in olsystem's copy of this file; left blank here so local dev simply
+# skips retention scoring. To run the scripts locally, export MATOMO_TOKEN
+# rather than filling this in.
 matomo_api:
 
 stats: # This section is used to state what stats need to be gathered.

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -80,6 +80,12 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
+# Matomo Reporting API token, for Core Vitals retention scoring
+# (openlibrary/admin/vitals.py). The real value lives in olsystem's copy of this
+# file; left blank here so local dev simply skips retention scoring. To run the
+# on-demand script locally, export MATOMO_TOKEN rather than filling this in.
+matomo_api:
+
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
       filter: all

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -84,6 +84,12 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
+# Matomo Reporting API token, for Core Vitals retention scoring
+# (openlibrary/admin/vitals.py). The real value lives in olsystem's copy of this
+# file; left blank here so local dev simply skips retention scoring. To run the
+# on-demand script locally, export MATOMO_TOKEN rather than filling this in.
+matomo_api:
+
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
       filter: all

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -84,10 +84,12 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
-# Matomo Reporting API token, for Core Vitals retention scoring
-# (openlibrary/admin/vitals.py). The real value lives in olsystem's copy of this
-# file; left blank here so local dev simply skips retention scoring. To run the
-# on-demand script locally, export MATOMO_TOKEN rather than filling this in.
+# Matomo Reporting API token, read by openlibrary/core/matomo.py.
+# Should be a view-only Matomo user: the read-only allowlist in that module
+# guards against mistakes, not against a token that can write. The real value
+# lives in olsystem's copy of this file; left blank here so local dev simply
+# skips retention scoring. To run the scripts locally, export MATOMO_TOKEN
+# rather than filling this in.
 matomo_api:
 
 stats: # This section is used to state what stats need to be gathered.

--- a/docker/mockservices/main.py
+++ b/docker/mockservices/main.py
@@ -481,7 +481,8 @@ async def matomo_api(request: Request) -> JSONResponse:
         offset = _matomo_form_int(form, "filter_offset", 0)
         since = _matomo_form_int(form, "minTimestamp", 0)
     except ValueError as exc:
-        return JSONResponse({"result": "error", "message": str(exc)})
+        logger.warning("Invalid Matomo API request parameters", exc_info=exc)
+        return JSONResponse({"result": "error", "message": "Invalid request parameters"})
     if limit < 1 or offset < 0:
         return JSONResponse({"result": "error", "message": "filter_limit must be >= 1 and filter_offset >= 0"})
 

--- a/docker/mockservices/main.py
+++ b/docker/mockservices/main.py
@@ -390,6 +390,77 @@ async def amazon_get_items(request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# Matomo Reporting API  (Core Vitals retention scoring, issue #11956)
+# POST /matomo/index.php
+#
+# matomo.archive.org is restricted to IA's network, so retention scoring is
+# otherwise untestable locally. Point the client at this instead:
+#   MATOMO_URL=http://mockservices:8090/matomo
+#
+# Returns visits in the exact shape Live.getLastVisitsDetails does, which is
+# the part worth mocking faithfully: `dimension1` is a FLAT field on the visit
+# (not nested under `customDimensions`, which this endpoint deliberately never
+# returns), and engagement lives in `actionDetails` as a mix of `event` and
+# `action` entries. Reading dimension1 from the wrong place is a real bug this
+# pipeline shipped, so the mock encodes the true wire format.
+# ---------------------------------------------------------------------------
+
+MATOMO_COHORTS = ["visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"]
+
+# (eventCategory, eventAction) pairs the scorer recognises, plus one it does
+# not, so tests can assert unmapped events are ignored rather than crashing.
+MATOMO_SAMPLE_EVENTS = [
+    ("CTAClick", "Read"),
+    ("CTAClick", "Borrow"),
+    ("CTAClick", "Edit"),
+    ("ReadingLog", "WantToRead"),
+    ("MainNav", "MyBooks"),
+    ("PatronImports", "Goodreads"),
+    ("SearchModal", "Open"),
+]
+
+
+def _matomo_visit(index: int, since_timestamp: int) -> dict:
+    """One synthetic visit, deterministic in `index` so tests can assert exactly."""
+    cohort = MATOMO_COHORTS[index % len(MATOMO_COHORTS)]
+    category, action = MATOMO_SAMPLE_EVENTS[index % len(MATOMO_SAMPLE_EVENTS)]
+    return {
+        "idVisit": str(index),
+        # Flat, exactly as the real API returns it.
+        "dimension1": cohort,
+        "visitorId": f"visitor{index:04d}",
+        "userId": None,
+        "firstActionTimestamp": since_timestamp + index,
+        "serverTimestamp": since_timestamp + index,
+        "actionDetails": [
+            {"type": "event", "eventCategory": category, "eventAction": action},
+            {"type": "action", "url": f"https://openlibrary.org/works/OL{index}W/Mock_Book"},
+        ],
+    }
+
+
+@app.post("/matomo/index.php")
+async def matomo_api(request: Request) -> JSONResponse:
+    form = await request.form()
+    method = str(form.get("method", ""))
+
+    if not form.get("token_auth"):
+        return JSONResponse({"result": "error", "message": "Requests to the API must be authenticated"})
+
+    if method != "Live.getLastVisitsDetails":
+        return JSONResponse({"result": "error", "message": f"Mock does not implement {method}"})
+
+    # Honour paging so the client's pagination loop is genuinely exercised.
+    total = int(str(form.get("mock_total_visits", "12")))
+    limit = int(str(form.get("filter_limit", "500")))
+    offset = int(str(form.get("filter_offset", "0")))
+    since = int(str(form.get("minTimestamp", "0")))
+
+    visits = [_matomo_visit(i, since) for i in range(offset, min(offset + limit, total))]
+    return JSONResponse(visits)
+
+
+# ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
 

--- a/docker/mockservices/main.py
+++ b/docker/mockservices/main.py
@@ -397,46 +397,72 @@ async def amazon_get_items(request: Request) -> JSONResponse:
 # otherwise untestable locally. Point the client at this instead:
 #   MATOMO_URL=http://mockservices:8090/matomo
 #
-# Returns visits in the exact shape Live.getLastVisitsDetails does, which is
-# the part worth mocking faithfully: `dimension1` is a FLAT field on the visit
-# (not nested under `customDimensions`, which this endpoint deliberately never
-# returns), and engagement lives in `actionDetails` as a mix of `event` and
-# `action` entries. Reading dimension1 from the wrong place is a real bug this
-# pipeline shipped, so the mock encodes the true wire format.
+# Returns visits in the shape Live.getLastVisitsDetails does. The part worth
+# mocking faithfully is the wire format: `dimension1` is a FLAT field on the
+# visit -- this endpoint never returns the `customDimensions` structure it looks
+# like it should -- and engagement lives in `actionDetails` as a mix of `event`
+# and `action` entries. Newest-first ordering and `minTimestamp` filtering are
+# honoured so paging and window behaviour can be exercised against it.
 # ---------------------------------------------------------------------------
 
 MATOMO_COHORTS = ["visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"]
 
-# (eventCategory, eventAction) pairs the scorer recognises, plus one it does
-# not, so tests can assert unmapped events are ignored rather than crashing.
+# Deliberately a different length from MATOMO_COHORTS (7) so cohorts and events
+# do not advance in lockstep -- otherwise `visitor` would always carry the same
+# event and most cohort/event pairs would never appear in the feed.
 MATOMO_SAMPLE_EVENTS = [
     ("CTAClick", "Read"),
     ("CTAClick", "Borrow"),
-    ("CTAClick", "Edit"),
     ("ReadingLog", "WantToRead"),
     ("MainNav", "MyBooks"),
-    ("PatronImports", "Goodreads"),
+    # Real traffic a consumer's schema may have no row for; included so callers
+    # can assert unmapped events are ignored rather than fatal.
     ("SearchModal", "Open"),
 ]
 
+# Fixed at import, and deliberately NOT derived from the caller's
+# `minTimestamp`: if visit times are built from the filter then every visit is
+# after it by construction, the mock can never disagree with the filter, and the
+# one property `minTimestamp` exists to enforce becomes untestable. Two days back
+# so the feed sits comfortably inside a client's maximum window while still being
+# old enough that "since a minute ago" correctly returns nothing.
+MATOMO_MOCK_EPOCH = int((datetime.now(UTC) - timedelta(days=2)).timestamp())
+MATOMO_MOCK_VISITS = 12
+# Seconds between consecutive visits in the fake feed.
+MATOMO_MOCK_INTERVAL = 60
 
-def _matomo_visit(index: int, since_timestamp: int) -> dict:
-    """One synthetic visit, deterministic in `index` so tests can assert exactly."""
+
+def _matomo_visit(index: int) -> dict:
+    """One synthetic visit, fully determined by `index`."""
     cohort = MATOMO_COHORTS[index % len(MATOMO_COHORTS)]
     category, action = MATOMO_SAMPLE_EVENTS[index % len(MATOMO_SAMPLE_EVENTS)]
+    timestamp = MATOMO_MOCK_EPOCH + index * MATOMO_MOCK_INTERVAL
     return {
         "idVisit": str(index),
         # Flat, exactly as the real API returns it.
         "dimension1": cohort,
         "visitorId": f"visitor{index:04d}",
         "userId": None,
-        "firstActionTimestamp": since_timestamp + index,
-        "serverTimestamp": since_timestamp + index,
+        "firstActionTimestamp": timestamp,
+        "serverTimestamp": timestamp,
         "actionDetails": [
             {"type": "event", "eventCategory": category, "eventAction": action},
             {"type": "action", "url": f"https://openlibrary.org/works/OL{index}W/Mock_Book"},
         ],
     }
+
+
+def _matomo_form_int(form, key: str, default: int) -> int:
+    """Read an int from a form body.
+
+    Starlette types form values as `str | UploadFile`, hence the str() before
+    int(); a non-numeric value is a caller error and should surface as one.
+    """
+    raw = form.get(key, default)
+    try:
+        return int(str(raw))
+    except TypeError, ValueError:
+        raise ValueError(f"{key} must be an integer, got {raw!r}") from None
 
 
 @app.post("/matomo/index.php")
@@ -450,14 +476,21 @@ async def matomo_api(request: Request) -> JSONResponse:
     if method != "Live.getLastVisitsDetails":
         return JSONResponse({"result": "error", "message": f"Mock does not implement {method}"})
 
-    # Honour paging so the client's pagination loop is genuinely exercised.
-    total = int(str(form.get("mock_total_visits", "12")))
-    limit = int(str(form.get("filter_limit", "500")))
-    offset = int(str(form.get("filter_offset", "0")))
-    since = int(str(form.get("minTimestamp", "0")))
+    try:
+        limit = _matomo_form_int(form, "filter_limit", 500)
+        offset = _matomo_form_int(form, "filter_offset", 0)
+        since = _matomo_form_int(form, "minTimestamp", 0)
+    except ValueError as exc:
+        return JSONResponse({"result": "error", "message": str(exc)})
+    if limit < 1 or offset < 0:
+        return JSONResponse({"result": "error", "message": "filter_limit must be >= 1 and filter_offset >= 0"})
 
-    visits = [_matomo_visit(i, since) for i in range(offset, min(offset + limit, total))]
-    return JSONResponse(visits)
+    # Filter on the feed's own timestamps, so `minTimestamp` is actually honoured
+    # and a narrower window really does return fewer visits. Newest first, which
+    # is the order the real endpoint uses and what makes paging overlap possible.
+    feed = [v for v in (_matomo_visit(i) for i in range(MATOMO_MOCK_VISITS)) if v["firstActionTimestamp"] >= since]
+    feed.reverse()
+    return JSONResponse(feed[offset : offset + limit])
 
 
 # ---------------------------------------------------------------------------

--- a/docker/mockservices/main.py
+++ b/docker/mockservices/main.py
@@ -386,6 +386,77 @@ async def amazon_get_items(request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# Matomo Reporting API  (Core Vitals retention scoring, issue #11956)
+# POST /matomo/index.php
+#
+# matomo.archive.org is restricted to IA's network, so retention scoring is
+# otherwise untestable locally. Point the client at this instead:
+#   MATOMO_URL=http://mockservices:8090/matomo
+#
+# Returns visits in the exact shape Live.getLastVisitsDetails does, which is
+# the part worth mocking faithfully: `dimension1` is a FLAT field on the visit
+# (not nested under `customDimensions`, which this endpoint deliberately never
+# returns), and engagement lives in `actionDetails` as a mix of `event` and
+# `action` entries. Reading dimension1 from the wrong place is a real bug this
+# pipeline shipped, so the mock encodes the true wire format.
+# ---------------------------------------------------------------------------
+
+MATOMO_COHORTS = ["visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"]
+
+# (eventCategory, eventAction) pairs the scorer recognises, plus one it does
+# not, so tests can assert unmapped events are ignored rather than crashing.
+MATOMO_SAMPLE_EVENTS = [
+    ("CTAClick", "Read"),
+    ("CTAClick", "Borrow"),
+    ("CTAClick", "Edit"),
+    ("ReadingLog", "WantToRead"),
+    ("MainNav", "MyBooks"),
+    ("PatronImports", "Goodreads"),
+    ("SearchModal", "Open"),
+]
+
+
+def _matomo_visit(index: int, since_timestamp: int) -> dict:
+    """One synthetic visit, deterministic in `index` so tests can assert exactly."""
+    cohort = MATOMO_COHORTS[index % len(MATOMO_COHORTS)]
+    category, action = MATOMO_SAMPLE_EVENTS[index % len(MATOMO_SAMPLE_EVENTS)]
+    return {
+        "idVisit": str(index),
+        # Flat, exactly as the real API returns it.
+        "dimension1": cohort,
+        "visitorId": f"visitor{index:04d}",
+        "userId": None,
+        "firstActionTimestamp": since_timestamp + index,
+        "serverTimestamp": since_timestamp + index,
+        "actionDetails": [
+            {"type": "event", "eventCategory": category, "eventAction": action},
+            {"type": "action", "url": f"https://openlibrary.org/works/OL{index}W/Mock_Book"},
+        ],
+    }
+
+
+@app.post("/matomo/index.php")
+async def matomo_api(request: Request) -> JSONResponse:
+    form = await request.form()
+    method = str(form.get("method", ""))
+
+    if not form.get("token_auth"):
+        return JSONResponse({"result": "error", "message": "Requests to the API must be authenticated"})
+
+    if method != "Live.getLastVisitsDetails":
+        return JSONResponse({"result": "error", "message": f"Mock does not implement {method}"})
+
+    # Honour paging so the client's pagination loop is genuinely exercised.
+    total = int(str(form.get("mock_total_visits", "12")))
+    limit = int(str(form.get("filter_limit", "500")))
+    offset = int(str(form.get("filter_offset", "0")))
+    since = int(str(form.get("minTimestamp", "0")))
+
+    visits = [_matomo_visit(i, since) for i in range(offset, min(offset + limit, total))]
+    return JSONResponse(visits)
+
+
+# ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
 

--- a/docker/mockservices/tests/conftest.py
+++ b/docker/mockservices/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Make the repo root importable for the tests in this directory.
+
+These tests import ``openlibrary.core.matomo`` to exercise the mock Matomo feed
+over real HTTP. That works inside the dev containers only because
+the image sets ``PYTHONPATH=/openlibrary``; GitHub CI sets no such thing.
+
+pytest's default ``prepend`` import mode inserts a test module's *basedir* onto
+``sys.path`` -- the first ancestor directory without an ``__init__.py``. For
+tests under ``openlibrary/tests/`` that walk lands on the repo root, so
+``openlibrary`` imports fine. This directory has no ``__init__.py`` chain, so the
+basedir is this directory, and ``import openlibrary`` fails at collection with
+``ModuleNotFoundError`` -- which is exactly how CI broke.
+
+Adding ``__init__.py`` files here would be the other fix, but ``main.py`` and
+``requirements.txt`` in this tree are copied into the mockservices container as
+flat files (see ``docker/mockservices/Dockerfile``), and turning it into a
+package for the benefit of the test runner would misrepresent what it is.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[3]
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/docker/mockservices/tests/test_e2e.py
+++ b/docker/mockservices/tests/test_e2e.py
@@ -16,13 +16,10 @@ code sends (see openlibrary/accounts/model.py, openlibrary/core/lending.py),
 not just what's convenient to construct.
 """
 
-import datetime
 import os
 
 import pytest
 import requests
-
-from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_URL = os.environ.get("MOCKSERVICES_URL", "http://mockservices:8090")
 
@@ -216,65 +213,15 @@ class TestLoanChangesFeed:
 
 
 # ---------------------------------------------------------------------------
-# Matomo mock — Core Vitals retention scoring (issue #11956)
+# Matomo mock — the parts that need a live container.
 #
-# matomo.archive.org is IP-restricted to IA's network, so this is the only way
-# to exercise the real MatomoClient and the real scorer end to end in dev or CI.
-# The feed is small and deterministic on purpose: the expected R_total below is
-# worked out by hand from the fixture, so a scoring regression shows up as an
-# arithmetic mismatch rather than "some number changed".
+# Everything else about this endpoint is covered by test_matomo_inprocess.py,
+# which serves the same app on a loopback port and therefore also runs in CI.
+# Only keep tests here that genuinely require the deployed container.
 # ---------------------------------------------------------------------------
 
 
 class TestMatomoMock:
-    """The 12-visit default feed, and the exact score it must produce.
-
-    Visit i has cohort MATOMO_COHORTS[i % 7] and event MATOMO_SAMPLE_EVENTS[i % 7],
-    plus a /works/ page view worth book_view (5) on every visit:
-
-        i=0  visitor  CTAClick|Read          read 100 + 5 = 105
-        i=1  d0       CTAClick|Borrow        read 100 + 5 = 105
-        i=2  d1+      CTAClick|Edit          edit  25 + 5 =  30
-        i=3  d7+      ReadingLog|WantToRead  want   10 + 5 =  15
-        i=4  d14+     MainNav|MyBooks        mybooks 5 + 5 =  10
-        i=5  d30+     PatronImports|Goodreads  gr 200 + 5 = 205
-        i=6  d90+     SearchModal|Open       (unmapped) + 5 =   5
-        i=7..11 repeat the cycle from i=0
-
-        visitor    210 x 0.01 =   2.10   (2 patrons)
-        registrant 210 x 0.20 =  42.00   (2 patrons, d0)
-        returning  315 x 0.50 = 157.50   (7 patrons, d1+/d7+/d14+/d30+)
-        retained     5 x 1.00 =   5.00   (1 patron, d90+)
-                              = 206.60 over 12 patrons
-    """
-
-    EXPECTED_R_TOTAL = 206.60
-    EXPECTED_PATRONS = 12
-
-    @pytest.fixture
-    def client(self):
-        return MatomoClient("mock-token", url=f"{MOCKSERVICES_URL}/matomo")
-
-    def test_requires_a_token(self):
-        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails"})
-        assert resp.json()["result"] == "error"
-
     def test_rejects_unimplemented_methods(self):
         resp = _post("/matomo/index.php", data={"method": "SitesManager.getAllSites", "token_auth": "t"})
         assert resp.json()["result"] == "error"
-
-    def test_dimension1_is_flat_not_nested(self):
-        """The real API returns dimension1 flat; reading it as nested scored every visit as `visitor`."""
-        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails", "token_auth": "t"})
-        visit = resp.json()[0]
-        assert visit["dimension1"] == "visitor"
-        assert "customDimensions" not in visit
-
-    def test_client_fetches_the_whole_feed_through_real_http(self, client):
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert len(visits) == 12
-
-    def test_client_pagination_is_exercised(self, client):
-        """A page_size below the feed size must still return everything, in order."""
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
-        assert [v["idVisit"] for v in visits] == [str(i) for i in range(12)]

--- a/docker/mockservices/tests/test_e2e.py
+++ b/docker/mockservices/tests/test_e2e.py
@@ -16,10 +16,13 @@ code sends (see openlibrary/accounts/model.py, openlibrary/core/lending.py),
 not just what's convenient to construct.
 """
 
+import datetime
 import os
 
 import pytest
 import requests
+
+from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_URL = os.environ.get("MOCKSERVICES_URL", "http://mockservices:8090")
 
@@ -210,3 +213,68 @@ class TestLoanChangesFeed:
     def test_missing_action_returns_422(self):
         resp = _get("/services/loans/loan/")
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Matomo mock — Core Vitals retention scoring (issue #11956)
+#
+# matomo.archive.org is IP-restricted to IA's network, so this is the only way
+# to exercise the real MatomoClient and the real scorer end to end in dev or CI.
+# The feed is small and deterministic on purpose: the expected R_total below is
+# worked out by hand from the fixture, so a scoring regression shows up as an
+# arithmetic mismatch rather than "some number changed".
+# ---------------------------------------------------------------------------
+
+
+class TestMatomoMock:
+    """The 12-visit default feed, and the exact score it must produce.
+
+    Visit i has cohort MATOMO_COHORTS[i % 7] and event MATOMO_SAMPLE_EVENTS[i % 7],
+    plus a /works/ page view worth book_view (5) on every visit:
+
+        i=0  visitor  CTAClick|Read          read 100 + 5 = 105
+        i=1  d0       CTAClick|Borrow        read 100 + 5 = 105
+        i=2  d1+      CTAClick|Edit          edit  25 + 5 =  30
+        i=3  d7+      ReadingLog|WantToRead  want   10 + 5 =  15
+        i=4  d14+     MainNav|MyBooks        mybooks 5 + 5 =  10
+        i=5  d30+     PatronImports|Goodreads  gr 200 + 5 = 205
+        i=6  d90+     SearchModal|Open       (unmapped) + 5 =   5
+        i=7..11 repeat the cycle from i=0
+
+        visitor    210 x 0.01 =   2.10   (2 patrons)
+        registrant 210 x 0.20 =  42.00   (2 patrons, d0)
+        returning  315 x 0.50 = 157.50   (7 patrons, d1+/d7+/d14+/d30+)
+        retained     5 x 1.00 =   5.00   (1 patron, d90+)
+                              = 206.60 over 12 patrons
+    """
+
+    EXPECTED_R_TOTAL = 206.60
+    EXPECTED_PATRONS = 12
+
+    @pytest.fixture
+    def client(self):
+        return MatomoClient("mock-token", url=f"{MOCKSERVICES_URL}/matomo")
+
+    def test_requires_a_token(self):
+        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails"})
+        assert resp.json()["result"] == "error"
+
+    def test_rejects_unimplemented_methods(self):
+        resp = _post("/matomo/index.php", data={"method": "SitesManager.getAllSites", "token_auth": "t"})
+        assert resp.json()["result"] == "error"
+
+    def test_dimension1_is_flat_not_nested(self):
+        """The real API returns dimension1 flat; reading it as nested scored every visit as `visitor`."""
+        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails", "token_auth": "t"})
+        visit = resp.json()[0]
+        assert visit["dimension1"] == "visitor"
+        assert "customDimensions" not in visit
+
+    def test_client_fetches_the_whole_feed_through_real_http(self, client):
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert len(visits) == 12
+
+    def test_client_pagination_is_exercised(self, client):
+        """A page_size below the feed size must still return everything, in order."""
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
+        assert [v["idVisit"] for v in visits] == [str(i) for i in range(12)]

--- a/docker/mockservices/tests/test_e2e.py
+++ b/docker/mockservices/tests/test_e2e.py
@@ -16,10 +16,13 @@ code sends (see openlibrary/accounts/model.py, openlibrary/core/lending.py),
 not just what's convenient to construct.
 """
 
+import datetime
 import os
 
 import pytest
 import requests
+
+from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_URL = os.environ.get("MOCKSERVICES_URL", "http://mockservices:8090")
 
@@ -198,3 +201,68 @@ class TestLoanChangesFeed:
     def test_missing_action_returns_422(self):
         resp = _get("/services/loans/loan/")
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Matomo mock — Core Vitals retention scoring (issue #11956)
+#
+# matomo.archive.org is IP-restricted to IA's network, so this is the only way
+# to exercise the real MatomoClient and the real scorer end to end in dev or CI.
+# The feed is small and deterministic on purpose: the expected R_total below is
+# worked out by hand from the fixture, so a scoring regression shows up as an
+# arithmetic mismatch rather than "some number changed".
+# ---------------------------------------------------------------------------
+
+
+class TestMatomoMock:
+    """The 12-visit default feed, and the exact score it must produce.
+
+    Visit i has cohort MATOMO_COHORTS[i % 7] and event MATOMO_SAMPLE_EVENTS[i % 7],
+    plus a /works/ page view worth book_view (5) on every visit:
+
+        i=0  visitor  CTAClick|Read          read 100 + 5 = 105
+        i=1  d0       CTAClick|Borrow        read 100 + 5 = 105
+        i=2  d1+      CTAClick|Edit          edit  25 + 5 =  30
+        i=3  d7+      ReadingLog|WantToRead  want   10 + 5 =  15
+        i=4  d14+     MainNav|MyBooks        mybooks 5 + 5 =  10
+        i=5  d30+     PatronImports|Goodreads  gr 200 + 5 = 205
+        i=6  d90+     SearchModal|Open       (unmapped) + 5 =   5
+        i=7..11 repeat the cycle from i=0
+
+        visitor    210 x 0.01 =   2.10   (2 patrons)
+        registrant 210 x 0.20 =  42.00   (2 patrons, d0)
+        returning  315 x 0.50 = 157.50   (7 patrons, d1+/d7+/d14+/d30+)
+        retained     5 x 1.00 =   5.00   (1 patron, d90+)
+                              = 206.60 over 12 patrons
+    """
+
+    EXPECTED_R_TOTAL = 206.60
+    EXPECTED_PATRONS = 12
+
+    @pytest.fixture
+    def client(self):
+        return MatomoClient("mock-token", url=f"{MOCKSERVICES_URL}/matomo")
+
+    def test_requires_a_token(self):
+        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails"})
+        assert resp.json()["result"] == "error"
+
+    def test_rejects_unimplemented_methods(self):
+        resp = _post("/matomo/index.php", data={"method": "SitesManager.getAllSites", "token_auth": "t"})
+        assert resp.json()["result"] == "error"
+
+    def test_dimension1_is_flat_not_nested(self):
+        """The real API returns dimension1 flat; reading it as nested scored every visit as `visitor`."""
+        resp = _post("/matomo/index.php", data={"method": "Live.getLastVisitsDetails", "token_auth": "t"})
+        visit = resp.json()[0]
+        assert visit["dimension1"] == "visitor"
+        assert "customDimensions" not in visit
+
+    def test_client_fetches_the_whole_feed_through_real_http(self, client):
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert len(visits) == 12
+
+    def test_client_pagination_is_exercised(self, client):
+        """A page_size below the feed size must still return everything, in order."""
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
+        assert [v["idVisit"] for v in visits] == [str(i) for i in range(12)]

--- a/docker/mockservices/tests/test_matomo_inprocess.py
+++ b/docker/mockservices/tests/test_matomo_inprocess.py
@@ -1,0 +1,129 @@
+"""End-to-end retention scoring over real HTTP, with no container required.
+
+``test_e2e.py`` next door covers the same ground but skips unless the
+mockservices *container* is reachable -- and GitHub CI runs ``make test-py`` with
+no containers at all, so those tests skip there and catch nothing. This module
+closes that gap: it serves the *same* mock app in-process on an ephemeral
+loopback port, so the real ``MatomoClient`` makes real HTTP requests and parses
+real JSON on every CI run.
+
+It lives here rather than under ``openlibrary/tests/`` deliberately.
+``openlibrary/conftest.py`` has an autouse ``no_requests`` fixture that blocks
+``requests`` outright, and overriding a repo-wide safety net to let one test
+through is the wrong trade. This directory is already outside that guard,
+already collected by ``make test-py``, and already the home for tests that speak
+to a mock service over HTTP.
+
+That matters because the bugs in this area live precisely in the seam between
+Matomo's wire format and our parsing of it -- for instance ``dimension1``, which
+this endpoint returns flat and which an earlier prototype read from a nested
+structure the API never sends, silently mislabelling every visit. Unit tests with
+a stubbed client cannot see that. This can.
+
+The mock app is loaded from ``docker/mockservices/main.py`` by path rather than
+copied, so there is one definition of the fake feed and it cannot drift from
+what the container serves.
+"""
+
+import datetime
+import importlib.util
+import pathlib
+import socket
+import threading
+import time
+
+import pytest
+import requests
+
+from openlibrary.core.matomo import MatomoClient
+
+MOCKSERVICES_MAIN = pathlib.Path(__file__).parents[1] / "main.py"
+
+# The mock's default feed size, and the cohorts it cycles through. Asserted here
+# so a change to the fake feed cannot quietly invalidate the tests that consume it.
+EXPECTED_VISITS = 12
+EXPECTED_COHORTS = {"visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"}
+
+
+def _load_mock_app():
+    """Import docker/mockservices/main.py by path; it is not an installed package."""
+    spec = importlib.util.spec_from_file_location("ol_mockservices_main", MOCKSERVICES_MAIN)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        pytest.skip(f"could not load {MOCKSERVICES_MAIN}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def matomo_url():
+    """Serve the mockservices app on localhost for the duration of the module."""
+    uvicorn = pytest.importorskip("uvicorn", reason="uvicorn is needed to serve the mock in-process")
+    pytest.importorskip("fastapi", reason="fastapi is needed to build the mock app")
+
+    port = _free_port()
+    config = uvicorn.Config(_load_mock_app(), host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 30
+    while not server.started:
+        if time.monotonic() > deadline:  # pragma: no cover - CI safety valve
+            server.should_exit = True
+            pytest.fail("mock Matomo server did not start within 30s")
+        time.sleep(0.05)
+
+    yield f"http://127.0.0.1:{port}/matomo"
+
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+@pytest.fixture
+def client(matomo_url):
+    return MatomoClient("mock-token", url=matomo_url)
+
+
+class TestWireFormat:
+    def test_dimension1_arrives_flat_on_the_visit(self, client):
+        """Bug 1 lived here: `customDimensions` is never returned by this endpoint."""
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert visits
+        assert visits[0]["dimension1"] == "visitor"
+        assert all("customDimensions" not in visit for visit in visits)
+
+    def test_all_seven_cohorts_survive_the_round_trip(self, client):
+        """The cohort labels are the contract between Matomo and any future scorer."""
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert {visit["dimension1"] for visit in visits} == EXPECTED_COHORTS
+
+    def test_action_details_carry_events_and_page_views(self, client):
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        types = {action["type"] for visit in visits for action in visit["actionDetails"]}
+        assert types == {"event", "action"}
+
+    def test_a_caller_cannot_strip_the_token(self, client):
+        """Fixed keys are applied after caller params, so the real token always wins."""
+        assert client._post("Live.getLastVisitsDetails", token_auth="") != []
+
+    def test_the_mock_rejects_an_unauthenticated_request(self, matomo_url):
+        """Matomo answers 200 with an error body rather than an HTTP status code."""
+        body = requests.post(f"{matomo_url}/index.php", data={"method": "Live.getLastVisitsDetails"}, timeout=10).json()
+        assert body["result"] == "error"
+
+
+class TestPaginationOverHttp:
+    def test_a_short_page_size_still_returns_the_whole_feed_in_order(self, client):
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
+        assert [visit["idVisit"] for visit in visits] == [str(i) for i in range(EXPECTED_VISITS)]
+
+    def test_page_size_larger_than_the_feed_is_a_single_request(self, client):
+        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
+        assert len(visits) == EXPECTED_VISITS

--- a/docker/mockservices/tests/test_matomo_inprocess.py
+++ b/docker/mockservices/tests/test_matomo_inprocess.py
@@ -1,4 +1,4 @@
-"""End-to-end retention scoring over real HTTP, with no container required.
+"""The Matomo client against a real HTTP server, with no container required.
 
 ``test_e2e.py`` next door covers the same ground but skips unless the
 mockservices *container* is reachable -- and GitHub CI runs ``make test-py`` with
@@ -14,6 +14,10 @@ through is the wrong trade. This directory is already outside that guard,
 already collected by ``make test-py``, and already the home for tests that speak
 to a mock service over HTTP.
 
+Note this shares source with the container but not its pinned runtime: the
+container installs its own fastapi/uvicorn (``docker/mockservices/requirements.txt``)
+while this runs them from the root requirements. Code fidelity, not runtime fidelity.
+
 That matters because the bugs in this area live precisely in the seam between
 Matomo's wire format and our parsing of it -- for instance ``dimension1``, which
 this endpoint returns flat and which an earlier prototype read from a nested
@@ -28,7 +32,6 @@ what the container serves.
 import datetime
 import importlib.util
 import pathlib
-import socket
 import threading
 import time
 
@@ -39,26 +42,33 @@ from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_MAIN = pathlib.Path(__file__).parents[1] / "main.py"
 
-# The mock's default feed size, and the cohorts it cycles through. Asserted here
-# so a change to the fake feed cannot quietly invalidate the tests that consume it.
-EXPECTED_VISITS = 12
+# The cohort labels are the contract between Matomo and any consumer, so they
+# are spelled out here independently of the mock. The feed *size* is a property
+# of the fixture rather than the contract, so it is read from the mock instead of
+# duplicated -- see expected_visits in the fixture below.
 EXPECTED_COHORTS = {"visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"}
 
 
-def _load_mock_app():
+def _load_mock_app_module():
     """Import docker/mockservices/main.py by path; it is not an installed package."""
     spec = importlib.util.spec_from_file_location("ol_mockservices_main", MOCKSERVICES_MAIN)
     if spec is None or spec.loader is None:  # pragma: no cover - defensive
-        pytest.skip(f"could not load {MOCKSERVICES_MAIN}")
+        # A breakage, not an unmet precondition: skipping here would silently
+        # reopen the CI gap this module exists to close.
+        pytest.fail(f"could not load {MOCKSERVICES_MAIN}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module.app
+    return module
 
 
-def _free_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def _load_mock_app():
+    return _load_mock_app_module().app
+
+
+@pytest.fixture(scope="module")
+def expected_visits():
+    """The mock's feed size, read from the mock rather than restated here."""
+    return _load_mock_app_module().MATOMO_MOCK_VISITS
 
 
 @pytest.fixture(scope="module")
@@ -67,19 +77,23 @@ def matomo_url():
     uvicorn = pytest.importorskip("uvicorn", reason="uvicorn is needed to serve the mock in-process")
     pytest.importorskip("fastapi", reason="fastapi is needed to build the mock app")
 
-    port = _free_port()
-    config = uvicorn.Config(_load_mock_app(), host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    # port=0 lets the kernel choose and uvicorn bind it, rather than picking a
+    # free port and binding it later -- which races under a parallel runner.
+    config = uvicorn.Config(_load_mock_app(), host="127.0.0.1", port=0, log_level="warning", lifespan="off")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
 
     deadline = time.monotonic() + 30
     while not server.started:
+        if not thread.is_alive():  # pragma: no cover - fail fast with the real cause
+            pytest.fail("mock Matomo server thread died during startup")
         if time.monotonic() > deadline:  # pragma: no cover - CI safety valve
             server.should_exit = True
             pytest.fail("mock Matomo server did not start within 30s")
         time.sleep(0.05)
 
+    port = server.servers[0].sockets[0].getsockname()[1]
     yield f"http://127.0.0.1:{port}/matomo"
 
     server.should_exit = True
@@ -91,27 +105,33 @@ def client(matomo_url):
     return MatomoClient("mock-token", url=matomo_url)
 
 
+def _recent() -> datetime.datetime:
+    """A `since` early enough to include the mock's whole fixed-epoch feed."""
+    return datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=6)
+
+
 class TestWireFormat:
     def test_dimension1_arrives_flat_on_the_visit(self, client):
-        """Bug 1 lived here: `customDimensions` is never returned by this endpoint."""
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert visits
-        assert visits[0]["dimension1"] == "visitor"
-        assert all("customDimensions" not in visit for visit in visits)
+        """This endpoint never returns the nested `customDimensions` it looks like it should."""
+        fetch = client.get_visits_since(_recent())
+        assert fetch.visits
+        assert all(visit["dimension1"] in EXPECTED_COHORTS for visit in fetch.visits)
+        assert all("customDimensions" not in visit for visit in fetch.visits)
 
-    def test_all_seven_cohorts_survive_the_round_trip(self, client):
-        """The cohort labels are the contract between Matomo and any future scorer."""
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert {visit["dimension1"] for visit in visits} == EXPECTED_COHORTS
+    def test_every_cohort_label_survives_the_round_trip(self, client):
+        """The cohort labels are the contract between Matomo and any consumer."""
+        fetch = client.get_visits_since(_recent())
+        assert {visit["dimension1"] for visit in fetch.visits} == EXPECTED_COHORTS
 
     def test_action_details_carry_events_and_page_views(self, client):
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        types = {action["type"] for visit in visits for action in visit["actionDetails"]}
+        fetch = client.get_visits_since(_recent())
+        types = {action["type"] for visit in fetch.visits for action in visit["actionDetails"]}
         assert types == {"event", "action"}
 
-    def test_a_caller_cannot_strip_the_token(self, client):
+    def test_a_caller_cannot_strip_the_token(self, client, expected_visits):
         """Fixed keys are applied after caller params, so the real token always wins."""
-        assert client._post("Live.getLastVisitsDetails", token_auth="") != []
+        rows = client._post("Live.getLastVisitsDetails", token_auth="", minTimestamp=0)
+        assert len(rows) == expected_visits
 
     def test_the_mock_rejects_an_unauthenticated_request(self, matomo_url):
         """Matomo answers 200 with an error body rather than an HTTP status code."""
@@ -120,10 +140,44 @@ class TestWireFormat:
 
 
 class TestPaginationOverHttp:
-    def test_a_short_page_size_still_returns_the_whole_feed_in_order(self, client):
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
-        assert [visit["idVisit"] for visit in visits] == [str(i) for i in range(EXPECTED_VISITS)]
+    def test_a_short_page_size_still_returns_the_whole_feed(self, client, expected_visits):
+        fetch = client.get_visits_since(_recent(), page_size=5)
+        assert len(fetch.visits) == expected_visits
+        # Newest first, which is the order the real endpoint uses.
+        ids = [int(visit["idVisit"]) for visit in fetch.visits]
+        assert ids == sorted(ids, reverse=True)
 
-    def test_page_size_larger_than_the_feed_is_a_single_request(self, client):
-        visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
-        assert len(visits) == EXPECTED_VISITS
+    def test_no_visit_is_returned_twice_across_pages(self, client, expected_visits):
+        fetch = client.get_visits_since(_recent(), page_size=5)
+        ids = [visit["idVisit"] for visit in fetch.visits]
+        assert len(ids) == len(set(ids)) == expected_visits
+
+    def test_a_page_size_over_the_feed_size_returns_everything(self, client, expected_visits):
+        fetch = client.get_visits_since(_recent(), page_size=500)
+        assert len(fetch.visits) == expected_visits
+
+    def test_a_clean_fetch_is_not_flagged_truncated(self, client):
+        fetch = client.get_visits_since(_recent())
+        assert fetch.truncated is False
+        assert fetch.truncated_reason is None
+
+
+class TestWindowFiltering:
+    """`minTimestamp` is honoured by the mock, so window behaviour is testable.
+
+    The fake feed is stamped from a fixed epoch rather than from the caller's
+    filter; deriving it from the filter would make every visit pass by
+    construction and this whole class vacuous.
+    """
+
+    def test_a_window_after_the_whole_feed_returns_nothing(self, client):
+        fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1))
+        assert fetch.visits == []
+        assert fetch.truncated is False
+
+    def test_a_narrower_window_returns_fewer_visits(self, client, expected_visits):
+        module = _load_mock_app_module()
+        epoch, interval = module.MATOMO_MOCK_EPOCH, module.MATOMO_MOCK_INTERVAL
+        # Halfway through the feed, so roughly half the visits are excluded.
+        midpoint = datetime.datetime.fromtimestamp(epoch + (expected_visits // 2) * interval, datetime.UTC)
+        assert 0 < len(client.get_visits_since(midpoint).visits) < expected_visits

--- a/openlibrary/core/matomo.py
+++ b/openlibrary/core/matomo.py
@@ -1,0 +1,207 @@
+"""Minimal read-only Matomo Reporting API client, for Core Vitals retention scoring.
+
+Groundwork for the Core Vitals Retention Score (issue #11956): the scorer that
+consumes this lands separately, so that the access layer -- where the token
+handling and the read-only guarantees live -- can be reviewed on its own terms
+rather than alongside a scoring formula. See ``ol-kb/wiki/core-vitals.md``.
+
+Deliberately knows nothing about scoring. Retention is computed entirely from
+Matomo and is intended to move into a standalone Core Vitals service, so this
+module imports nothing from Open Library and should stay that way -- the move
+should be a file copy, not an untangling.
+
+The Matomo instance (``matomo.archive.org``, site ID 6 = openlibrary.org) is
+restricted to Internet Archive's internal network. Production runs on IA
+infrastructure and reaches it directly. From a developer machine, set
+``HTTPS_PROXY`` to an allowlisted forward proxy -- ``requests`` picks that up
+from the environment automatically, so nothing here needs to know about it.
+
+To work with no Matomo access at all, point ``MATOMO_URL`` at the mock in
+``docker/mockservices``, which serves the same wire format from a small,
+predictable visit feed::
+
+    MATOMO_URL=http://mockservices:8090/matomo
+"""
+
+import datetime
+import logging
+import os
+import time
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger("openlibrary.matomo")
+
+MATOMO_URL = "https://matomo.archive.org"
+MATOMO_SITE_ID = 6
+
+# Live.getLastVisitsDetails is paginated; cap total pages so a runaway
+# response can never spin a scheduled job forever. See also `budget_seconds`,
+# which bounds wall-clock rather than request count.
+MAX_PAGES = 200
+
+# Matomo's own raw-log retention is finite, and a longer request is far more
+# likely to be a mistake than an intent.
+MAX_WINDOW = datetime.timedelta(days=7)
+
+
+class MatomoError(Exception):
+    pass
+
+
+class MatomoClient:
+    """Read-only client for the Matomo Reporting API.
+
+    READ-ONLY BY INTENT.
+
+    This client must never call a Matomo API method that writes, deletes, or
+    otherwise mutates data -- the instance holds production analytics for
+    openlibrary.org and a destructive call would be irreversible.
+
+    :attr:`_ALLOWED_METHODS` is an exact-match allowlist, and :meth:`_post`
+    applies caller params before the fixed keys so nothing can redirect the
+    request at another module, site, or token. Treat that as a guardrail against
+    mistakes, **not** as a security boundary: the token itself is the only real
+    control, so the credential in ``matomo_api`` should be a view-only Matomo
+    user. An earlier prefix-based allowlist here was bypassable via
+    ``API.getBulkRequest``, which tunnels arbitrary methods inside an ``API.``
+    call -- hence exact matching.
+    """
+
+    # Extend only with methods this codebase actually calls, and only read ones.
+    _ALLOWED_METHODS = frozenset({"Live.getLastVisitsDetails"})
+
+    def __init__(self, token: str, url: str = "", site_id: int = 0, budget_seconds: int = 300) -> None:
+        if not token:
+            raise MatomoError("A Matomo API token is required (set `matomo_api` in openlibrary.yml)")
+        self._token = token
+        # Read the environment here rather than at import time so a test or a
+        # dev shell can retarget the client without reimporting the module. An
+        # unset environment always means production, never something in between.
+        self.url = (url or os.environ.get("MATOMO_URL") or MATOMO_URL).rstrip("/")
+        self.site_id = site_id or int(os.environ.get("MATOMO_SITE_ID") or MATOMO_SITE_ID)
+        self.timeout = 30
+        # `timeout` is per socket read, so it bounds no overall duration. This is
+        # the real wall clock, checked between pages.
+        self.budget_seconds = budget_seconds
+        # Set when a fetch stops early; callers surface it rather than reporting
+        # a truncated hour as a quiet one.
+        self.truncated = False
+        # One connection reused across pages instead of a fresh TLS handshake per
+        # request, with a short retry so a single transient 5xx mid-pagination
+        # does not leave a hole in the series.
+        self._session = requests.Session()
+        retries = Retry(total=3, backoff_factor=0.5, status_forcelist=(502, 503, 504), allowed_methods=frozenset({"POST"}))
+        self._session.mount("https://", HTTPAdapter(max_retries=retries))
+        self._session.mount("http://", HTTPAdapter(max_retries=retries))
+
+    def _post(self, method: str, **params) -> list | dict:
+        """Issue a single read-only Reporting API call.
+
+        Uses POST rather than GET so the auth token travels in the request body
+        instead of the query string, keeping it out of access and proxy logs.
+
+        Caller params are applied *before* the fixed keys, so no caller can
+        redirect this at another ``module``, site, or token.
+        """
+        if method not in self._ALLOWED_METHODS:
+            raise MatomoError(f"BLOCKED: {method!r} is not in the read-only allowlist; this client must never mutate Matomo data")
+
+        payload = {
+            **params,
+            "module": "API",
+            "method": method,
+            "format": "json",
+            "idSite": self.site_id,
+            "token_auth": self._token,
+        }
+        try:
+            response = self._session.post(f"{self.url}/index.php", data=payload, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+        except requests.RequestException as exc:
+            raise MatomoError(f"Matomo API request failed ({method}): {exc}") from exc
+        except ValueError as exc:
+            raise MatomoError(f"Matomo API returned a non-JSON response ({method})") from exc
+
+        if isinstance(data, dict) and data.get("result") == "error":
+            raise MatomoError(f"Matomo API error ({method}): {data.get('message')}")
+        return data
+
+    def get_visits_since(self, since: datetime.datetime, page_size: int = 500) -> list[dict]:
+        """Return every visit active since ``since``, paginating as needed.
+
+        Each visit dict carries a flat top-level ``dimension1`` field holding the
+        patron's "Days Since Registration" bucket (visitor/d0/d1+/d7+/d14+/d30+/d90+,
+        set by ``get_days_registered()`` in ``openlibrary/accounts/__init__.py``) and
+        an ``actionDetails`` list of that visit's page views and custom events.
+
+        Note ``dimension1`` is flat, NOT nested under a ``customDimensions`` key --
+        ``Live.getLastVisitsDetails`` does not return that structure, and reading it
+        as though it did silently classifies every visit as ``visitor``.
+        """
+        if since > (now := datetime.datetime.now(datetime.UTC)):
+            raise MatomoError(f"`since` is in the future ({since.isoformat()})")
+        if (now - since) > MAX_WINDOW:
+            raise MatomoError(f"Windows longer than {MAX_WINDOW.days} days are not supported; asked for {(now - since).days} days")
+
+        since_timestamp = int(since.timestamp())
+        # Bound the date range by `since` rather than a fixed `last7`, which
+        # silently clamped any longer window to 7 days while still reporting the
+        # window that was asked for.
+        #
+        # Padded by a day at each end because Matomo interprets `date` in the
+        # *site's* configured timezone while `since` is UTC. Without the padding a
+        # site behind UTC drops the earliest hours of the window: measured
+        # 2026-07-31, an exact UTC range returned 0 visits for the 06:00 hour
+        # because 06:00 UTC is the previous day in the site's timezone.
+        # `minTimestamp` still does the precise filtering; this only has to be
+        # wide enough not to exclude anything.
+        day = datetime.timedelta(days=1)
+        date_range = f"{(since - day).date().isoformat()},{(now + day).date().isoformat()}"
+
+        visits: list[dict] = []
+        seen_visit_ids: set[str] = set()
+        deadline = time.monotonic() + self.budget_seconds
+        self.truncated = False
+
+        for _page in range(MAX_PAGES):
+            if time.monotonic() > deadline:
+                self.truncated = True
+                logger.warning("Matomo fetch exceeded its %ds budget after %d visits; results are truncated", self.budget_seconds, len(visits))
+                break
+
+            batch = self._post(
+                "Live.getLastVisitsDetails",
+                period="range",
+                date=date_range,
+                minTimestamp=since_timestamp,
+                filter_limit=page_size,
+                # Offset by what we actually hold: Matomo enforces server-side row
+                # caps, so a page can legitimately be shorter than `page_size`, and
+                # stepping by `page * page_size` would skip records.
+                filter_offset=len(visits),
+            )
+            # Stop only on an empty page. A short-but-non-empty page means the
+            # server capped the row count, not that the feed is exhausted --
+            # treating it as the end silently truncates the score.
+            if not batch:
+                break
+            if not isinstance(batch, list):
+                raise MatomoError(f"Expected a list of visits, got {type(batch).__name__}")
+
+            # The feed is newest-first and live, so visits arriving mid-pagination
+            # shift the window and re-present records we already hold. Patron
+            # counts survive that (they are sets) but points would double-count.
+            fresh = [visit for visit in batch if str(visit.get("idVisit", "")) not in seen_visit_ids]
+            seen_visit_ids.update(str(visit.get("idVisit", "")) for visit in batch)
+            visits.extend(fresh)
+            if not fresh:
+                break
+        else:
+            self.truncated = True
+            logger.warning("Matomo visit pagination hit the %d-page cap; results are truncated", MAX_PAGES)
+
+        return visits

--- a/openlibrary/core/matomo.py
+++ b/openlibrary/core/matomo.py
@@ -1,24 +1,17 @@
-"""Minimal read-only Matomo Reporting API client, for Core Vitals retention scoring.
+"""Read-only Matomo Reporting API client.
 
-Groundwork for the Core Vitals Retention Score (issue #11956): the scorer that
-consumes this lands separately, so that the access layer -- where the token
-handling and the read-only guarantees live -- can be reviewed on its own terms
-rather than alongside a scoring formula. See ``ol-kb/wiki/core-vitals.md``.
+Groundwork for the Core Vitals Retention Score (issue #11956); the scorer that
+consumes it lands separately. See ``ol-kb/wiki/core-vitals.md`` for the formulas.
 
-Deliberately knows nothing about scoring. Retention is computed entirely from
-Matomo and is intended to move into a standalone Core Vitals service, so this
-module imports nothing from Open Library and should stay that way -- the move
-should be a file copy, not an untangling.
+Imports nothing from Open Library, deliberately: retention is computed entirely
+from Matomo and is intended to move into a standalone Core Vitals service, so
+that move should be a file copy rather than an untangling.
 
-The Matomo instance (``matomo.archive.org``, site ID 6 = openlibrary.org) is
-restricted to Internet Archive's internal network. Production runs on IA
-infrastructure and reaches it directly. From a developer machine, set
-``HTTPS_PROXY`` to an allowlisted forward proxy -- ``requests`` picks that up
-from the environment automatically, so nothing here needs to know about it.
-
-To work with no Matomo access at all, point ``MATOMO_URL`` at the mock in
-``docker/mockservices``, which serves the same wire format from a small,
-predictable visit feed::
+The instance (``matomo.archive.org``, site 6 = openlibrary.org) is restricted to
+Internet Archive's network; production reaches it directly. From a developer
+machine either set ``HTTPS_PROXY`` to an allowlisted forward proxy, which
+``requests`` picks up on its own, or point ``MATOMO_URL`` at the fake in
+``docker/mockservices`` to work with no Matomo access at all::
 
     MATOMO_URL=http://mockservices:8090/matomo
 """
@@ -27,6 +20,7 @@ import datetime
 import logging
 import os
 import time
+from dataclasses import dataclass, field
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -34,82 +28,97 @@ from urllib3.util.retry import Retry
 
 logger = logging.getLogger("openlibrary.matomo")
 
-MATOMO_URL = "https://matomo.archive.org"
-MATOMO_SITE_ID = 6
+DEFAULT_MATOMO_URL = "https://matomo.archive.org"
+DEFAULT_SITE_ID = 6
 
-# Live.getLastVisitsDetails is paginated; cap total pages so a runaway
-# response can never spin a scheduled job forever. See also `budget_seconds`,
-# which bounds wall-clock rather than request count.
+# A loop guard, not the operative limit: `if not batch` and `if not fresh`
+# already terminate against any well-behaved server. `budget_seconds` is the
+# bound an operator should actually tune.
 MAX_PAGES = 200
 
-# Matomo's own raw-log retention is finite, and a longer request is far more
+# Matomo's own raw-log retention is finite, so a longer request is far more
 # likely to be a mistake than an intent.
 MAX_WINDOW = datetime.timedelta(days=7)
 
 
 class MatomoError(Exception):
-    pass
+    """Matomo was unreachable, or answered with something unusable."""
+
+
+class MatomoMethodNotAllowed(MatomoError):
+    """A method outside the read-only allowlist was requested.
+
+    Distinct so that a caller handling "Matomo is flaky" cannot accidentally
+    swallow a programming error.
+    """
+
+
+@dataclass(frozen=True)
+class VisitFetch:
+    """The result of one fetch: the visits, and whether they are all of them.
+
+    `truncated_reason` carries the signal in the return value rather than as
+    state on the client, so a caller cannot read it a call too late and a type
+    checker can see it exists.
+    """
+
+    visits: list[dict] = field(default_factory=list)
+    truncated_reason: str | None = None
+
+    @property
+    def truncated(self) -> bool:
+        return self.truncated_reason is not None
+
+    def __len__(self) -> int:
+        return len(self.visits)
 
 
 class MatomoClient:
     """Read-only client for the Matomo Reporting API.
 
-    READ-ONLY BY INTENT.
+    Must never call a method that writes, deletes, or otherwise mutates: the
+    instance holds production analytics for openlibrary.org.
 
-    This client must never call a Matomo API method that writes, deletes, or
-    otherwise mutates data -- the instance holds production analytics for
-    openlibrary.org and a destructive call would be irreversible.
-
-    :attr:`_ALLOWED_METHODS` is an exact-match allowlist, and :meth:`_post`
-    applies caller params before the fixed keys so nothing can redirect the
-    request at another module, site, or token. Treat that as a guardrail against
-    mistakes, **not** as a security boundary: the token itself is the only real
-    control, so the credential in ``matomo_api`` should be a view-only Matomo
-    user. An earlier prefix-based allowlist here was bypassable via
-    ``API.getBulkRequest``, which tunnels arbitrary methods inside an ``API.``
-    call -- hence exact matching.
+    :attr:`_ALLOWED_METHODS` matches exactly, and :meth:`_post` applies caller
+    params before the fixed keys so nothing can redirect a request at another
+    module, site, or token. Both are guardrails against mistakes rather than a
+    security boundary -- the credential is the only real control, so the
+    configured token should belong to a view-only Matomo user.
     """
 
-    # Extend only with methods this codebase actually calls, and only read ones.
+    # Extend only with read methods this codebase actually calls. Exact matching
+    # rather than by prefix: `API.getBulkRequest` sits under `API.` and tunnels
+    # arbitrary methods through its own `urls[]` parameter.
     _ALLOWED_METHODS = frozenset({"Live.getLastVisitsDetails"})
 
-    def __init__(self, token: str, url: str = "", site_id: int = 0, budget_seconds: int = 300) -> None:
+    def __init__(self, token: str, url: str | None = None, site_id: int | None = None) -> None:
         if not token:
-            raise MatomoError("A Matomo API token is required (set `matomo_api` in openlibrary.yml)")
+            raise ValueError("A Matomo API token is required")
         self._token = token
-        # Read the environment here rather than at import time so a test or a
-        # dev shell can retarget the client without reimporting the module. An
-        # unset environment always means production, never something in between.
-        self.url = (url or os.environ.get("MATOMO_URL") or MATOMO_URL).rstrip("/")
-        self.site_id = site_id or int(os.environ.get("MATOMO_SITE_ID") or MATOMO_SITE_ID)
+        # Resolved here rather than at import time so a test or dev shell can
+        # retarget the client without reimporting. An unset environment always
+        # means production.
+        self.url = (url or os.environ.get("MATOMO_URL") or DEFAULT_MATOMO_URL).rstrip("/")
+        self.site_id = site_id if site_id is not None else int(os.environ.get("MATOMO_SITE_ID") or DEFAULT_SITE_ID)
         self.timeout = 30
-        # `timeout` is per socket read, so it bounds no overall duration. This is
-        # the real wall clock, checked between pages.
-        self.budget_seconds = budget_seconds
-        # Set when a fetch stops early; callers surface it rather than reporting
-        # a truncated hour as a quiet one.
-        self.truncated = False
-        # One connection reused across pages instead of a fresh TLS handshake per
-        # request, with a short retry so a single transient 5xx mid-pagination
-        # does not leave a hole in the series.
+        # One connection reused across pages, with a short retry so a single
+        # transient 5xx mid-pagination does not leave a hole in the series.
         self._session = requests.Session()
         retries = Retry(total=3, backoff_factor=0.5, status_forcelist=(502, 503, 504), allowed_methods=frozenset({"POST"}))
         self._session.mount("https://", HTTPAdapter(max_retries=retries))
         self._session.mount("http://", HTTPAdapter(max_retries=retries))
 
-    def _post(self, method: str, **params) -> list | dict:
-        """Issue a single read-only Reporting API call.
+    def _post(self, method: str, **params) -> list[dict]:
+        """Issue one read-only Reporting API call and return its rows.
 
-        Uses POST rather than GET so the auth token travels in the request body
-        instead of the query string, keeping it out of access and proxy logs.
-
-        Caller params are applied *before* the fixed keys, so no caller can
-        redirect this at another ``module``, site, or token.
+        POST rather than GET so the token travels in the body instead of the
+        query string, where proxies and access logs would capture it.
         """
         if method not in self._ALLOWED_METHODS:
-            raise MatomoError(f"BLOCKED: {method!r} is not in the read-only allowlist; this client must never mutate Matomo data")
+            raise MatomoMethodNotAllowed(f"{method!r} is not in the read-only allowlist; this client must never mutate Matomo data")
 
         payload = {
+            # Caller params first, so the fixed keys below always win.
             **params,
             "module": "API",
             "method": method,
@@ -128,50 +137,51 @@ class MatomoClient:
 
         if isinstance(data, dict) and data.get("result") == "error":
             raise MatomoError(f"Matomo API error ({method}): {data.get('message')}")
+        if not isinstance(data, list):
+            # Checked here rather than in the caller: an empty dict is falsy, so
+            # a caller testing emptiness first would read it as "end of feed".
+            raise MatomoError(f"Matomo API returned {type(data).__name__}, expected a list of rows ({method})")
         return data
 
-    def get_visits_since(self, since: datetime.datetime, page_size: int = 500) -> list[dict]:
-        """Return every visit active since ``since``, paginating as needed.
+    def _window(self, since: datetime.datetime) -> tuple[int, str]:
+        """Validate the requested window; return (minTimestamp, Matomo date range).
 
-        Each visit dict carries a flat top-level ``dimension1`` field holding the
-        patron's "Days Since Registration" bucket (visitor/d0/d1+/d7+/d14+/d30+/d90+,
-        set by ``get_days_registered()`` in ``openlibrary/accounts/__init__.py``) and
-        an ``actionDetails`` list of that visit's page views and custom events.
-
-        Note ``dimension1`` is flat, NOT nested under a ``customDimensions`` key --
-        ``Live.getLastVisitsDetails`` does not return that structure, and reading it
-        as though it did silently classifies every visit as ``visitor``.
+        The range is padded a day either side because Matomo reads `date` in the
+        *site's* timezone while `since` is UTC -- an exact range drops the
+        earliest hours for any site behind UTC. `minTimestamp` does the precise
+        filtering, so this only has to be wide enough not to exclude anything.
         """
-        if since > (now := datetime.datetime.now(datetime.UTC)):
-            raise MatomoError(f"`since` is in the future ({since.isoformat()})")
+        now = datetime.datetime.now(datetime.UTC)
+        if since > now:
+            raise ValueError(f"`since` is in the future ({since.isoformat()})")
         if (now - since) > MAX_WINDOW:
-            raise MatomoError(f"Windows longer than {MAX_WINDOW.days} days are not supported; asked for {(now - since).days} days")
+            raise ValueError(f"Windows longer than {MAX_WINDOW.days} days are not supported; asked for {(now - since).days} days")
 
-        since_timestamp = int(since.timestamp())
-        # Bound the date range by `since` rather than a fixed `last7`, which
-        # silently clamped any longer window to 7 days while still reporting the
-        # window that was asked for.
-        #
-        # Padded by a day at each end because Matomo interprets `date` in the
-        # *site's* configured timezone while `since` is UTC. Without the padding a
-        # site behind UTC drops the earliest hours of the window: measured
-        # 2026-07-31, an exact UTC range returned 0 visits for the 06:00 hour
-        # because 06:00 UTC is the previous day in the site's timezone.
-        # `minTimestamp` still does the precise filtering; this only has to be
-        # wide enough not to exclude anything.
         day = datetime.timedelta(days=1)
-        date_range = f"{(since - day).date().isoformat()},{(now + day).date().isoformat()}"
+        return int(since.timestamp()), f"{(since - day).date().isoformat()},{(now + day).date().isoformat()}"
 
+    def get_visits_since(self, since: datetime.datetime, page_size: int = 500, budget_seconds: int = 300) -> VisitFetch:
+        """Fetch every visit active since ``since``.
+
+        Each visit carries a flat top-level ``dimension1`` holding the patron's
+        "Days Since Registration" bucket, and an ``actionDetails`` list of that
+        visit's page views and custom events. ``dimension1`` is flat, *not*
+        nested under ``customDimensions`` -- this endpoint does not return that
+        structure, and reading it as though it did yields no cohort at all.
+
+        ``budget_seconds`` bounds one fetch; ``timeout`` is per socket read and
+        bounds nothing overall. The budget is checked between pages, and a
+        single page can spend up to ``timeout`` x retries inside the loop, so
+        treat it as approximate rather than a hard deadline.
+        """
+        since_timestamp, date_range = self._window(since)
         visits: list[dict] = []
-        seen_visit_ids: set[str] = set()
-        deadline = time.monotonic() + self.budget_seconds
-        self.truncated = False
+        seen: set[str] = set()
+        deadline = time.monotonic() + budget_seconds
 
-        for _page in range(MAX_PAGES):
+        for page in range(MAX_PAGES):
             if time.monotonic() > deadline:
-                self.truncated = True
-                logger.warning("Matomo fetch exceeded its %ds budget after %d visits; results are truncated", self.budget_seconds, len(visits))
-                break
+                return self._truncated(visits, f"exceeded the {budget_seconds}s budget after {page} pages")
 
             batch = self._post(
                 "Live.getLastVisitsDetails",
@@ -179,29 +189,26 @@ class MatomoClient:
                 date=date_range,
                 minTimestamp=since_timestamp,
                 filter_limit=page_size,
-                # Offset by what we actually hold: Matomo enforces server-side row
-                # caps, so a page can legitimately be shorter than `page_size`, and
-                # stepping by `page * page_size` would skip records.
+                # Offset by rows held, not page x page_size: Matomo enforces
+                # server-side row caps, so a page can come back short.
                 filter_offset=len(visits),
             )
-            # Stop only on an empty page. A short-but-non-empty page means the
-            # server capped the row count, not that the feed is exhausted --
-            # treating it as the end silently truncates the score.
             if not batch:
                 break
-            if not isinstance(batch, list):
-                raise MatomoError(f"Expected a list of visits, got {type(batch).__name__}")
 
-            # The feed is newest-first and live, so visits arriving mid-pagination
-            # shift the window and re-present records we already hold. Patron
-            # counts survive that (they are sets) but points would double-count.
-            fresh = [visit for visit in batch if str(visit.get("idVisit", "")) not in seen_visit_ids]
-            seen_visit_ids.update(str(visit.get("idVisit", "")) for visit in batch)
+            # The feed is live and newest-first, so a visit arriving mid-fetch
+            # shifts the window and re-presents rows already held.
+            fresh = [visit for visit in batch if str(visit.get("idVisit", "")) not in seen]
+            seen.update(str(visit.get("idVisit", "")) for visit in batch)
             visits.extend(fresh)
             if not fresh:
                 break
         else:
-            self.truncated = True
-            logger.warning("Matomo visit pagination hit the %d-page cap; results are truncated", MAX_PAGES)
+            return self._truncated(visits, f"hit the {MAX_PAGES}-page cap")
 
-        return visits
+        return VisitFetch(visits)
+
+    @staticmethod
+    def _truncated(visits: list[dict], reason: str) -> VisitFetch:
+        logger.warning("Matomo fetch truncated after %d visits: %s", len(visits), reason)
+        return VisitFetch(visits, truncated_reason=reason)

--- a/openlibrary/core/matomo.py
+++ b/openlibrary/core/matomo.py
@@ -177,6 +177,10 @@ class MatomoClient:
         since_timestamp, date_range = self._window(since)
         visits: list[dict] = []
         seen: set[str] = set()
+        # Rows the server has served, including duplicates. The offset must
+        # track this rather than len(visits): dedupe makes the two diverge, and
+        # offsetting by the deduped count re-requests rows already consumed.
+        consumed = 0
         deadline = time.monotonic() + budget_seconds
 
         for page in range(MAX_PAGES):
@@ -189,20 +193,22 @@ class MatomoClient:
                 date=date_range,
                 minTimestamp=since_timestamp,
                 filter_limit=page_size,
-                # Offset by rows held, not page x page_size: Matomo enforces
+                # Offset by rows consumed, not page x page_size: Matomo enforces
                 # server-side row caps, so a page can come back short.
-                filter_offset=len(visits),
+                filter_offset=consumed,
             )
             if not batch:
                 break
+            consumed += len(batch)
 
-            # The feed is live and newest-first, so a visit arriving mid-fetch
-            # shifts the window and re-presents rows already held.
+            # The feed is live and newest-first, so visits arriving mid-fetch
+            # shift the window and re-present rows already consumed. An
+            # all-duplicate page therefore means the window moved, NOT that the
+            # feed ended -- breaking here silently dropped everything past the
+            # shift, with no truncation reported.
             fresh = [visit for visit in batch if str(visit.get("idVisit", "")) not in seen]
             seen.update(str(visit.get("idVisit", "")) for visit in batch)
             visits.extend(fresh)
-            if not fresh:
-                break
         else:
             return self._truncated(visits, f"hit the {MAX_PAGES}-page cap")
 

--- a/openlibrary/tests/core/test_matomo.py
+++ b/openlibrary/tests/core/test_matomo.py
@@ -208,13 +208,51 @@ class TestGetVisitsSince:
             fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
         assert [v["idVisit"] for v in fetch.visits] == [1, 2, 3, 4]
 
-    def test_a_page_of_only_duplicates_ends_pagination(self):
+    def test_a_live_feed_shifting_by_a_full_page_loses_nothing(self):
+        """Regression: an all-duplicate page means the window moved, not that the feed ended.
+
+        The feed is newest-first and live. If enough visits arrive between two
+        requests, the next offset lands entirely on rows already consumed.
+        Treating that as end-of-feed dropped everything past the shift and
+        reported `truncated=False` -- a silently short score.
+        """
         client = _client()
-        pages = [[{"idVisit": 1}], [{"idVisit": 1}]]
+        state = {"n": 0}
+
+        def growing_feed(_method, **kw):
+            state["n"] += 1
+            # Five new visits land after the first page and remain thereafter.
+            feed = list(range(15, 0, -1)) if state["n"] >= 2 else list(range(10, 0, -1))
+            offset, limit = kw["filter_offset"], kw["filter_limit"]
+            return [{"idVisit": str(v)} for v in feed[offset : offset + limit]]
+
+        with patch.object(client, "_post", side_effect=growing_feed):
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
+
+        collected = {int(v["idVisit"]) for v in fetch.visits}
+        assert set(range(1, 11)) <= collected, "lost visits past the window shift"
+        assert len(fetch.visits) == len(collected), "returned duplicates"
+
+    def test_the_offset_tracks_rows_served_not_rows_kept(self):
+        """Offsetting by the deduped count re-requests rows already consumed."""
+        client = _client()
+        pages = [
+            [{"idVisit": 1}, {"idVisit": 2}],
+            [{"idVisit": 2}, {"idVisit": 3}],  # one duplicate
+            [],
+        ]
+        with patch.object(client, "_post", side_effect=pages) as mock_post:
+            client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=2)
+        # 0, then 2 (rows served), then 4 -- not 0, 2, 3 (rows kept).
+        assert [call.kwargs["filter_offset"] for call in mock_post.call_args_list] == [0, 2, 4]
+
+    def test_an_empty_page_ends_pagination(self):
+        client = _client()
+        pages = [[{"idVisit": 1}], [{"idVisit": 1}], []]
         with patch.object(client, "_post", side_effect=pages) as mock_post:
             fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=1)
         assert len(fetch.visits) == 1
-        assert mock_post.call_count == 2
+        assert mock_post.call_count == 3
 
     def test_passes_min_timestamp(self):
         client = _client()

--- a/openlibrary/tests/core/test_matomo.py
+++ b/openlibrary/tests/core/test_matomo.py
@@ -1,0 +1,251 @@
+"""Tests for the read-only Matomo client used by Core Vitals retention scoring."""
+
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from openlibrary.core.matomo import MAX_PAGES, MatomoClient, MatomoError
+
+
+def _response(payload, status_code: int = 200):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _client(**kwargs) -> MatomoClient:
+    return MatomoClient("tok", **kwargs)
+
+
+def _patch_post(client, **kwargs):
+    """Patch the client's own session, which is what issues requests."""
+    return patch.object(client._session, "post", **kwargs)
+
+
+class TestReadOnlyAllowlist:
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "SitesManager.deleteSite",
+            "UsersManager.setUserAccess",
+            "Goals.addGoal",
+            "AnythingElse.get",
+            # Prefix matching allowed this: it sits under "API." but tunnels
+            # arbitrary methods via its `urls[]` parameter.
+            "API.getBulkRequest",
+            # These were allowed by the old prefix list but are not used here.
+            "VisitsSummary.get",
+            "Events.getCategory",
+        ],
+    )
+    def test_rejects_anything_not_exactly_allowlisted(self, method):
+        with pytest.raises(MatomoError, match="BLOCKED"):
+            _client()._post(method)
+
+    def test_blocks_before_any_network_call_is_made(self):
+        client = _client()
+        with _patch_post(client) as mock_post, pytest.raises(MatomoError, match="BLOCKED"):
+            client._post("SitesManager.deleteSite")
+        mock_post.assert_not_called()
+
+    def test_allows_the_one_method_this_codebase_uses(self):
+        client = _client()
+        with _patch_post(client, return_value=_response([])):
+            assert client._post("Live.getLastVisitsDetails") == []
+
+    def test_requires_a_token(self):
+        with pytest.raises(MatomoError, match="token is required"):
+            MatomoClient("")
+
+
+class TestTokenHandling:
+    def test_token_is_sent_in_the_post_body_not_the_url(self):
+        """The token must never land in a query string, where proxies and access logs record it."""
+        client = MatomoClient("s3cret")
+        with _patch_post(client, return_value=_response([])) as mock_post:
+            client._post("Live.getLastVisitsDetails")
+
+        url = mock_post.call_args.args[0]
+        assert "s3cret" not in url
+        assert mock_post.call_args.kwargs["data"]["token_auth"] == "s3cret"
+        assert "params" not in mock_post.call_args.kwargs
+
+    # `method` is not in this list because it is a positional parameter of
+    # `_post`, so it cannot be smuggled in via **params at all.
+    @pytest.mark.parametrize("key", ["token_auth", "module", "idSite", "format"])
+    def test_a_caller_cannot_override_the_fixed_keys(self, key):
+        """Params are applied before the fixed keys, so nothing can redirect the request."""
+        client = MatomoClient("real-token", site_id=6)
+        with _patch_post(client, return_value=_response([])) as mock_post:
+            client._post("Live.getLastVisitsDetails", **{key: "hijacked"})
+
+        sent = mock_post.call_args.kwargs["data"]
+        assert sent[key] != "hijacked"
+        assert sent["token_auth"] == "real-token"
+        assert sent["module"] == "API"
+        assert sent["idSite"] == 6
+
+    def test_the_token_does_not_appear_in_error_messages(self):
+        client = MatomoClient("s3cret")
+        with _patch_post(client, side_effect=requests.ConnectionError("no route")), pytest.raises(MatomoError) as excinfo:
+            client._post("Live.getLastVisitsDetails")
+        assert "s3cret" not in str(excinfo.value)
+
+    def test_posts_to_the_index_php_endpoint(self):
+        client = _client(url="https://matomo.example.org/")
+        with _patch_post(client, return_value=_response([])) as mock_post:
+            client._post("Live.getLastVisitsDetails")
+        assert mock_post.call_args.args[0] == "https://matomo.example.org/index.php"
+
+
+class TestErrorHandling:
+    def test_wraps_network_failures(self):
+        client = _client()
+        with _patch_post(client, side_effect=requests.ConnectionError("no route")), pytest.raises(MatomoError, match="request failed"):
+            client._post("Live.getLastVisitsDetails")
+
+    def test_raises_on_matomo_api_error_payload(self):
+        client = _client()
+        payload = {"result": "error", "message": "Invalid token_auth"}
+        with _patch_post(client, return_value=_response(payload)), pytest.raises(MatomoError, match="Invalid token_auth"):
+            client._post("Live.getLastVisitsDetails")
+
+    def test_raises_on_non_json_response(self):
+        client = _client()
+        response = _response(None)
+        response.json.side_effect = ValueError("not json")
+        with _patch_post(client, return_value=response), pytest.raises(MatomoError, match="non-JSON"):
+            client._post("Live.getLastVisitsDetails")
+
+
+class TestWindowBounds:
+    def test_rejects_a_window_longer_than_matomo_will_serve(self):
+        """`date` is derived from `since`, but Matomo's raw retention is finite."""
+        client = _client()
+        since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=30)
+        with pytest.raises(MatomoError, match="longer than"):
+            client.get_visits_since(since)
+
+    def test_rejects_a_future_since(self):
+        client = _client()
+        with pytest.raises(MatomoError, match="in the future"):
+            client.get_visits_since(datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1))
+
+    def test_the_date_range_covers_the_requested_window(self):
+        """A fixed `date=last7` silently clamped anything longer to seven days.
+
+        The range is padded a day either side because Matomo reads `date` in the
+        site's timezone while `since` is UTC -- an exact range dropped the
+        earliest hour entirely against the real instance.
+        """
+        client = _client()
+        now = datetime.datetime.now(datetime.UTC)
+        since = now - datetime.timedelta(days=3)
+        with patch.object(client, "_post", return_value=[]) as mock_post:
+            client.get_visits_since(since)
+
+        start, _, end = mock_post.call_args.kwargs["date"].partition(",")
+        assert datetime.date.fromisoformat(start) < since.date()
+        assert datetime.date.fromisoformat(end) > now.date()
+
+
+class TestGetVisitsSince:
+    def test_paginates_until_an_empty_page(self):
+        client = _client()
+        pages = [
+            [{"idVisit": i} for i in range(3)],
+            [{"idVisit": i} for i in range(3, 6)],
+            [],
+        ]
+        with patch.object(client, "_post", side_effect=pages) as mock_post:
+            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
+
+        assert [v["idVisit"] for v in visits] == list(range(6))
+        assert mock_post.call_count == 3
+
+    def test_a_short_page_does_not_end_pagination(self):
+        """Matomo enforces server-side row caps, so a page can be shorter than asked.
+
+        Treating that as the end of the feed silently truncated the score.
+        """
+        client = _client()
+        pages = [
+            [{"idVisit": i} for i in range(100)],
+            [{"idVisit": i} for i in range(100, 150)],
+            [],
+        ]
+        with patch.object(client, "_post", side_effect=pages):
+            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
+        assert len(visits) == 150
+        assert client.truncated is False
+
+    def test_offset_follows_what_was_actually_received(self):
+        """Stepping by page*page_size skips records whenever a page comes back short."""
+        client = _client()
+        pages = [[{"idVisit": i} for i in range(10)], []]
+        with patch.object(client, "_post", side_effect=pages) as mock_post:
+            client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
+        assert [call.kwargs["filter_offset"] for call in mock_post.call_args_list] == [0, 10]
+
+    def test_duplicate_visits_across_pages_are_dropped(self):
+        """The feed is live and newest-first, so pages overlap as visits arrive."""
+        client = _client()
+        pages = [
+            [{"idVisit": 1}, {"idVisit": 2}, {"idVisit": 3}],
+            [{"idVisit": 3}, {"idVisit": 4}],
+            [],
+        ]
+        with patch.object(client, "_post", side_effect=pages):
+            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
+        assert [v["idVisit"] for v in visits] == [1, 2, 3, 4]
+
+    def test_a_page_of_only_duplicates_ends_pagination(self):
+        client = _client()
+        pages = [[{"idVisit": 1}], [{"idVisit": 1}]]
+        with patch.object(client, "_post", side_effect=pages) as mock_post:
+            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=1)
+        assert len(visits) == 1
+        assert mock_post.call_count == 2
+
+    def test_passes_min_timestamp(self):
+        client = _client()
+        since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+        with patch.object(client, "_post", return_value=[]) as mock_post:
+            client.get_visits_since(since)
+        assert mock_post.call_args.kwargs["minTimestamp"] == int(since.timestamp())
+
+    def test_rejects_an_unexpected_payload_shape(self):
+        client = _client()
+        with patch.object(client, "_post", return_value={"unexpected": "dict"}), pytest.raises(MatomoError, match="Expected a list"):
+            client.get_visits_since(datetime.datetime.now(datetime.UTC))
+
+    def test_the_page_cap_sets_the_truncated_flag(self):
+        """A truncated hour must not be reported as a quiet hour."""
+        client = _client()
+        page = [{"idVisit": f"p{n}"} for n in range(2)]
+        with patch.object(client, "_post", side_effect=lambda *a, **k: [{"idVisit": f"{k['filter_offset']}-{n}"} for n in range(2)]):
+            client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=2)
+        assert client.truncated is True
+        assert len(page) == 2  # sanity: the stub returns fresh ids each call
+
+    def test_the_time_budget_sets_the_truncated_flag(self):
+        """`timeout` is per socket read and bounds no overall duration."""
+        client = _client(budget_seconds=0)
+        with patch.object(client, "_post", return_value=[{"idVisit": 1}]) as mock_post:
+            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert client.truncated is True
+        assert visits == []
+        mock_post.assert_not_called()
+
+    def test_a_clean_run_leaves_truncated_false(self):
+        client = _client()
+        with patch.object(client, "_post", return_value=[]):
+            client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert client.truncated is False
+
+    def test_the_page_cap_is_bounded(self):
+        assert MAX_PAGES == 200

--- a/openlibrary/tests/core/test_matomo.py
+++ b/openlibrary/tests/core/test_matomo.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from openlibrary.core.matomo import MAX_PAGES, MatomoClient, MatomoError
+from openlibrary.core.matomo import MatomoClient, MatomoError, MatomoMethodNotAllowed
 
 
 def _response(payload, status_code: int = 200):
@@ -43,12 +43,16 @@ class TestReadOnlyAllowlist:
         ],
     )
     def test_rejects_anything_not_exactly_allowlisted(self, method):
-        with pytest.raises(MatomoError, match="BLOCKED"):
+        with pytest.raises(MatomoMethodNotAllowed, match="read-only allowlist"):
             _client()._post(method)
+
+    def test_a_disallowed_method_is_distinguishable_from_a_flaky_matomo(self):
+        """A caller degrading gracefully on MatomoError must not swallow a programming error."""
+        assert issubclass(MatomoMethodNotAllowed, MatomoError)
 
     def test_blocks_before_any_network_call_is_made(self):
         client = _client()
-        with _patch_post(client) as mock_post, pytest.raises(MatomoError, match="BLOCKED"):
+        with _patch_post(client) as mock_post, pytest.raises(MatomoMethodNotAllowed):
             client._post("SitesManager.deleteSite")
         mock_post.assert_not_called()
 
@@ -58,7 +62,8 @@ class TestReadOnlyAllowlist:
             assert client._post("Live.getLastVisitsDetails") == []
 
     def test_requires_a_token(self):
-        with pytest.raises(MatomoError, match="token is required"):
+        """A missing token is a caller bug, not Matomo being unreachable."""
+        with pytest.raises(ValueError, match="token is required"):
             MatomoClient("")
 
 
@@ -127,12 +132,12 @@ class TestWindowBounds:
         """`date` is derived from `since`, but Matomo's raw retention is finite."""
         client = _client()
         since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=30)
-        with pytest.raises(MatomoError, match="longer than"):
+        with pytest.raises(ValueError, match="longer than"):
             client.get_visits_since(since)
 
     def test_rejects_a_future_since(self):
         client = _client()
-        with pytest.raises(MatomoError, match="in the future"):
+        with pytest.raises(ValueError, match="in the future"):
             client.get_visits_since(datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1))
 
     def test_the_date_range_covers_the_requested_window(self):
@@ -162,9 +167,9 @@ class TestGetVisitsSince:
             [],
         ]
         with patch.object(client, "_post", side_effect=pages) as mock_post:
-            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
 
-        assert [v["idVisit"] for v in visits] == list(range(6))
+        assert [v["idVisit"] for v in fetch.visits] == list(range(6))
         assert mock_post.call_count == 3
 
     def test_a_short_page_does_not_end_pagination(self):
@@ -179,9 +184,9 @@ class TestGetVisitsSince:
             [],
         ]
         with patch.object(client, "_post", side_effect=pages):
-            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
-        assert len(visits) == 150
-        assert client.truncated is False
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
+        assert len(fetch.visits) == 150
+        assert fetch.truncated is False
 
     def test_offset_follows_what_was_actually_received(self):
         """Stepping by page*page_size skips records whenever a page comes back short."""
@@ -200,15 +205,15 @@ class TestGetVisitsSince:
             [],
         ]
         with patch.object(client, "_post", side_effect=pages):
-            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
-        assert [v["idVisit"] for v in visits] == [1, 2, 3, 4]
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=3)
+        assert [v["idVisit"] for v in fetch.visits] == [1, 2, 3, 4]
 
     def test_a_page_of_only_duplicates_ends_pagination(self):
         client = _client()
         pages = [[{"idVisit": 1}], [{"idVisit": 1}]]
         with patch.object(client, "_post", side_effect=pages) as mock_post:
-            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=1)
-        assert len(visits) == 1
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=1)
+        assert len(fetch.visits) == 1
         assert mock_post.call_count == 2
 
     def test_passes_min_timestamp(self):
@@ -218,34 +223,41 @@ class TestGetVisitsSince:
             client.get_visits_since(since)
         assert mock_post.call_args.kwargs["minTimestamp"] == int(since.timestamp())
 
-    def test_rejects_an_unexpected_payload_shape(self):
+    @pytest.mark.parametrize("payload", [{"unexpected": "dict"}, {}, "a string", 42])
+    def test_a_non_list_payload_is_an_error_not_an_empty_feed(self, payload):
+        """An empty dict is falsy: checking emptiness first would read it as end-of-feed."""
         client = _client()
-        with patch.object(client, "_post", return_value={"unexpected": "dict"}), pytest.raises(MatomoError, match="Expected a list"):
-            client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        with _patch_post(client, return_value=_response(payload)), pytest.raises(MatomoError, match="expected a list of rows"):
+            client._post("Live.getLastVisitsDetails")
 
-    def test_the_page_cap_sets_the_truncated_flag(self):
-        """A truncated hour must not be reported as a quiet hour."""
+    def test_the_page_cap_reports_truncation(self):
+        """A truncated window must not be reported as a quiet one."""
         client = _client()
-        page = [{"idVisit": f"p{n}"} for n in range(2)]
         with patch.object(client, "_post", side_effect=lambda *a, **k: [{"idVisit": f"{k['filter_offset']}-{n}"} for n in range(2)]):
-            client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=2)
-        assert client.truncated is True
-        assert len(page) == 2  # sanity: the stub returns fresh ids each call
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=2)
+        assert fetch.truncated is True
+        assert "page cap" in fetch.truncated_reason
 
-    def test_the_time_budget_sets_the_truncated_flag(self):
+    def test_the_time_budget_reports_truncation(self):
         """`timeout` is per socket read and bounds no overall duration."""
-        client = _client(budget_seconds=0)
+        client = _client()
         with patch.object(client, "_post", return_value=[{"idVisit": 1}]) as mock_post:
-            visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert client.truncated is True
-        assert visits == []
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC), budget_seconds=0)
+        assert fetch.truncated is True
+        assert "budget" in fetch.truncated_reason
+        assert fetch.visits == []
         mock_post.assert_not_called()
 
-    def test_a_clean_run_leaves_truncated_false(self):
+    def test_the_budget_is_per_call_not_per_client(self):
+        """It bounds one fetch, so a client is not permanently poisoned by a tight budget."""
         client = _client()
         with patch.object(client, "_post", return_value=[]):
-            client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert client.truncated is False
+            assert client.get_visits_since(datetime.datetime.now(datetime.UTC), budget_seconds=0).truncated is True
+            assert client.get_visits_since(datetime.datetime.now(datetime.UTC), budget_seconds=300).truncated is False
 
-    def test_the_page_cap_is_bounded(self):
-        assert MAX_PAGES == 200
+    def test_a_clean_run_is_not_flagged_truncated(self):
+        client = _client()
+        with patch.object(client, "_post", return_value=[]):
+            fetch = client.get_visits_since(datetime.datetime.now(datetime.UTC))
+        assert fetch.truncated is False
+        assert fetch.truncated_reason is None


### PR DESCRIPTION
Part of #11956 — Core Vitals: Retention Score. **Groundwork only; this does not close the issue.**

This is the Matomo access layer alone. The scorer that consumes it is stacked in #13213, which is
where the remaining open questions live.

Split out deliberately so the part with the security surface and the external dependency can be reviewed on its own terms, rather than alongside a scoring formula whose weights and counting semantics are still being settled with @mekarpeles. Every open question on that discussion lives in the scorer; none live here.

## What's here

- `openlibrary/core/matomo.py` — a read-only client that fetches visit detail and nothing else.
- A Matomo mock in `docker/mockservices`, because `matomo.archive.org` is IP-restricted to IA's network and everything above this was otherwise untestable without a VPN.
- `matomo_api` in `conf/openlibrary.yml` (blank here; the real value belongs in olsystem).

## Read-only, and honest about how much that's worth

`_ALLOWED_METHODS` is an **exact-match** allowlist, not a prefix one. A prefix list is bypassable — `API.getBulkRequest` sits under `API.` and tunnels arbitrary methods through its `urls[]` parameter. Caller params are also applied *before* the fixed keys, so nothing can redirect a request at another `module`, `idSite`, or `token_auth`.

Both are guardrails against mistakes, **not a security boundary**. The credential is the only real control, so `matomo_api` should hold a **view-only Matomo user** — flagging that as the one deploy-side ask.

The token goes in the POST body, never a query string, so it stays out of access and proxy logs. A test asserts it never appears in a URL or in an exception message.

## Things that would otherwise have produced quietly-wrong numbers

- **Pagination stops on an empty page, not a short one.** Matomo enforces server-side row caps, so a request for 500 rows can legitimately return fewer; treating that as the end of the feed silently truncates. Offsets follow what was actually received.
- **Visits are deduped on `idVisit`.** The feed is live and newest-first, so pages overlap as new visits arrive. Measured: two duplicated visits inflated a downstream total by 40%.
- **`budget_seconds` is a real wall clock.** `timeout` is per socket read and bounds no overall duration, so "200 pages × 30s" was never the limit it appeared to be. Truncation for any reason sets `truncated`, which callers surface — a truncated window must not read as a quiet one.
- **The date range is derived from `since`**, not a fixed `last7` which clamped longer windows while still reporting the window asked for. It's padded a day either side because **Matomo interprets `date` in the site's timezone while `since` is UTC** — an exact UTC range returned zero visits for the 06:00 hour against the real instance. `minTimestamp` still does the precise filtering.
- One `requests.Session` with a short retry, rather than a fresh TLS handshake per page against shared IA infrastructure.

## Testing

`docker/mockservices` serves `Live.getLastVisitsDetails` in the real wire format — `dimension1` **flat on the visit**, and never the nested `customDimensions` that reading it wrongly implies — from a deterministic 12-visit feed that honours paging.

`test_matomo_inprocess.py` runs that same mock app in-process on a loopback port, so the real client makes real HTTP requests on **every CI run**. This matters: the container-gated tests next door skip when `mockservices` isn't up, and CI runs `make test-py` with no containers at all, so they cover nothing there. Verified with all services down — 14 pass, container-gated ones skip.

Also verified live against production Matomo through an allowlisted proxy.

## Notes for review

- **This ships with no production caller yet** — the tests are the only consumers until the scorer lands. That's the cost of the split, and worth naming rather than hiding. `MAX_WINDOW` / `budget_seconds` / `truncated` exist to serve the scorer.
- Imports nothing from Open Library, since this is intended to move into a standalone Core Vitals service on ol-home0 later. That move should be a file copy, not an untangling.

