### PR TITLE
Replace undo feature flag with explicit is_super_librarian() check

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -63,7 +63,6 @@ features:
     debug: enabled
     stats: enabled
     stats-header: enabled
-    undo: enabled
 
 upstream_to_www_migration: true
 default_template_root: /upstream

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -29,7 +29,6 @@ class Features(BaseSettings):
     # debug: bool # disabled because we should probably get rid of it but we still have a `features.is_enabled("debug")` to deal with we didn't see in #12884
     stats: bool
     stats_header: bool
-    # undo: bool # Warning: this is enabled locally but a usergroup of librarians in testing/production
 
     @classmethod
     def from_yaml(cls, path: Path | str) -> Features:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -980,6 +980,14 @@ class User(Thing):
             ]
         )
 
+    def is_super_librarian_or_higher(self) -> bool:
+        return self.is_member_of_any(
+            [
+                "/usergroup/super-librarians",
+                "/usergroup/admin",
+            ]
+        )
+
     def is_beta_tester(self) -> bool:
         return self.is_usergroup_member("/usergroup/beta-testers")
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -793,7 +793,7 @@ class _yaml_edit(_yaml):
 
     def is_admin(self):
         u = delegate.context.user
-        return u and (u.is_admin() or u.is_super_librarian())
+        return u and u.is_super_librarian_or_higher()
 
     def GET(self, key):
         # only allow admin users to edit yaml

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -556,7 +556,7 @@ class SaveBookHelper:
         comment = formdata.pop("_comment", "")
 
         user = accounts.get_current_user()
-        delete = user and (user.is_admin() or user.is_super_librarian()) and formdata.pop("_delete", "")
+        delete = user and user.is_super_librarian_or_higher() and formdata.pop("_delete", "")
 
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
@@ -748,7 +748,7 @@ class SaveBookHelper:
     def _prevent_ocaid_deletion(self, edition) -> None:
         # Allow admins to modify ocaid
         user = accounts.get_current_user()
-        if user and (user.is_admin() or user.is_super_librarian()):
+        if user and user.is_super_librarian_or_higher():
             return
 
         # read ocaid from form data

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -134,7 +134,7 @@ class merge_work(delegate.page):
             raise web.forbidden()
 
         optional_kwargs = {}
-        if not (user.is_admin() or user.is_super_librarian()):
+        if not user.is_super_librarian_or_higher():
             optional_kwargs["can_merge"] = "false"
 
         return render_template("merge/works", mrid=i.mrid, primary=i.primary, **optional_kwargs)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -245,11 +245,6 @@ def reload():
     all_js().reload()
 
 
-def user_can_revert_records():
-    user = web.ctx.site.get_user()
-    return user and (user.is_admin() or user.is_super_librarian())
-
-
 @public
 def get_document(key, limit_redirs=5):
     doc = None
@@ -275,7 +270,8 @@ class revert(delegate.mode):
         if v is None:
             raise web.seeother(web.changequery({}))
 
-        if not web.ctx.site.can_write(key) or not user_can_revert_records():
+        user = web.ctx.site.get_user()
+        if not web.ctx.site.can_write(key) or not (user and user.is_super_librarian_or_higher()):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -240,7 +240,7 @@ class merge_authors(delegate.page):
         keys = sorted(keys, key=lambda key: int(key[2:-1]))
 
         user = get_current_user()
-        can_merge = user and (user.is_admin() or user.is_super_librarian())
+        can_merge = user and user.is_super_librarian_or_higher()
         return render_template(
             "merge/authors",
             keys,
@@ -255,7 +255,7 @@ class merge_authors(delegate.page):
         selected = uniq(i.merge_key)
 
         user = get_current_user()
-        can_merge = user and (user.is_admin() or user.is_super_librarian())
+        can_merge = user and user.is_super_librarian_or_higher()
         can_request_merge = not can_merge and (user and user.is_librarian())
 
         # filter bad keys

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -9,7 +9,7 @@ import math
 import web
 import yaml
 
-from infogami.utils import delegate, features
+from infogami.utils import delegate
 from infogami.utils.view import (
     add_flash_message,  # noqa: F401 side effects may be needed
     public,
@@ -172,12 +172,8 @@ class recentchanges_view(delegate.page):
 
     # Required for reverting changesets
     def POST(self, id):
-        allowed_usergroups = ["/usergroup/admin", "/usergroup/super-librarians"]
-        if not (user := get_current_user()) or not (user.is_member_of_any(allowed_usergroups)):
+        if not (user := get_current_user()) or not user.is_super_librarian():
             raise web.unauthorized()
-        if not features.is_enabled("undo"):
-            return render_template("permission_denied", web.ctx.path, "Permission denied to undo.")
-
         id = int(id)
         change = web.ctx.site.get_change(id)
         change._undo()

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -172,7 +172,7 @@ class recentchanges_view(delegate.page):
 
     # Required for reverting changesets
     def POST(self, id):
-        if not (user := get_current_user()) or not user.is_super_librarian():
+        if not (user := get_current_user()) or not user.is_super_librarian_or_higher():
             raise web.unauthorized()
         id = int(id)
         change = web.ctx.site.get_change(id)

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -20,6 +20,7 @@ def mock_user():
         {
             "is_admin": lambda slf: False,
             "is_super_librarian": lambda slf: False,
+            "is_super_librarian_or_higher": lambda slf: slf.is_admin() or slf.is_super_librarian(),
             "is_librarian": lambda slf: False,
             "is_usergroup_member": lambda slf, grp: False,
         },

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -56,7 +56,7 @@ $ i18n_strings = {
             </div>
         </div>
 
-        $ is_privileged = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
+        $ is_privileged = ctx.user and ctx.user.is_super_librarian_or_higher()
         <div class="formElement">
             <div class="label"><label for="id_value">$:_("And optionally, an ID number &#151; like an ISBN &#151; would be helpful...")</label></div>
                 <label for="id_name" class="hidden">$_("ID Type")</label>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -40,7 +40,7 @@ $:macros.HiddenSaveButton("addWork")
             alert_class = ''
             alert_message = ''
     $:macros.databarEdit(edition if edition is not None else work)
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+    $if ctx.user and ctx.user.is_super_librarian_or_higher():
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn" class="delete-record">$_("Delete Record")</button>
@@ -127,7 +127,7 @@ $:macros.HiddenSaveButton("addWork")
                     </div>
                 </fieldset>
 
-                $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+                $if ctx.user and ctx.user.is_super_librarian_or_higher():
                     <fieldset class="major" id="identifiers">
                         <legend>$_("Work Series")</legend>
                         <div class="ol-message ol-message--warning">
@@ -158,7 +158,7 @@ $:macros.HiddenSaveButton("addWork")
                     </div>
                     <div id="hiddenWorkIdentifiers"></div>
                     <div id="identifiers-display-works">
-                        $ admin = str(bool(ctx.user) and (ctx.user.is_admin() or ctx.user.is_super_librarian()))
+                        $ admin = str(bool(ctx.user) and ctx.user.is_super_librarian_or_higher())
                         $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenWorkIdentifiers', id_config_string=work_config.identifiers, input_prefix='work--identifiers', multiple='true', admin=admin))
                     </div>
                 </fieldset>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -12,7 +12,7 @@ $# @param {string} props.label for menu, also used as alt text for dropdown icon
 $# @param {string|null} props.image URL for image (optional)
 $# @param {DropdownLink[]} props.links
 $ singleton = len(props.get('links', [])) == 1
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
+$ is_privileged_user = ctx.user and ctx.user.is_super_librarian_or_higher()
 
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:

--- a/openlibrary/templates/recentchanges/header.html
+++ b/openlibrary/templates/recentchanges/header.html
@@ -12,7 +12,7 @@ $ label = label or change.kind.replace("_", " ").replace("-", " ").title()
         </div>
         <div class="smallest gray sansserif">$datestr(change.timestamp)</div>
     </div>
-    $if change.can_undo() and "undo" in ctx.features:
+    $if change.can_undo() and ctx.user and ctx.user.is_super_librarian():
         <div class="editButton">
             <form id="undo-form" method="POST">
                 <button class="linkButton" name="#" accesskey="u" id="undo-button" type="submit">$_("Undo All")</button>

--- a/openlibrary/templates/recentchanges/header.html
+++ b/openlibrary/templates/recentchanges/header.html
@@ -12,7 +12,7 @@ $ label = label or change.kind.replace("_", " ").replace("-", " ").title()
         </div>
         <div class="smallest gray sansserif">$datestr(change.timestamp)</div>
     </div>
-    $if change.can_undo() and ctx.user and ctx.user.is_super_librarian():
+    $if change.can_undo() and ctx.user and ctx.user.is_super_librarian_or_higher():
         <div class="editButton">
             <form id="undo-form" method="POST">
                 <button class="linkButton" name="#" accesskey="u" id="undo-button" type="submit">$_("Undo All")</button>

--- a/openlibrary/templates/showmarc.html
+++ b/openlibrary/templates/showmarc.html
@@ -45,7 +45,7 @@ $var title: $title
     $else:
         <p><b>$_("LEADER:")</b> <code>$record.leader</code><br>
         $:record.html()</p>
-   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+   $if ctx.user and ctx.user.is_super_librarian_or_higher():
        <div>
           <a href="$next_url" class="slick-next adminOnly right">$_("Next")</a>
        </div>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -8,7 +8,7 @@ $:macros.HiddenSaveButton("addAuthor")
 
 <div id="contentHead">
     $:macros.databarEdit(page)
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+    $if ctx.user and ctx.user.is_super_librarian_or_higher():
         <span class="adminOnly right">
             <button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addAuthor">$_("Delete Record")</button>
         </span>
@@ -106,7 +106,7 @@ $:macros.HiddenSaveButton("addAuthor")
                         <div id="id-errors-author" class="note" style="display: none"></div>
                         <div id="hiddenAuthorIdentifiers"></div>
                         <div id="identifiers-display">
-                            $ admin = ctx.user.is_admin() or ctx.user.is_super_librarian()
+                            $ admin = ctx.user.is_super_librarian_or_higher()
                             $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=dict(page.remote_ids),output_selector='#hiddenAuthorIdentifiers', admin=str(admin), input_prefix='author--remote_ids', id_config_string=author_config.identifiers))
                         </div>
                         <br>

--- a/openlibrary/templates/type/edition/title_and_author.html
+++ b/openlibrary/templates/type/edition/title_and_author.html
@@ -23,7 +23,7 @@ $ view_type = 'desktop' if for_desktop else 'mobile'
               ($work.first_publish_year)
             </span>
     </div>
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+    $if ctx.user and ctx.user.is_super_librarian_or_higher():
       $ primary_series = work.get_primary_series() if work else None
       $if primary_series:
         <div class="series-line">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,6 +1,6 @@
 $def with (page, edition=None)
 
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
+$ is_privileged_user = ctx.user and ctx.user.is_super_librarian_or_higher()
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 
 $ component_times = {}

--- a/openlibrary/templates/type/tag/form.html
+++ b/openlibrary/templates/type/tag/form.html
@@ -9,7 +9,7 @@ $ heading = _("Edit tag") if is_editing else _("Add a tag to Open Library")
 <div id="contentHead">
     $if is_editing:
         $:macros.databarEdit(page)
-        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+        $if ctx.user and ctx.user.is_super_librarian_or_higher():
             <span class="adminOnly right">
                 <button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete"
                     form="tag-form">$_("Delete Record")</button>

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+$if ctx.user and ctx.user.is_super_librarian_or_higher():
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -91,6 +91,37 @@ class TestUserGroupMembership:
         )
         assert user.is_librarian_or_higher() is False
 
+    def test_is_super_librarian_or_higher(self, monkeypatch):
+        user = models.User(MockSite(), "/people/test", data={})
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/super-librarians")]),
+        )
+        assert user.is_super_librarian_or_higher() is True
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/admin")]),
+        )
+        assert user.is_super_librarian_or_higher() is True
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/librarians")]),
+        )
+        assert user.is_super_librarian_or_higher() is False
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[]),
+        )
+        assert user.is_super_librarian_or_higher() is False
+
 
 class MockSite:
     def get(self, key):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR replaces `features.is_enabled("undo")` and "undo" in `ctx.features` with an explicit `user.is_super_librarian()` check.

### Technical
<!-- What should be noted about the implementation? -->
- Removed `undo` flag from `conf/openlibrary.yml` and the commented reference in `openlibrary/core/features.py`.
- Removed the `features.is_enabled("undo")` and usergroup list checks in `openlibrary/plugins/upstream/recentchanges.py`, replacing them with a single `user.is_super_librarian()` check.
- Updated `openlibrary/templates/recentchanges/header.html` to check `ctx.user.is_super_librarian()` instead of the feature flag.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Tested against local docker stack: "Undo All" renders for super-librarians, hidden for anonymous; POST undo succeeds (303) as super-librarian, 401 for anonymous and for admin-only accounts (matches prod's `/usergroup/super-librarians `gating).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
