### PR TITLE
fix(js): resolve console errors on book, work, author, and search pages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -80,8 +80,10 @@ export function initEditionsTable() {
             bAutoWidth: false,
             pageLength: currentLength ? currentLength : DEFAULT_LENGTH,
             drawCallback: function() {
-                if ($('#ile-toolbar')) {
-                    const editionStorage = JSON.parse(sessionStorage.getItem('ile-items'))['edition'];
+                // A jQuery object is always truthy, so check its length for the toolbar's presence.
+                if ($('#ile-toolbar').length) {
+                    // `ile-items` is unset until the first ILE selection is made.
+                    const editionStorage = JSON.parse(sessionStorage.getItem('ile-items') || '{}').edition || [];
                     const matchEdition = (string) => {
                         return string.match(/OL[0-9]+[a-zA-Z]/);
                     };

--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
@@ -70,10 +70,15 @@ export class MyBooksDropper extends Dropper {
         const splitKey = this.workKey ? this.workKey.split('/') : [''];
         const workOlid = splitKey[splitKey.length - 1];
 
+        // The check-in container is only rendered for authenticated patrons, so
+        // construct the components only when it exists — a `CheckInComponents`
+        // built without one is truthy but uninitialized, and throws on `initialize()`.
+        const checkInContainer = workOlid ? document.querySelector(`#check-in-container-${workOlid}`) : null;
+
         /**
          * @type {CheckInComponents|null}
          */
-        this.checkInComponents = workOlid ? new CheckInComponents(document.querySelector(`#check-in-container-${workOlid}`)) : null;
+        this.checkInComponents = checkInContainer ? new CheckInComponents(checkInContainer) : null;
 
         /**
          * References this dropper's reading log buttons.


### PR DESCRIPTION
Fixes two uncaught `TypeError`s that fire on production book, work, author, and search pages.

### Technical

- `MyBooksDropper` constructed a `CheckInComponents` even when `#check-in-container-*` was absent — it is only rendered for logged-in patrons. The constructor returns early in that case, but the instance is still truthy, so the `if (this.checkInComponents)` guard passed and `initialize()` threw on undefined members. Now the component is only constructed when the container exists.
- `editions-table`'s `drawCallback` tested a jQuery object for truthiness (always `true`) and indexed `JSON.parse(null)` when the `ile-items` session key was unset. Now checks `.length` and defaults the parsed value.

### Testing

Reproduces on openlibrary.org today — open https://openlibrary.org/books/OL7353617M logged out and both errors appear in the console.

Locally, with a logged-out browser:

1. `docker compose run --rm home npm run build-assets:js && docker compose restart web`
2. Visit `/books/OL3421846M`, `/search?q=lord+of+the+rings`, and an author page — console is clean.

`npm run test:e2e` goes from 16 passed / 4 failed to 20 passed; `npm run test:js` (495 tests) still passes.
