### PR TITLE
fix(env): resolve get_ol_env() name collision causing 500

### DIFF
--- a/openlibrary/core/env.py
+++ b/openlibrary/core/env.py
@@ -14,7 +14,7 @@ class OLEnv:
         return os.environ.get("LOCAL_DEV") == "true"
 
 
-def get_ol_env_name() -> str:
+def get_deployment_name() -> str:
     """Which deployment this request is served from, based on the host.
 
     Drives dev-facing UI cues (favicon, logo badge) so localhost,

--- a/openlibrary/core/env.py
+++ b/openlibrary/core/env.py
@@ -1,6 +1,8 @@
 import os
 from functools import cached_property
 
+import web
+
 
 class OLEnv:
     @cached_property
@@ -10,6 +12,21 @@ class OLEnv:
     @cached_property
     def LOCAL_DEV(self) -> bool:
         return os.environ.get("LOCAL_DEV") == "true"
+
+
+def get_ol_env_name() -> str:
+    """Which deployment this request is served from, based on the host.
+
+    Drives dev-facing UI cues (favicon, logo badge) so localhost,
+    testing.openlibrary.org, and production tabs are distinguishable.
+    """
+    match web.ctx.host:
+        case "openlibrary.org" | "www.openlibrary.org":
+            return "production"
+        case "testing.openlibrary.org":
+            return "testing"
+        case _:
+            return "development"
 
 
 _ol_env = OLEnv()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -24,7 +24,7 @@ from openlibrary.core import db
 from openlibrary.core.batch_imports import (
     batch_import,
 )
-from openlibrary.core.env import get_ol_env, get_ol_env_name
+from openlibrary.core.env import get_deployment_name, get_ol_env
 from openlibrary.core.features import features as ol_features
 from openlibrary.core.jinja import render_jinja_template
 from openlibrary.i18n import gettext as _
@@ -1144,7 +1144,7 @@ def setup_template_globals():
             "render_jinja_template": render_jinja_template,
             "get_sentry": get_sentry,
             "get_ol_env": get_ol_env,
-            "get_ol_env_name": get_ol_env_name,
+            "get_deployment_name": get_deployment_name,
             # bad use of globals
             "is_bot": is_bot,
             "time": time,

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -24,7 +24,7 @@ from openlibrary.core import db
 from openlibrary.core.batch_imports import (
     batch_import,
 )
-from openlibrary.core.env import get_ol_env
+from openlibrary.core.env import get_ol_env, get_ol_env_name
 from openlibrary.core.features import features as ol_features
 from openlibrary.core.jinja import render_jinja_template
 from openlibrary.i18n import gettext as _
@@ -1144,6 +1144,7 @@ def setup_template_globals():
             "render_jinja_template": render_jinja_template,
             "get_sentry": get_sentry,
             "get_ol_env": get_ol_env,
+            "get_ol_env_name": get_ol_env_name,
             # bad use of globals
             "is_bot": is_bot,
             "time": time,

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1475,22 +1475,6 @@ class Request:
 
 
 @public
-def get_ol_env() -> str:
-    """Which deployment this request is served from, based on the host.
-
-    Drives dev-facing UI cues (favicon, logo badge) so localhost,
-    testing.openlibrary.org, and production tabs are distinguishable.
-    """
-    match web.ctx.host:
-        case "openlibrary.org" | "www.openlibrary.org":
-            return "production"
-        case "testing.openlibrary.org":
-            return "testing"
-        case _:
-            return "development"
-
-
-@public
 def render_once(key: str) -> bool:
     rendered = web.ctx.setdefault("render_once", {})
     if key in rendered:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -51,7 +51,7 @@ $ is_privileged_user = ctx.user and ctx.user.is_librarian_or_higher()
   $  'show_mask': True
   $ }
 
-  $ ol_env = get_ol_env()
+  $ ol_env = get_ol_env_name()
   <div class="logo-component">
     <a href="/" title="$_('The Internet Archive\'s Open Library: One page for every book')">
       <div class="logo-txt$(' logo-txt--env-' + ol_env if ol_env != 'production' else '')">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -51,7 +51,7 @@ $ is_privileged_user = ctx.user and ctx.user.is_librarian_or_higher()
   $  'show_mask': True
   $ }
 
-  $ ol_env = get_ol_env_name()
+  $ ol_env = get_deployment_name()
   <div class="logo-component">
     <a href="/" title="$_('The Internet Archive\'s Open Library: One page for every book')">
       <div class="logo-txt$(' logo-txt--env-' + ol_env if ol_env != 'production' else '')">

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -23,7 +23,7 @@ $def with (title)
     <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />
     <link href="/static/images/openlibrary-167x167.png" rel="apple-touch-icon" sizes="167x167" />
     <link href="/static/images/openlibrary-180x180.png" rel="apple-touch-icon" sizes="180x180" />
-    $ ol_env = get_ol_env_name()
+    $ ol_env = get_deployment_name()
     $if ol_env == 'production':
         <link href="/static/images/openlibrary-192x192.png" rel="icon" sizes="192x192" />
         <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -23,7 +23,7 @@ $def with (title)
     <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />
     <link href="/static/images/openlibrary-167x167.png" rel="apple-touch-icon" sizes="167x167" />
     <link href="/static/images/openlibrary-180x180.png" rel="apple-touch-icon" sizes="180x180" />
-    $ ol_env = get_ol_env()
+    $ ol_env = get_ol_env_name()
     $if ol_env == 'production':
         <link href="/static/images/openlibrary-192x192.png" rel="icon" sizes="192x192" />
         <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />


### PR DESCRIPTION
## Problem

Rendering `/` failed with `TypeError: can only concatenate str (not "OLEnv") to str` at `lib/nav_head.html:57`:

```python
' logo-txt--env-' + ol_env
```

## Root cause

Two PRs added a function named `get_ol_env()` with different return types:

- string helper `get_ol_env() -> str` in `plugins/upstream/utils.py`, used by templates for the env badge/favicon
- `get_ol_env() -> OLEnv` (config flags `.LOCAL_DEV`, `.OL_EXPOSE_SOLR_INTERNALS_PARAMS`) in `core/env.py`, registered into template globals by `plugins/openlibrary/code.py`

The `Template.globals.update` won, so templates resolved the name to the `OLEnv` object — but the templates expected a string — breaking the concatenation.

## Fix

- `core/env.py`: add `get_ol_env_name() -> str` hosting the host-based badge logic; `plugins/upstream/utils.py`: drop the string duplicate
- `plugins/openlibrary/code.py`: register `get_ol_env_name` alongside `get_ol_env`
- `templates/lib/nav_head.html` + `templates/site/head.html`: call `get_ol_env_name()` for the badge/favicon; `.LOCAL_DEV` usages on the `OLEnv` object remain unchanged

## Validation

- `/` returns **200**, renders the `logo-txt--env-development` badge and dev favicons
- `get_ol_env()` (the object) is untouched, so all shared callers are unaffected
- `ruff check` / `ruff format` pass