### PR TITLE
Continue Reading Phase 3: My Books Landing Page Carousel

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -17,7 +17,7 @@ from simplejson.errors import JSONDecodeError
 
 from infogami.utils import delegate
 from infogami.utils.view import public
-from openlibrary.accounts.model import OpenLibraryAccount
+from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
 from openlibrary.core import cache, stats
 from openlibrary.core.env import get_ol_env
 from openlibrary.plugins.upstream.utils import urlencode
@@ -1126,3 +1126,75 @@ def get_lending_state(doc, user=None, check_loan_status=False) -> str:
         return "preview_only"
 
     return "locate"
+
+
+RESULTS_PER_PAGE: int = 25
+
+
+def get_loan_history_data(username: str, page: int) -> dict:
+    """Fetch loan history data for a user.
+
+    This will use a patron's S3 keys to query the IA loan history API,
+    get the IA IDs, get the OLIDs if available, and then convert this
+    into editions and IA-only items for display in the loan history.
+
+    This returns both editions and IA-only items because the loan history API
+    includes items that are not in Open Library, and displaying only IA
+    items creates pagination and navigation issues. For further discussion,
+    see https://github.com/internetarchive/openlibrary/pull/8375.
+    """
+    from infogami.utils.view import render
+
+    if not (account := OpenLibraryAccount.get_by_username(username)):
+        raise render.notfound("Account not found for %s" % username, create=False)
+
+    s3_keys = get_s3_keys(account)
+    limit = RESULTS_PER_PAGE
+    offset = page * limit - limit
+    response = s3_loan_api(
+        s3_keys=s3_keys,
+        action="user_borrow_history",
+        limit=limit + 1,
+        offset=offset,
+        newest=True,
+    ).json()
+    history = response.get("history") or {}
+    loan_history = history.get("items") or []
+
+    # We request limit+1 to see if there is another page of history to display,
+    # and then pop the +1 off if it's present.
+    show_next = len(loan_history) == limit + 1
+    if show_next:
+        loan_history.pop()
+
+    ocaids = [loan_record["identifier"] for loan_record in loan_history]
+    loan_history_map = {loan_record["identifier"]: loan_record for loan_record in loan_history}
+
+    # Get editions and attach their loan history.
+    editions_map = get_items_and_add_availability(ocaids=ocaids)
+    for edition in editions_map.values():
+        if edition_loan_history := loan_history_map.get(edition.get("ocaid")):
+            edition["last_loan_date"] = edition_loan_history.get("updatedate", "")
+        else:
+            edition["last_loan_date"] = ""
+
+    # Create 'placeholders' dicts for items in the Internet Archive loan history,
+    # but absent from Open Library, and then add loan history.
+    # ia_only['loan'] isn't set because `LoanStatus.html` reads it as a current
+    # loan. No apparently way to distinguish between current and past loans with
+    # this API call.
+    ia_only_loans = [{"ocaid": ocaid} for ocaid in ocaids if ocaid not in editions_map]
+    for ia_only_loan in ia_only_loans:
+        loan_data = loan_history_map[ia_only_loan["ocaid"]]
+        ia_only_loan["last_loan_date"] = loan_data.get("updatedate", "")
+        ia_only_loan["ia_only"] = True  # type: ignore[typeddict-unknown-key]
+
+    editions_and_ia_loans = list(editions_map.values()) + ia_only_loans
+    editions_and_ia_loans.sort(key=lambda item: item.get("last_loan_date", ""), reverse=True)
+
+    return {
+        "docs": editions_and_ia_loans,
+        "show_next": show_next,
+        "limit": limit,
+        "page": page,
+    }

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1304,11 +1304,11 @@ msgid_plural "There are %(count)d people waiting for this book."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html
+#: account/loans.html books/custom_carousel_card.html
 msgid "Not yet downloaded."
 msgstr ""
 
-#: account/loans.html
+#: account/loans.html books/custom_carousel_card.html
 msgid "Download Now"
 msgstr ""
 
@@ -3317,6 +3317,29 @@ msgstr ""
 #: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
+msgstr ""
+
+#: FormatExpiry.html books/custom_carousel_card.html
+msgid "Expires"
+msgstr ""
+
+#: books/custom_carousel_card.html
+#, python-format
+msgid "1 person waiting"
+msgid_plural "%(count)d people waiting"
+msgstr[0] ""
+msgstr[1] ""
+
+#: books/custom_carousel_card.html
+msgid "Return via ADE"
+msgstr ""
+
+#: ReturnForm.html books/custom_carousel_card.html
+msgid "Really return this book?"
+msgstr ""
+
+#: ReturnForm.html books/custom_carousel_card.html
+msgid "Return book"
 msgstr ""
 
 #: books/daisy.html
@@ -7336,10 +7359,6 @@ msgstr ""
 msgid "Go to next section"
 msgstr ""
 
-#: FormatExpiry.html
-msgid "Expires"
-msgstr ""
-
 #: FulltextSearchSuggestion.html
 msgid "Checking for Search Inside matches"
 msgstr ""
@@ -7569,14 +7588,6 @@ msgstr ""
 
 #: RelatedSubjects.html
 msgid "Related..."
-msgstr ""
-
-#: ReturnForm.html
-msgid "Really return this book?"
-msgstr ""
-
-#: ReturnForm.html
-msgid "Return book"
 msgstr ""
 
 #: SearchResultsWork.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1406,6 +1406,10 @@ msgstr ""
 msgid "Already Read"
 msgstr ""
 
+#: account/mybooks.html
+msgid "Continue Reading"
+msgstr ""
+
 #: account/mybooks.html type/user/view.html
 msgid "This reader has chosen to make their Reading Log private."
 msgstr ""
@@ -3317,10 +3321,6 @@ msgstr ""
 #: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
-msgstr ""
-
-#: FormatExpiry.html books/custom_carousel_card.html
-msgid "Expires"
 msgstr ""
 
 #: books/custom_carousel_card.html
@@ -7357,6 +7357,10 @@ msgstr ""
 
 #: EditionNavBar.html
 msgid "Go to next section"
+msgstr ""
+
+#: FormatExpiry.html
+msgid "Expires"
 msgstr ""
 
 #: FulltextSearchSuggestion.html

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -13,6 +13,12 @@ $ loanstatus_start_time = time()
 $ availability = (doc.availability or {}) if hasattr(doc, 'availability') else doc.get('availability', {})
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0]['key'])
+
+$code:
+    _raw_cover = doc.get('cover_id') or doc.get('cover_i') or (doc.get('covers') and doc['covers'][0])
+    _ol_cover_id = None if (not _raw_cover or _raw_cover == -1) else _raw_cover
+    _ol_cover_edition_key = doc.get('cover_edition_key') or ''
+    _ol_author_names = list(doc.get('author_name') or [])
 $ book_title = doc.get('title') if hasattr(doc, 'get') else getattr(doc, 'title', None)
 
 $ user = get_current_user()
@@ -59,7 +65,7 @@ $def analytics_attr(action):
     data-ol-link-track="CTAClick|$action"
 
 $if lending_state == 'borrowed':
-  $:macros.ReadButton(ocaid, analytics_attr, loan=user_loan, listen=listen, edition_key=edition_key, book_title=book_title)
+  $:macros.ReadButton(ocaid, analytics_attr, loan=user_loan, listen=listen, edition_key=edition_key, book_title=book_title, ol_work_key=work_key, ol_cover_id=_ol_cover_id, ol_cover_edition_key=_ol_cover_edition_key, ol_author_names=_ol_author_names)
   $if secondary_action:
     $:macros.ReturnForm(ocaid, user_loan['expiry'])
 
@@ -69,7 +75,7 @@ $elif lending_state == 'partner':
 
 $elif lending_state == 'open':
   $# Open / Publicly Readable (Unrestricted)
-  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
+  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title, ol_work_key=work_key, ol_cover_id=_ol_cover_id, ol_cover_edition_key=_ol_cover_edition_key, ol_author_names=_ol_author_names)
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
 
@@ -79,12 +85,12 @@ $elif lending_state == 'printdisabled':
   $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
     $:macros.PreviewSearchInside(ocaid)
-  $:macros.ReadButton(ocaid, analytics_attr, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen, edition_key=edition_key, book_title=book_title)
+  $:macros.ReadButton(ocaid, analytics_attr, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen, edition_key=edition_key, book_title=book_title, ol_work_key=work_key, ol_cover_id=_ol_cover_id, ol_cover_edition_key=_ol_cover_edition_key, ol_author_names=_ol_author_names)
 
 $elif lending_state == 'borrowable':
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
-  $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen, edition_key=edition_key, book_title=book_title)
+  $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen, edition_key=edition_key, book_title=book_title, ol_work_key=work_key, ol_cover_id=_ol_cover_id, ol_cover_edition_key=_ol_cover_edition_key, ol_author_names=_ol_author_names)
 
 $elif lending_state == 'waitlist':
   $if secondary_action:

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,4 +1,4 @@
-$def with(ocaid, analytics_attr, borrow=False, listen=False, loan=None, label='', printdisabled=False, edition_key=None, book_title='')
+$def with(ocaid, analytics_attr, borrow=False, listen=False, loan=None, label='', printdisabled=False, edition_key=None, book_title='', ol_work_key=None, ol_cover_id=None, ol_cover_edition_key=None, ol_author_names=None)
 
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
@@ -31,6 +31,8 @@ $if any(menu_items) and not is_carousel:
         $:data_attr
         $if loan:
           data-userid="$(loan['userid'])"
+        data-ol-action="$(action)"
+        data-ol-book="$json_encode({'workKey': ol_work_key or '', 'title': book_title or '', 'coverId': ol_cover_id, 'coverEditionKey': ol_cover_edition_key or None, 'ocaid': ocaid or None, 'authorNames': list(ol_author_names or [])})"
         >$label</a>
     <details class="cta-btn cta-btn--available">
       <summary aria-label="$_('More reading options')"></summary>
@@ -59,5 +61,7 @@ $else:
         $:data_attr
         $if loan:
           data-userid="$(loan['userid'])"
+        data-ol-action="$(action)"
+        data-ol-book="$json_encode({'workKey': ol_work_key or '', 'title': book_title or '', 'coverId': ol_cover_id, 'coverEditionKey': ol_cover_edition_key or None, 'ocaid': ocaid or None, 'authorNames': list(ol_author_names or [])})"
         >$label</a>
   </div>

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -35,6 +35,38 @@ document.addEventListener('click', function(e) {
     }
 }, true);
 
+// Phase 2 — client-side read history: capture every Read/Borrow CTA click
+// site-wide and store a lightweight record in localStorage (ol_read_history).
+// No PII is stored — only public book metadata embedded by the server in
+// data-ol-action / data-ol-book attributes on the CTA link itself.
+document.addEventListener('click', function(e) {
+    const btn = e.target.closest('[data-ol-action="read"], [data-ol-action="borrow"]');
+    if (!btn) return;
+
+    let book = {};
+    try {
+        book = JSON.parse(btn.dataset.olBook || '{}');
+    } catch { /* ignore corrupt attribute value */ }
+
+    const workKey = book.workKey || '';
+    const olid = workKey.split('/').pop();
+    if (!olid || !workKey) return;
+
+    import(/* webpackChunkName: "reading-history" */ './my-books/store/readingHistory')
+        .then(({ addEntry }) => {
+            addEntry({
+                olid,
+                workKey,
+                title: book.title || '',
+                coverId: book.coverId || null,
+                coverEditionKey: book.coverEditionKey || null,
+                ocaid: book.ocaid || null,
+                authorNames: Array.isArray(book.authorNames) ? book.authorNames : [],
+                timestamp: Date.now(),
+            });
+        });
+});
+
 initSentry();
 
 // Init the service worker first since it does caching

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,3 +1,4 @@
+import { addEntry } from './my-books/store/readingHistory';
 import initSentry from './sentry';
 import 'jquery';
 import { exposeGlobally } from './jsdef';
@@ -40,7 +41,9 @@ document.addEventListener('click', function(e) {
 // No PII is stored — only public book metadata embedded by the server in
 // data-ol-action / data-ol-book attributes on the CTA link itself.
 document.addEventListener('click', function(e) {
-    const btn = e.target.closest('[data-ol-action="read"], [data-ol-action="borrow"]');
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    const btn = target.closest('[data-ol-action="read"], [data-ol-action="borrow"]');
     if (!btn) return;
 
     let book = {};
@@ -49,22 +52,19 @@ document.addEventListener('click', function(e) {
     } catch { /* ignore corrupt attribute value */ }
 
     const workKey = book.workKey || '';
-    const olid = workKey.split('/').pop();
+    const olid = workKey.split('/').filter(Boolean).pop();
     if (!olid || !workKey) return;
 
-    import(/* webpackChunkName: "reading-history" */ './my-books/store/readingHistory')
-        .then(({ addEntry }) => {
-            addEntry({
-                olid,
-                workKey,
-                title: book.title || '',
-                coverId: book.coverId || null,
-                coverEditionKey: book.coverEditionKey || null,
-                ocaid: book.ocaid || null,
-                authorNames: Array.isArray(book.authorNames) ? book.authorNames : [],
-                timestamp: Date.now(),
-            });
-        });
+    addEntry({
+        olid,
+        workKey,
+        title: book.title || '',
+        coverId: book.coverId || null,
+        coverEditionKey: book.coverEditionKey || null,
+        ocaid: book.ocaid || null,
+        authorNames: Array.isArray(book.authorNames) ? book.authorNames : [],
+        timestamp: Date.now(),
+    });
 });
 
 initSentry();

--- a/openlibrary/plugins/openlibrary/js/my-books/continueReading.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/continueReading.js
@@ -1,0 +1,72 @@
+import { getHistory } from './store/readingHistory';
+
+/**
+ * Initializes the "Continue Reading" client-side carousel on the My Books page
+ * using reading history stored in localStorage (ol_read_history).
+ */
+export function initContinueReading() {
+    const container = document.querySelector('#continue-reading-container');
+    if (!container) return;
+
+    const history = getHistory();
+    if (!history || !history.length) return;
+
+    const carouselTrack = container.querySelector('.continue-reading-carousel');
+    if (!carouselTrack) return;
+
+    // Clear existing content
+    carouselTrack.innerHTML = '';
+
+    const fallbackCover = 'https://openlibrary.org/static/images/icons/avatar_book.png';
+
+    history.forEach(item => {
+        const card = document.createElement('div');
+        card.className = 'book carousel__item';
+        card.style.textAlign = 'center';
+
+        const workUrl = item.workKey || (item.olid ? `/works/${item.olid}` : '#');
+        let coverUrl = fallbackCover;
+        if (item.coverId && item.coverId !== -1) {
+            coverUrl = `https://covers.openlibrary.org/b/id/${item.coverId}-M.jpg`;
+        } else if (item.coverEditionKey) {
+            coverUrl = `https://covers.openlibrary.org/b/olid/${item.coverEditionKey}-M.jpg`;
+        }
+
+        const readUrl = item.ocaid ? `/borrow/ia/${item.ocaid}?ref=ol` : workUrl;
+        const authorLine = Array.isArray(item.authorNames) && item.authorNames.length > 0
+            ? `by ${item.authorNames.join(', ')}`
+            : '';
+
+        card.innerHTML = `
+            <div class="book-cover" style="position: relative; display: inline-block; margin: 0 auto; border-radius: 4px; max-width: 100%;">
+                <a href="${escapeHtml(workUrl)}">
+                    <img class="bookcover" loading="lazy" title="${escapeHtml(item.title)} ${escapeHtml(authorLine)}" alt="${escapeHtml(item.title)}" src="${escapeHtml(coverUrl)}" />
+                </a>
+            </div>
+            <div class="ol-action-row">
+                <div class="ol-macro-wrapper">
+                    <div class="cta-button-group">
+                        <a href="${escapeHtml(readUrl)}" class="cta-btn cta-btn--available" data-ol-action="read">
+                            Read
+                        </a>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        carouselTrack.appendChild(card);
+    });
+
+    // Make section visible
+    container.style.display = 'block';
+}
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -4,10 +4,13 @@ import myBooksStore from './store';
 import { getListPartials } from '../lists/ListService';
 import { ShowcaseItem, createActiveShowcaseItem, toggleActiveShowcaseItems } from '../lists/ShowcaseItem';
 import { removeChildren } from '../utils';
+import { initContinueReading } from './continueReading';
 
 // XXX : jsdoc
 // XXX : decompose
 export function initMyBooksAffordances(dropperElements, showcaseElements) {
+    initContinueReading();
+
     const showcases = [];
     for (const elem of showcaseElements) {
         const showcase = new ShowcaseItem(elem);

--- a/openlibrary/plugins/openlibrary/js/my-books/store/readingHistory.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/store/readingHistory.js
@@ -1,0 +1,90 @@
+const STORAGE_KEY = 'ol_read_history';
+const MAX_ENTRIES = 20;
+
+/**
+ * @typedef {Object} ReadHistoryEntry
+ * @property {string} olid            - Work OLID (e.g. 'OL123W')
+ * @property {string} workKey         - Full work key path (e.g. '/works/OL123W')
+ * @property {string} title           - Book title
+ * @property {number|null} coverId    - Numeric cover ID for covers.openlibrary.org/b/id/
+ * @property {string|null} coverEditionKey - Edition OLID for /b/olid/ cover fallback
+ * @property {string|null} ocaid      - Internet Archive identifier for /b/ia/ cover fallback
+ * @property {string[]} authorNames   - List of author name strings
+ * @property {number} timestamp       - Date.now() at the time of the read/borrow interaction
+ */
+
+/**
+ * Reads and parses the history array from localStorage.
+ * Returns an empty array on missing key or JSON parse failure (corrupt data).
+ *
+ * @returns {ReadHistoryEntry[]}
+ */
+function readFromStorage() {
+    try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Serialises the history array back to localStorage.
+ * Silently no-ops when localStorage is unavailable (e.g. private-browsing
+ * quota exceeded or SecurityError in sandboxed iframes).
+ *
+ * @param {ReadHistoryEntry[]} entries
+ */
+function writeToStorage(entries) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch {
+        // ignore — storage unavailable
+    }
+}
+
+/**
+ * Upserts a book into the reading history.
+ *
+ * - If a record with the same `olid` already exists it is removed first
+ *   (so the updated record lands at position 0, i.e. most-recent).
+ * - The list is capped at MAX_ENTRIES (20) oldest entries are dropped.
+ * - Only public book metadata is stored; no PII.
+ *
+ * @param {ReadHistoryEntry} entry
+ */
+export function addEntry({ olid, workKey, title, coverId, coverEditionKey, ocaid, authorNames, timestamp }) {
+    const history = readFromStorage().filter(e => e.olid !== olid);
+    history.unshift({
+        olid,
+        workKey,
+        title,
+        coverId: coverId || null,
+        coverEditionKey: coverEditionKey || null,
+        ocaid: ocaid || null,
+        authorNames: Array.isArray(authorNames) ? authorNames : [],
+        timestamp: timestamp || Date.now(),
+    });
+    writeToStorage(history.slice(0, MAX_ENTRIES));
+}
+
+/**
+ * Returns the full reading history sorted by timestamp descending
+ * (most-recently interacted with first).
+ *
+ * @returns {ReadHistoryEntry[]}
+ */
+export function getHistory() {
+    return readFromStorage().slice().sort((a, b) => b.timestamp - a.timestamp);
+}
+
+/**
+ * Removes all entries from the reading history.
+ * Intended for use in tests and user opt-out flows.
+ */
+export function clearHistory() {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // ignore — storage unavailable
+    }
+}

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -32,7 +32,6 @@ from openlibrary.accounts import (
     audit_accounts,
     clear_cookies,
     encrypt_s3_keys,
-    get_s3_keys,
     valid_email,
 )
 from openlibrary.core import helpers as h
@@ -43,10 +42,7 @@ from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.db import get_db
 from openlibrary.core.follows import PubSub
-from openlibrary.core.lending import (
-    get_items_and_add_availability,
-    s3_loan_api,
-)
+from openlibrary.core.lending import get_loan_history_data
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
 from openlibrary.i18n import gettext as _
@@ -1192,8 +1188,7 @@ def get_account_loans_json(user: User) -> dict[str, Any]:
 
 def get_account_loan_history_json(user: User, page: int) -> dict[str, Any]:
     username = user["key"].split("/")[-1]
-    mb = MyBooksTemplate(username, key="loan_history")
-    loan_history_data = dict(get_loan_history_data(page=page, mb=mb))
+    loan_history_data = dict(get_loan_history_data(username, page=page))
     # Ensure all `docs` are `dicts`, as some are `Edition`s.
     loan_history_data["docs"] = [loan.dict() if not isinstance(loan, dict) else loan for loan in loan_history_data["docs"]]
     return {"loans_history": loan_history_data}
@@ -1237,7 +1232,7 @@ class account_loan_history(delegate.page):
         user = accounts.get_current_user()
         username = user["key"].split("/")[-1]
         mb = MyBooksTemplate(username, key="loan_history")
-        loan_history_data = get_loan_history_data(page=page, mb=mb)
+        loan_history_data = get_loan_history_data(username, page=page)
         template = render["account/loan_history"](
             docs=loan_history_data["docs"],
             current_page=page,
@@ -1402,70 +1397,6 @@ def process_goodreads_csv(i):
         else:
             books_wo_isbns[_book["Book Id"]] = _book
     return books, books_wo_isbns
-
-
-def get_loan_history_data(page: int, mb: MyBooksTemplate) -> dict[str, Any]:
-    """
-    Retrieve IA loan history data for page `page` of the patron's history.
-
-    This will use a patron's S3 keys to query the IA loan history API,
-    get the IA IDs, get the OLIDs if available, and and then convert this
-    into editions and IA-only items for display in the loan history.
-
-    This returns both editions and IA-only items because the loan history API
-    includes items that are not in Open Library, and displaying only IA
-    items creates pagination and navigation issues. For further discussion,
-    see https://github.com/internetarchive/openlibrary/pull/8375.
-    """
-    if not (account := OpenLibraryAccount.get_by_username(mb.username)):
-        raise render.notfound("Account for not found for %s" % mb.username, create=False)
-    s3_keys = get_s3_keys(account)
-    limit = RESULTS_PER_PAGE
-    offset = page * limit - limit
-    loan_history = s3_loan_api(
-        s3_keys=s3_keys,
-        action="user_borrow_history",
-        limit=limit + 1,
-        offset=offset,
-        newest=True,
-    ).json()["history"]["items"]
-
-    # We request limit+1 to see if there is another page of history to display,
-    # and then pop the +1 off if it's present.
-    show_next = len(loan_history) == limit + 1
-    if show_next:
-        loan_history.pop()
-
-    ocaids = [loan_record["identifier"] for loan_record in loan_history]
-    loan_history_map = {loan_record["identifier"]: loan_record for loan_record in loan_history}
-
-    # Get editions and attach their loan history.
-    editions_map = get_items_and_add_availability(ocaids=ocaids)
-    for edition in editions_map.values():
-        edition_loan_history = loan_history_map.get(edition.get("ocaid"))
-        edition["last_loan_date"] = edition_loan_history.get("updatedate") if edition_loan_history else ""
-
-    # Create 'placeholders' dicts for items in the Internet Archive loan history,
-    # but absent from Open Library, and then add loan history.
-    # ia_only['loan'] isn't set because `LoanStatus.html` reads it as a current
-    # loan. No apparently way to distinguish between current and past loans with
-    # this API call.
-    ia_only_loans = [{"ocaid": ocaid} for ocaid in ocaids if ocaid not in editions_map]
-    for ia_only_loan in ia_only_loans:
-        loan_data = loan_history_map[ia_only_loan["ocaid"]]
-        ia_only_loan["last_loan_date"] = loan_data.get("updatedate", "")
-        # Determine the macro to load for loan-history items only.
-        ia_only_loan["ia_only"] = True  # type: ignore[typeddict-unknown-key]
-
-    editions_and_ia_loans = list(editions_map.values()) + ia_only_loans
-    editions_and_ia_loans.sort(key=lambda item: item.get("last_loan_date", ""), reverse=True)
-
-    return {
-        "docs": editions_and_ia_loans,
-        "show_next": show_next,
-        "limit": limit,
-        "page": page,
-    }
 
 
 class account_security_check(delegate.page):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -20,10 +20,7 @@ from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.cache import memcache_memoize
 from openlibrary.core.follows import PubSub
-from openlibrary.core.lending import (
-    add_availability,
-    get_loans_of_user,
-)
+from openlibrary.core.lending import add_availability, get_loan_history_data, get_loans_of_user
 from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.i18n import gettext as _
@@ -74,14 +71,53 @@ class mybooks_home(delegate.page):
 
         if mb.me:
             myloans = get_loans_of_user(mb.me.key)
-            loans = web.Storage({"docs": [], "total_results": len(myloans)})
-            # TODO: should do in one web.ctx.get_many fetch
+
+            # Dictionary mapping dedup_key -> (book, timestamp, is_active)
+            merged_books: dict[str, tuple[Any, float, bool]] = {}
+
+            # Process active loans first
             for loan in myloans:
-                # Book will be None if no OL edition exists for the book
-                if book := site.get().get(loan["book"]):
-                    book.loan = loan
-                    loans.docs.append(book)
-            docs["loans"] = loans
+                book_key = loan["book"]
+                if book := site.get().get(book_key):
+                    for _ in range(5):
+                        if getattr(getattr(book, "type", None), "key", None) == "/type/redirect":
+                            book_key = book.location
+                            book = site.get().get(book_key)
+                        else:
+                            break
+                    if book:
+                        book.loan = loan
+                        works = getattr(book, "works", None)
+                        work_key = works[0].key if works and len(works) > 0 else book.key
+                        loaned_at = loan.get("loaned_at") or 0.0
+                        merged_books[work_key] = (book, float(loaned_at), True)
+
+            try:
+                history_data = get_loan_history_data(mb.username, page=1)
+                history_books = [doc for doc in history_data.get("docs", []) if not doc.get("ia_only")]
+            except Exception:  # noqa: BLE001
+                history_books = []
+
+            for book in history_books:
+                works = getattr(book, "works", None)
+                work_key = works[0].key if works and len(works) > 0 else book.key
+                updatedate = book.get("last_loan_date") or ""
+                try:
+                    timestamp = datetime.fromisoformat(updatedate.replace(" ", "T")).timestamp()
+                except ValueError:
+                    timestamp = 0.0
+
+                # Add history record only if no active loan exists for this book
+                if work_key not in merged_books:
+                    merged_books[work_key] = (book, timestamp, False)
+
+            # Sort: active loans first (is_active=True > False), then by timestamp desc.
+            # This ensures a currently-borrowed book always ranks above a recently-returned one.
+            total_results = len(merged_books)
+            sorted_entries = sorted(merged_books.values(), key=lambda x: (x[2], x[1]), reverse=True)
+            final_books = [entry[0] for entry in sorted_entries[:18]]
+
+            docs["loans"] = web.Storage({"docs": final_books, "total_results": total_results})
 
         if mb.me or mb.is_public:
             want_to_read = mb.readlog.get_works("want-to-read", limit=6)

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -45,6 +45,15 @@ $def year_span(year, use_local_year=False):
   $# Render carousels
   $if owners_page:
     $:(compact_carousel(loans) or empty_carousel(loans))
+    <div id="continue-reading-container" class="continue-reading-container" style="display: none;">
+      <div class="carousel-section-header">
+        <h2 class="home-h2">$_('Continue Reading')</h2>
+      </div>
+      <div class="carousel-container carousel-container-decorated">
+        <div class="carousel carousel--grid continue-reading-carousel">
+        </div>
+      </div>
+    </div>
   $if owners_page or public:
     $:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
     $:(compact_carousel(want_to_read) or empty_carousel(want_to_read))

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -49,6 +49,9 @@ $if test or (books and len(books) >= min_books):
                               target_data = docs[0]
               $ book2 = storage(target_data)
               $ book2['authors'] = book.get('authors', [])
+              $ loan = book.get('loan')
+              $if loan:
+                $ book2['loan'] = loan
               $:render_template("books/custom_carousel_card", book2, lazy_load, layout, key=key, secondary_action=secondary_action)
         </div>
       </div>

--- a/openlibrary/templates/books/custom_carousel_card.html
+++ b/openlibrary/templates/books/custom_carousel_card.html
@@ -29,8 +29,32 @@ $if author_names:
 $else:
   $ byline = ''
 
-<div class="book carousel__item">
-  <div class="book-cover">
+<div class="book carousel__item" style="text-align: center;">
+
+
+  $ loan = book.get('loan')
+  <div class="book-cover" style="position: relative; display: inline-block; margin: 0 auto; border-radius: 4px; max-width: 100%;">
+    $if loan:
+      $ wlsize = book.get_waitinglist_size() if hasattr(book, 'get_waitinglist_size') else 0
+      $ has_expiry = loan.get('expiry')
+      $ is_bookreader = loan.get('resource_type') == 'bookreader'
+      $if has_expiry or wlsize or not is_bookreader:
+        <div class="loan-overlay-badge">
+          $if has_expiry:
+            $:macros.FormatExpiry(loan.get('expiry'))
+          $if wlsize:
+            <div class="loan-overlay-badge__waitlist">
+              $ungettext("1 person waiting", "%(count)d people waiting", wlsize, count=wlsize)
+            </div>
+          $if not is_bookreader:
+            <div class="loan-overlay-badge__not-bookreader">
+              $if loan.get('expiry') is None:
+                <span class="loan-overlay-badge__not-downloaded">$_("Not yet downloaded.")</span><br/>
+                <a href="$loan.get('loan_link')" class="loan-overlay-badge__download-link">$_("Download Now")</a>
+              $else:
+                <span style="opacity: 0.9;">$_("Return via ADE")</span>
+            </div>
+        </div>
     <a href="$(url)" data-ol-link-track="BookCarousel|CoverClick|$key">
       $if cover_url:
         <img class="bookcover" loading="lazy"
@@ -49,5 +73,20 @@ $else:
         </div>
     </a>
   </div>
-  $:macros.LoanStatus(book, work_key=url, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
+
+  <div class="ol-action-row">
+    <div class="ol-macro-wrapper">
+      $:macros.LoanStatus(book, work_key=url, listen=False, secondary_action=(secondary_action and not loan), analytics_override="BookCarousel|CTAClick|%s" % key)
+    </div>
+    $if loan and loan.get('resource_type') == 'bookreader':
+      <div class="ol-return-wrapper">
+        <form action="/borrow/ia/$(loan.get('ocaid'))" method="post" class="return-form" data-i18n="$json_encode({'confirm_return': _('Really return this book?')})">
+          <input type="hidden" name="action" value="return" />
+          <input type="hidden" name="redirect" value="$request.fullpath" />
+          <button type="submit" class="cta-btn cta-btn--ia cta-btn--available" title="$_('Return book')" aria-label="$_('Return book')">
+            <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#FFFFFF"><path d="M288-192v-72h288q50 0 85-35t35-85q0-50-35-85t-85-35H330l93 93-51 51-180-180 180-180 51 51-93 93h246q80 0 136 56t56 136q0 80-56 136t-136 56H288Z"/></svg>
+          </button>
+        </form>
+      </div>
+  </div>
 </div>

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import web
 
+from openlibrary.core.lending import get_loan_history_data
 from openlibrary.plugins.upstream import account as legacy_account
 
 
@@ -131,3 +132,34 @@ class TestAccountLoansJson:
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == json.loads(legacy_response.rawtext)
+
+    @pytest.mark.parametrize(
+        "mock_response_val",
+        [
+            {},
+            {"history": None},
+            {"history": {"items": None}},
+        ],
+    )
+    def test_get_loan_history_data_handles_missing_or_null_history(self, mock_response_val):
+        mock_account = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_response_val
+
+        with (
+            patch("openlibrary.core.lending.OpenLibraryAccount.get_by_username", return_value=mock_account),
+            patch("openlibrary.core.lending.get_s3_keys", return_value={"access": "acc", "secret": "sec"}),
+            patch("openlibrary.core.lending.s3_loan_api", return_value=mock_response) as mock_s3_loan_api,
+            patch("openlibrary.core.lending.get_items_and_add_availability", return_value={}) as mock_availability,
+        ):
+            result = get_loan_history_data(username="testuser", page=1)
+
+            assert result == {
+                "docs": [],
+                "show_next": False,
+                "limit": 25,
+                "page": 1,
+            }
+            mock_s3_loan_api.assert_called_once()
+            mock_availability.assert_called_once_with(ocaids=[])

--- a/openlibrary/tests/fastapi/test_unified_loans_carousel.py
+++ b/openlibrary/tests/fastapi/test_unified_loans_carousel.py
@@ -1,0 +1,179 @@
+from unittest.mock import MagicMock, patch
+
+from openlibrary.plugins.upstream.mybooks import MyBooksTemplate, mybooks_home
+from openlibrary.utils.request_context import RequestContextVars, req_context
+
+
+def test_unified_loans_carousel_merges_active_and_history():
+    # Setup req_context to prevent LookupError
+    req_context.set(RequestContextVars(x_forwarded_for=None, user_agent=None, lang="en", solr_editions=True, print_disabled=False, is_bot=False))
+
+    # Setup mock active loans
+    active_loan_book_A = MagicMock()
+    active_loan_book_A.key = "/books/OL1M"
+    active_work_A = MagicMock()
+    active_work_A.key = "/works/OL1W"
+    active_loan_book_A.works = [active_work_A]
+
+    active_loan_book_B = MagicMock()
+    active_loan_book_B.key = "/books/OL2M"
+    active_work_B = MagicMock()
+    active_work_B.key = "/works/OL2W"
+    active_loan_book_B.works = [active_work_B]
+
+    # Define mock active loans: A (older) and B (newer)
+    mock_active_loans = [
+        {"book": "/books/OL1M", "loaned_at": 1000.0},
+        {"book": "/books/OL2M", "loaned_at": 2000.0},
+    ]
+
+    # Setup mock resolved history edition A (re-opened)
+    mock_history_book_A = MagicMock()
+    mock_history_book_A.key = "/books/OL1M"
+    mock_history_book_A.works = [active_work_A]
+    mock_history_book_A.get.side_effect = lambda k, default=None: {
+        "last_loan_date": "2026-08-07 12:00:00",
+        "ia_only": False,
+    }.get(k, default)
+
+    # Mock template container
+    mock_mb = MagicMock(spec=MyBooksTemplate)
+    mock_mb.me = MagicMock()
+    mock_mb.me.key = "/people/testuser"
+    mock_mb.username = "testuser"  # instance attr not in spec; set explicitly
+    mock_mb.user = MagicMock()
+    mock_mb.is_public = False
+    mock_mb.key = "mybooks"
+    mock_mb.counts = {}
+    mock_mb.lists = []
+    mock_mb.component_times = {}
+    mock_mb.is_my_page = True
+
+    # Setup readlog mock to prevent AttributeError
+    mock_mb.readlog = MagicMock()
+    mock_mb.readlog.get_works.return_value = MagicMock(docs=[])
+
+    # Stub site.get().get to resolve the active books
+    mock_site = MagicMock()
+    site_map = {
+        "/books/OL1M": active_loan_book_A,
+        "/books/OL2M": active_loan_book_B,
+    }
+    mock_site.get.side_effect = site_map.get
+
+    mock_site_context = MagicMock()
+    mock_site_context.get.return_value = mock_site
+
+    mock_render = MagicMock()
+
+    # Patch the necessary functions
+    with (
+        patch("openlibrary.plugins.upstream.mybooks.get_loans_of_user", return_value=mock_active_loans),
+        patch("openlibrary.plugins.upstream.mybooks.get_loan_history_data") as mock_history_data,
+        patch("openlibrary.plugins.upstream.mybooks.site", mock_site_context),
+        patch("openlibrary.plugins.upstream.mybooks.render", mock_render),
+    ):
+        mock_history_data.return_value = {"docs": [mock_history_book_A]}
+
+        # Execute
+        home = mybooks_home()
+        home.render_template(mock_mb)
+
+        # Retrieve the docs dictionary passed to render["account/mybooks"](...)
+        mock_render_func = mock_render.__getitem__.return_value
+        assert mock_render_func.called
+        args, _kwargs = mock_render_func.call_args
+        docs = args[1]
+
+        loans_carousel = docs["loans"]
+        assert loans_carousel is not None
+
+        # Should contain active_loan_book_A and active_loan_book_B
+        assert len(loans_carousel.docs) == 2
+
+        # Sort order check:
+        # Since active loans are processed first and their timestamps are not overridden by history,
+        # they sort by their active loan timestamps: Book B (2000.0) first, Book A (1000.0) second.
+        assert loans_carousel.docs[0].key == "/books/OL2M"
+        assert loans_carousel.docs[1].key == "/books/OL1M"
+
+        # Both must have their `.loan` attribute attached as they are active loans
+        assert loans_carousel.docs[0].loan == {"book": "/books/OL2M", "loaned_at": 2000.0}
+        assert loans_carousel.docs[1].loan == {"book": "/books/OL1M", "loaned_at": 1000.0}
+
+
+def test_active_loan_ranks_above_recently_returned():
+    """A currently-borrowed book must appear before a recently-returned one,
+    even when the return timestamp is more recent than the active loan's loaned_at."""
+    req_context.set(RequestContextVars(x_forwarded_for=None, user_agent=None, lang="en", solr_editions=True, print_disabled=False, is_bot=False))
+
+    # Book A: still actively borrowed (loaned_at = old timestamp)
+    active_loan_book_A = MagicMock()
+    active_loan_book_A.key = "/books/OL1M"
+    active_work_A = MagicMock()
+    active_work_A.key = "/works/OL1W"
+    active_loan_book_A.works = [active_work_A]
+
+    # Book B: returned — present only in history with a very recent updatedate
+    returned_book_B = MagicMock()
+    returned_book_B.key = "/books/OL2M"
+    active_work_B = MagicMock()
+    active_work_B.key = "/works/OL2W"
+    returned_book_B.works = [active_work_B]
+    returned_book_B.get.side_effect = lambda k, default=None: {
+        "last_loan_date": "2026-08-07 12:00:00",  # very recent return timestamp
+        "ia_only": False,
+    }.get(k, default)
+
+    mock_active_loans = [{"book": "/books/OL1M", "loaned_at": 1000.0}]  # only A is active
+
+    mock_mb = MagicMock(spec=MyBooksTemplate)
+    mock_mb.me = MagicMock()
+    mock_mb.me.key = "/people/testuser"
+    mock_mb.username = "testuser"
+    mock_mb.user = MagicMock()
+    mock_mb.is_public = False
+    mock_mb.key = "mybooks"
+    mock_mb.counts = {}
+    mock_mb.lists = []
+    mock_mb.component_times = {}
+    mock_mb.is_my_page = True
+    mock_mb.readlog = MagicMock()
+    mock_mb.readlog.get_works.return_value = MagicMock(docs=[])
+
+    mock_site = MagicMock()
+    mock_site.get.side_effect = {"/books/OL1M": active_loan_book_A}.get
+
+    mock_site_context = MagicMock()
+    mock_site_context.get.return_value = mock_site
+
+    mock_render = MagicMock()
+
+    with (
+        patch("openlibrary.plugins.upstream.mybooks.get_loans_of_user", return_value=mock_active_loans),
+        patch("openlibrary.plugins.upstream.mybooks.get_loan_history_data") as mock_history_data,
+        patch("openlibrary.plugins.upstream.mybooks.site", mock_site_context),
+        patch("openlibrary.plugins.upstream.mybooks.render", mock_render),
+    ):
+        # History contains both A (old date) and B (recently returned)
+        mock_history_book_A = MagicMock()
+        mock_history_book_A.works = [active_work_A]
+        mock_history_book_A.get.side_effect = lambda k, default=None: {
+            "last_loan_date": "2024-01-01 00:00:00",
+            "ia_only": False,
+        }.get(k, default)
+        mock_history_data.return_value = {"docs": [mock_history_book_A, returned_book_B]}
+
+        home = mybooks_home()
+        home.render_template(mock_mb)
+
+        mock_render_func = mock_render.__getitem__.return_value
+        args, _kwargs = mock_render_func.call_args
+        loans_carousel = args[1]["loans"]
+
+        assert len(loans_carousel.docs) == 2
+        # Active loan A must appear first, returned B second — regardless of B's newer timestamp
+        assert loans_carousel.docs[0].key == "/books/OL1M"
+        assert loans_carousel.docs[1].key == "/books/OL2M"
+        # A must still carry its loan attribute
+        assert loans_carousel.docs[0].loan == {"book": "/books/OL1M", "loaned_at": 1000.0}

--- a/static/css/components/carousel--js.css
+++ b/static/css/components/carousel--js.css
@@ -27,3 +27,71 @@
 .carousel .slick-next {
   margin-right: 11px;
 }
+
+/* Loan overlay badge and action row */
+.loan-overlay-badge {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.65);
+  color: var(--white);
+  padding: 4px 8px;
+  font-size: 0.7em;
+  line-height: 1.3;
+  z-index: var(--z-index-level-2);
+  text-align: center;
+  border-radius: 4px 4px 0 0;
+  white-space: nowrap;
+}
+
+.loan-overlay-badge__waitlist {
+  color: var(--soft-green);
+  font-size: 0.9em;
+  margin-top: 2px;
+}
+
+.loan-overlay-badge__not-bookreader {
+  margin-top: 3px;
+  font-size: 0.9em;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding-top: 2px;
+  line-height: 1.3;
+}
+
+.loan-overlay-badge__not-downloaded {
+  color: var(--red-two);
+  font-weight: bold;
+}
+
+.loan-overlay-badge__download-link {
+  color: var(--button-hover-blue);
+  text-decoration: underline;
+}
+
+.ol-action-row {
+  margin-top: 10px;
+  display: flex;
+  gap: 4px;
+  height: 38px;
+}
+
+.ol-action-row > * {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+
+.ol-action-row .cta-btn,
+.ol-action-row .cta-button-group {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+}
+
+.ol-return-wrapper {
+  flex: 0 0 42px;
+}

--- a/static/css/legacy.css
+++ b/static/css/legacy.css
@@ -25,6 +25,7 @@
 @import "components/preview.css";
 @import "components/diff.css";
 @import "components/carousel.css";
+@import "components/custom-carousel-card.css";
 @import "components/category-item.css";
 @import "components/loading-indicator.css";
 @import "components/editions.css";

--- a/tests/unit/js/continueReading.test.js
+++ b/tests/unit/js/continueReading.test.js
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { initContinueReading } from '../../../openlibrary/plugins/openlibrary/js/my-books/continueReading';
+import * as readingHistoryStore from '../../../openlibrary/plugins/openlibrary/js/my-books/store/readingHistory';
+
+describe('initContinueReading', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        jest.restoreAllMocks();
+    });
+
+    test('does nothing when container is not in DOM', () => {
+        const spy = jest.spyOn(readingHistoryStore, 'getHistory');
+        expect(() => initContinueReading()).not.toThrow();
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('keeps container hidden when reading history is empty', () => {
+        document.body.innerHTML = `
+            <div id="continue-reading-container" style="display: none;">
+                <div class="continue-reading-carousel"></div>
+            </div>
+        `;
+        jest.spyOn(readingHistoryStore, 'getHistory').mockReturnValue([]);
+
+        initContinueReading();
+
+        const container = document.querySelector('#continue-reading-container');
+        expect(container.style.display).toBe('none');
+    });
+
+    test('populates carousel and displays container when history exists', () => {
+        document.body.innerHTML = `
+            <div id="continue-reading-container" style="display: none;">
+                <div class="continue-reading-carousel"></div>
+            </div>
+        `;
+
+        const mockItems = [
+            {
+                olid: 'OL123M',
+                workKey: '/works/OL123W',
+                title: 'Dune',
+                coverId: 45678,
+                ocaid: 'dune0000herb',
+                authorNames: ['Frank Herbert'],
+                timestamp: 1600000000000,
+            },
+            {
+                olid: 'OL999M',
+                workKey: '/works/OL999W',
+                title: 'Foundation & Empire',
+                coverEditionKey: 'OL999M',
+                ocaid: null,
+                authorNames: ['Isaac Asimov'],
+                timestamp: 1500000000000,
+            },
+        ];
+
+        jest.spyOn(readingHistoryStore, 'getHistory').mockReturnValue(mockItems);
+
+        initContinueReading();
+
+        const container = document.querySelector('#continue-reading-container');
+        expect(container.style.display).toBe('block');
+
+        const cards = container.querySelectorAll('.book.carousel__item');
+        expect(cards.length).toBe(2);
+
+        // First item checks
+        const firstCard = cards[0];
+        expect(firstCard.querySelector('a').getAttribute('href')).toBe('/works/OL123W');
+        expect(firstCard.querySelector('img').getAttribute('src')).toBe('https://covers.openlibrary.org/b/id/45678-M.jpg');
+        expect(firstCard.querySelector('img').getAttribute('title')).toBe('Dune by Frank Herbert');
+        expect(firstCard.querySelector('a.cta-btn').getAttribute('href')).toBe('/borrow/ia/dune0000herb?ref=ol');
+
+        // Second item checks
+        const secondCard = cards[1];
+        expect(secondCard.querySelector('img').getAttribute('src')).toBe('https://covers.openlibrary.org/b/olid/OL999M-M.jpg');
+        expect(secondCard.querySelector('a.cta-btn').getAttribute('href')).toBe('/works/OL999W');
+    });
+
+    test('escapes HTML special characters in title and authors', () => {
+        document.body.innerHTML = `
+            <div id="continue-reading-container" style="display: none;">
+                <div class="continue-reading-carousel"></div>
+            </div>
+        `;
+
+        const mockItems = [
+            {
+                olid: 'OL1M',
+                workKey: '/works/OL1W',
+                title: 'Cat & Mouse <Script>',
+                coverId: 100,
+                ocaid: 'cat',
+                authorNames: ['Author <1>', 'Author & 2'],
+                timestamp: 1600000000000,
+            },
+        ];
+
+        jest.spyOn(readingHistoryStore, 'getHistory').mockReturnValue(mockItems);
+
+        initContinueReading();
+
+        const card = document.querySelector('#continue-reading-container .book');
+        expect(card.innerHTML).toContain('Cat &amp; Mouse');
+        expect(card.querySelector('script')).toBeNull();
+        const img = document.querySelector('#continue-reading-container img');
+        expect(img.getAttribute('alt')).toBe('Cat & Mouse <Script>');
+    });
+});

--- a/tests/unit/js/readingHistory.test.js
+++ b/tests/unit/js/readingHistory.test.js
@@ -1,0 +1,197 @@
+import { addEntry, getHistory, clearHistory } from '../../../openlibrary/plugins/openlibrary/js/my-books/store/readingHistory';
+
+const STORAGE_KEY = 'ol_read_history';
+
+/**
+ * Returns a fully-populated entry, optionally overriding any fields.
+ * @param {Partial<import('../../../openlibrary/plugins/openlibrary/js/my-books/store/readingHistory').ReadHistoryEntry>} overrides
+ */
+function makeEntry(overrides = {}) {
+    return {
+        olid: 'OL1W',
+        workKey: '/works/OL1W',
+        title: 'Test Book',
+        coverId: 123,
+        coverEditionKey: 'OL1M',
+        ocaid: 'testbook00',
+        authorNames: ['Author One'],
+        timestamp: Date.now(),
+        ...overrides,
+    };
+}
+
+describe('readingHistory store', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    // --- addEntry ---
+
+    it('addEntry stores a single new entry', () => {
+        addEntry(makeEntry());
+
+        const history = getHistory();
+        expect(history).toHaveLength(1);
+        expect(history[0].olid).toBe('OL1W');
+        expect(history[0].title).toBe('Test Book');
+        expect(history[0].coverId).toBe(123);
+        expect(history[0].ocaid).toBe('testbook00');
+        expect(history[0].authorNames).toEqual(['Author One']);
+    });
+
+    it('addEntry stores all provided metadata fields', () => {
+        addEntry(makeEntry({
+            olid: 'OL99W',
+            workKey: '/works/OL99W',
+            title: 'Detailed Book',
+            coverId: 456,
+            coverEditionKey: 'OL99M',
+            ocaid: 'detailedbook00',
+            authorNames: ['Alice', 'Bob'],
+            timestamp: 1000000,
+        }));
+
+        const [entry] = getHistory();
+        expect(entry.olid).toBe('OL99W');
+        expect(entry.workKey).toBe('/works/OL99W');
+        expect(entry.coverId).toBe(456);
+        expect(entry.coverEditionKey).toBe('OL99M');
+        expect(entry.ocaid).toBe('detailedbook00');
+        expect(entry.authorNames).toEqual(['Alice', 'Bob']);
+        expect(entry.timestamp).toBe(1000000);
+    });
+
+    it('addEntry deduplicates by olid — old record is removed', () => {
+        addEntry(makeEntry({ olid: 'OL1W', title: 'First' }));
+        addEntry(makeEntry({ olid: 'OL2W', title: 'Second' }));
+        addEntry(makeEntry({ olid: 'OL1W', title: 'First (Re-read)', timestamp: Date.now() + 1000 }));
+
+        const history = getHistory();
+        expect(history).toHaveLength(2);
+
+        const match = history.find(e => e.olid === 'OL1W');
+        expect(match.title).toBe('First (Re-read)');
+    });
+
+    it('addEntry promotes re-read entry to front of the list', () => {
+        addEntry(makeEntry({ olid: 'OL1W', timestamp: 1000 }));
+        addEntry(makeEntry({ olid: 'OL2W', timestamp: 2000 }));
+        // Re-read OL1W — it should jump to position 0
+        addEntry(makeEntry({ olid: 'OL1W', timestamp: 3000 }));
+
+        const history = getHistory();
+        expect(history[0].olid).toBe('OL1W');
+        expect(history[1].olid).toBe('OL2W');
+    });
+
+    it('addEntry caps the list at 20 entries, dropping the oldest', () => {
+        for (let i = 0; i < 25; i++) {
+            addEntry(makeEntry({ olid: `OL${i}W`, timestamp: i }));
+        }
+
+        const history = getHistory();
+        expect(history).toHaveLength(20);
+    });
+
+    it('addEntry keeps the most-recently added entries when capping', () => {
+        for (let i = 0; i < 25; i++) {
+            addEntry(makeEntry({ olid: `OL${i}W`, timestamp: i }));
+        }
+
+        // OL24W was added last and should survive the cap
+        const history = getHistory();
+        const olids = history.map(e => e.olid);
+        expect(olids).toContain('OL24W');
+        // OL0W was added first (timestamp=0) and must be evicted
+        expect(olids).not.toContain('OL0W');
+    });
+
+    it('addEntry coerces falsy coverId to null', () => {
+        addEntry(makeEntry({ coverId: 0 }));
+        expect(getHistory()[0].coverId).toBeNull();
+    });
+
+    it('addEntry coerces empty ocaid to null', () => {
+        addEntry(makeEntry({ ocaid: '' }));
+        expect(getHistory()[0].ocaid).toBeNull();
+    });
+
+    it('addEntry coerces empty coverEditionKey to null', () => {
+        addEntry(makeEntry({ coverEditionKey: '' }));
+        expect(getHistory()[0].coverEditionKey).toBeNull();
+    });
+
+    it('addEntry defaults authorNames to an empty array when not provided', () => {
+        addEntry(makeEntry({ authorNames: undefined }));
+        expect(getHistory()[0].authorNames).toEqual([]);
+    });
+
+    it('addEntry uses Date.now() as timestamp when none is provided', () => {
+        const before = Date.now();
+        addEntry({ olid: 'OL1W', workKey: '/works/OL1W', title: 'T' });
+        const after = Date.now();
+
+        const [entry] = getHistory();
+        expect(entry.timestamp).toBeGreaterThanOrEqual(before);
+        expect(entry.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    // --- getHistory ---
+
+    it('getHistory returns an empty array when storage is empty', () => {
+        expect(getHistory()).toEqual([]);
+    });
+
+    it('getHistory returns entries sorted by timestamp descending', () => {
+        const now = Date.now();
+        addEntry(makeEntry({ olid: 'OL1W', timestamp: now }));
+        addEntry(makeEntry({ olid: 'OL2W', timestamp: now + 2000 }));
+        addEntry(makeEntry({ olid: 'OL3W', timestamp: now + 1000 }));
+
+        const history = getHistory();
+        expect(history[0].olid).toBe('OL2W');
+        expect(history[1].olid).toBe('OL3W');
+        expect(history[2].olid).toBe('OL1W');
+    });
+
+    it('getHistory does not mutate the stored order', () => {
+        // addEntry stores newest-first (unshift), so OL2W is at index 0 in storage
+        addEntry(makeEntry({ olid: 'OL1W', timestamp: 1 }));
+        addEntry(makeEntry({ olid: 'OL2W', timestamp: 2 }));
+
+        // getHistory sorts a copy; calling it twice must be stable
+        const first = getHistory();
+        const second = getHistory();
+        expect(first.map(e => e.olid)).toEqual(second.map(e => e.olid));
+    });
+
+    // --- clearHistory ---
+
+    it('clearHistory empties the list', () => {
+        addEntry(makeEntry());
+        addEntry(makeEntry({ olid: 'OL2W' }));
+
+        clearHistory();
+        expect(getHistory()).toHaveLength(0);
+    });
+
+    it('clearHistory removes the localStorage key entirely', () => {
+        addEntry(makeEntry());
+        clearHistory();
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    // --- resilience ---
+
+    it('getHistory returns an empty array on corrupt localStorage data', () => {
+        localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{');
+        expect(() => getHistory()).not.toThrow();
+        expect(getHistory()).toHaveLength(0);
+    });
+
+    it('addEntry recovers from corrupt localStorage data and writes a fresh entry', () => {
+        localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{');
+        expect(() => addEntry(makeEntry())).not.toThrow();
+        expect(getHistory()).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
Closes #13274

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: Implement client-side "Continue Reading" carousel on the My Books landing page (`/account/books/`) backed by `localStorage.ol_read_history`.

> [!NOTE]
> This is a **Draft PR** stacked on top of PR #13282 (`13273/feature/client-side-read-tracking`).

### Technical
- **Template (`openlibrary/templates/account/mybooks.html`)**: Added `#continue-reading-container` section (initially hidden) beneath the My Loans section for `owners_page`.
- **Client-Side Module (`openlibrary/plugins/openlibrary/js/my-books/continueReading.js`)**:
  - Implements `initContinueReading()` to query `localStorage.ol_read_history` via `store/readingHistory.getHistory()`.
  - Unhides `#continue-reading-container` if local reading history exists.
  - Dynamically builds standard carousel cards for each history entry, setting work link, cover thumbnail (cover ID or OLID), title, author byline, and Read button CTA.
- **My Books Initialization (`openlibrary/plugins/openlibrary/js/my-books/index.js`)**: Invokes `initContinueReading()` inside `initMyBooksAffordances()`.
- **Unit Tests (`tests/unit/js/continueReading.test.js`)**: Added Jest unit test suite covering DOM initialization, empty history guard, card rendering, and HTML escaping.

### Testing
- Ran Jest unit test suite:
  ```bash
  npx jest tests/unit/js/continueReading.test.js
  ```
  *(4/4 tests passing)*

- Manual Verification Steps:
  1. Open any book page and click "Read" or "Borrow".
  2. Navigate to `/account/books/`.
  3. Verify the "Continue Reading" carousel appears displaying the previously clicked book(s).

### Screenshot
*N/A — Client-side progressive enhancement carousel on My Books landing page.*

### Stakeholders
@Sadashii @mekarpeles
