### PR TITLE
fix(pre-commit): stop stylelint failing when every staged file is ignored

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,10 @@ repos:
           - stylelint@16.22.0
           - stylelint-declaration-strict-value@1.11.1
           - stylelint-prettier@5.0.3
-        args: [--fix]
+        # --allow-empty-input: pre-commit passes the staged .css files, and
+        # stylelint errors out if .stylelintignore excludes all of them (e.g. a
+        # commit that only touches static/css/tokens/). Exit 0 instead.
+        args: [--fix, --allow-empty-input]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v10.4.1


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical

`pre-commit` hands the stylelint hook the staged files matching `\.css$`, and stylelint then applies `.stylelintignore`. When that ignore list excludes *all* of them, stylelint resolves an empty lint set and exits 1 with `AllFilesIgnoredError`, which blocks the commit.

Two outcomes are worth separating:

- **No staged file matches `\.css$`** — pre-commit skips the hook. Fine.
- **Files match, but stylelint ignores every one** — the hook fails.

In practice the second case is any commit whose only CSS changes live under an ignored path, which today means `static/css/tokens/`, `static/css/tokens.css`, `static/css/lib/`, `static/build/`, `node_modules/`, or `vendor/`. A commit that only touches design tokens hits this every time, and that is a recurring shape of change right now.

`--allow-empty-input` makes stylelint exit 0 on an empty set. It is safe here specifically because pre-commit passes *explicit paths* rather than globs — the set can only come back empty when `.stylelintignore` deliberately excluded what was passed in. Repo-wide coverage is separately guaranteed by `npm run lint:css`, which globs the whole tree.

**This only affects local commits.** pre-commit.ci runs `--all-files`, so the file set is never empty there and CI was never failing on this.

Considered and rejected: mirroring the ignore list into an `exclude:` regex on the hook (duplicates `.stylelintignore` in two places that will drift), and un-ignoring `static/css/tokens/` with per-file rule disables (`stylelint-prettier` runs with `--fix` and would reformat the hand-aligned comment columns in `z-index.css`).

### Testing

On this branch:

```
# Previously failed with AllFilesIgnoredError, now passes
pre-commit run stylelint --files static/css/tokens/z-index.css   # Passed

# The pre-commit.ci path, unchanged
pre-commit run stylelint --all-files                             # Passed

pre-commit validate-config .pre-commit-config.yaml               # valid
```

Confirmed the flag does not neuter the hook — a real violation in a lintable file still fails:

```
printf '.tmp { position: relative; z-index: 42; }' > static/css/_tmp.css
pre-commit run stylelint --files static/css/_tmp.css

  3:3  ✖  Expected variable, function or keyword for "42" of "z-index"
           scale-unlimited/declaration-strict-value
  exit code: 2
```

To reproduce the original failure, check out `master` and run the first command above.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No UI changes.

### Stakeholders
@lokesh