### PR TITLE
Fix login issues for recent registrants who have requested print disability access

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -27,6 +27,7 @@ from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.edits import CommunityEditsQueue
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
+from openlibrary.plugins.openlibrary.pd import get_pd_org
 from openlibrary.utils.request_context import site
 
 try:
@@ -706,11 +707,11 @@ class OpenLibraryAccount(Account):
             u.save_preferences(prefs)
 
     def send_pd_email(self):
-        if org := self.pd_authority:
-            if org == "unqualified":
-                org = "vtmas_disabilityresources"
+        if org_id := self.pd_authority:
+            if org_id == "unqualified":
+                org_id = "vtmas_disabilityresources"
             displayname = web.safestr(self.displayname)
-            msg = render_template("email/account/pd_request", displayname=displayname, org=org)
+            msg = render_template("email/account/pd_request", displayname=displayname, org=get_pd_org(org_id))
             web.sendmail(
                 config.from_address,
                 self.email,

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -33,7 +33,9 @@ def get_pd_options() -> list[PDOption]:
 
 
 def get_pd_org(identifier: str) -> dict:
-    """Returns the name of the organization associated with the given identifier.
+    """Returns a dict containing the name and identifier of the
+    organization associated with the given identifier.
+
     Falls back to vtmas_disabilityresources if no match is found.
     """
     orgs = cached_pd_org_query()


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When new patrons who have requested print disability access first login to Open Library, we send them an email containing next steps for their access request.  For some time, the email generation has been failing, resulting in an error page when affected patrons login (related [Sentry event](https://sentry.archive.org/organizations/ia-ux/issues/642584/?project=7&query=is%3Aunresolved%20trace%3A114da0ec646f4c398288efa6fe15209e&referrer=issue-stream)).

**Root Cause:** The `email/account/pd_request` template expects `org` to be dict with `title` and `identifier` keys, but we were instead passing a string.

After deploying this branch to testing, I was able to login without error using a newly created account (having key `/people/20260804_pd_test`).  Before attempting to login on testing, logging into production with this account caused an error.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
