### PR TITLE
fix: track Book Preview and Search Inside events in Matomo

### DIFF
--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,6 +1,7 @@
 import 'jquery-ui/ui/widgets/dialog';
 // For dialog boxes (e.g. add to list)
 import 'jquery-colorbox';
+import { trackEvent } from './ol.analytics.js';
 
 /**
  * Wires up confirmation prompts.
@@ -66,6 +67,7 @@ export function initPreviewDialogs() {
     // lazy-loaded carousels) work without re-initialization.
     $(document).off('click.bookPreview').on('click.bookPreview', '[data-book-preview]', function(e) {
         e.preventDefault();
+        trackEvent('BookOptions', 'Preview');
         const $button = $(this);
         const dialog = document.getElementById('bookPreview');
         if (!dialog) return;
@@ -93,6 +95,7 @@ export function initPreviewDialogs() {
     // Handle clicking the "Search Inside" button to expand it to the input form
     $(document).off('click.bookSearchTrigger').on('click.bookSearchTrigger', '[data-search-trigger]', function(e) {
         e.preventDefault();
+        trackEvent('BookOptions', 'SearchInside');
         const $triggerBtn = $(this);
         const $btnGroup = $triggerBtn.closest('.cta-button-group');
         $triggerBtn.attr('aria-expanded', 'true');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up for #13112

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes missing event tracking for Book Preview and Search Inside buttons in Matomo stats.

### Technical
- Imports `trackEvent` from `ol.analytics.js` in `dialog.js`.
- Programmatically calls `trackEvent('BookOptions', 'Preview')` and `trackEvent('BookOptions', 'SearchInside')` inside their respective click handlers in `initPreviewDialogs()`.
- Programmatic tracking bypasses Matomo Tag Manager's selector-based trigger limitations with dynamic element visibility toggling (where the button is hidden immediately upon click) and Light DOM nesting constraints.

### Testing
Manual verification on a local instance:
1. Open a book page displaying "Preview" and "Search Inside" buttons.
2. Intercept `window._paq` calls in browser DevTools Console.
3. Click "Preview" and check that `_paq` receives `['trackEvent', 'BookOptions', 'Preview']`.
4. Click "Search" and check that `_paq` receives `['trackEvent', 'BookOptions', 'SearchInside']`.

### Screenshot
N/A (Non-visual behavior change)

### Stakeholders
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
