### PR TITLE
Finish the deprecated color-alias migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,10 @@ repos:
           - stylelint@16.22.0
           - stylelint-declaration-strict-value@1.11.1
           - stylelint-prettier@5.0.3
-        args: [--fix]
+        # --allow-empty-input: .stylelintignore covers whole directories (e.g.
+        # static/css/tokens/), so a commit touching only ignored files would
+        # otherwise fail the hook with AllFilesIgnoredError.
+        args: [--fix, --allow-empty-input]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v10.8.0

--- a/docs/ai/design.md
+++ b/docs/ai/design.md
@@ -90,7 +90,9 @@ Semantic tokens reference primitives and describe purpose, not appearance.
 --border-radius-card: var(--border-radius-lg);
 ```
 
-The main semantic groups in `colors.css`: text (`--color-text`, `-secondary`, `-muted`, `-inverse`), surfaces (`--color-background`, `--color-surface`, `-raised`, `-sunken`, `-header`), links (`--color-link`, `-hover`, `-visited`), primary action (`--color-primary`, `-hover`, `-active`, `-subtle`, `--color-on-primary`), borders (`--color-border`, `-subtle`, `-hover`, `-focused`, `-error`, `--color-focus-ring`), and status (`--color-{success,error,warning}-{fg,bg,border}`).
+The main semantic groups in `colors.css`: text (`--color-text`, `-heading`, `-secondary`, `-muted`, `-inverse`), icons (`--color-icon-muted`), surfaces (`--color-background`, `--color-surface`, `-raised`, `-sunken`, `-header`), links (`--color-link`, `-hover`, `-visited`), primary action (`--color-primary`, `-hover`, `-active`, `-subtle`, `--color-on-primary`), borders (`--color-border`, `-muted`, `-subtle`, `-hover`, `-focused`, `-error`, `--color-focus-ring`), and status (`--color-{success,error,warning}-{fg,bg,border}`).
+
+Two of these are a **decorative tier** and carry that caveat in `colors.css`: `--color-border-muted` (1.6:1 on white) and `--color-icon-muted` (2.5:1). They're for dividers and inert chrome. Anything a user has to *read* or that marks the edge of a control needs `--color-border` or darker.
 
 Hover has two tokens, split by mechanism rather than by surface. `--color-hover-overlay` is a translucent overlay for flat interactive rows (popover items, menu items, list rows) — it composes over whatever surface it lands on, so a row on `--color-surface-sunken` or `-header` still darkens instead of matching its own background. `--color-control-hover` is an opaque fill for raised controls, and must stay opaque: alpha fed to `--control-surface` inverts the specular highlight.
 

--- a/docs/ai/design.md
+++ b/docs/ai/design.md
@@ -92,7 +92,9 @@ Semantic tokens reference primitives and describe purpose, not appearance.
 
 The main semantic groups in `colors.css`: text (`--color-text`, `-heading`, `-secondary`, `-muted`, `-inverse`), icons (`--color-icon-muted`), surfaces (`--color-background`, `--color-surface`, `-raised`, `-sunken`, `-header`), links (`--color-link`, `-hover`, `-visited`), primary action (`--color-primary`, `-hover`, `-active`, `-subtle`, `--color-on-primary`), borders (`--color-border`, `-muted`, `-subtle`, `-hover`, `-focused`, `-error`, `--color-focus-ring`), and status (`--color-{success,error,warning}-{fg,bg,border}`).
 
-Two of these are a **decorative tier** and carry that caveat in `colors.css`: `--color-border-muted` (1.6:1 on white) and `--color-icon-muted` (2.5:1). They're for dividers and inert chrome. Anything a user has to *read* or that marks the edge of a control needs `--color-border` or darker.
+Two of these are a **decorative tier** and carry that caveat in `colors.css`: `--color-border-muted` (1.6:1 on white) and `--color-icon-muted` (2.5:1). In new code they're for dividers and inert chrome — anything a user has to *read*, or that is the sole marker of a control's edge, needs `--color-border` or darker.
+
+You will find existing control borders on `--color-border-muted`. They were migrated at their original weight so the token rollout stayed a no-op; that they sit below 3:1 is a pre-existing gap to fix deliberately, not a precedent to copy.
 
 Hover has two tokens, split by mechanism rather than by surface. `--color-hover-overlay` is a translucent overlay for flat interactive rows (popover items, menu items, list rows) — it composes over whatever surface it lands on, so a row on `--color-surface-sunken` or `-header` still darkens instead of matching its own background. `--color-control-hover` is an opaque fill for raised controls, and must stay opaque: alpha fed to `--control-surface` inverts the specular highlight.
 

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -155,7 +155,7 @@ export class OLMarkdownEditor extends LitElement {
     }
 
     .html-block {
-      border: 1px dashed var(--light-grey);
+      border: 1px dashed var(--color-border-muted);
       border-radius: var(--border-radius-card);
       margin: 0.55em 0;
       overflow: hidden;
@@ -165,7 +165,7 @@ export class OLMarkdownEditor extends LitElement {
       display: block;
       padding: 4px 8px;
       background: var(--grey-f4f4f4);
-      border-bottom: 1px dashed var(--light-grey);
+      border-bottom: 1px dashed var(--color-border-muted);
       font-size: 0.7rem;
       font-family: monospace;
       font-weight: 600;

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -76,7 +76,7 @@ export class OLMarkdownEditor extends LitElement {
       border: var(--border-input);
       border-radius: var(--border-radius-card);
       background: var(--white);
-      color: var(--dark-grey);
+      color: var(--color-text);
       max-height: 70vh;
       overflow-y: auto;
       /* Contain the toolbar/popover layering — a shadow root is not a
@@ -141,7 +141,7 @@ export class OLMarkdownEditor extends LitElement {
     }
 
     .editor-input .tiptap a {
-      color: var(--link-blue);
+      color: var(--color-link);
     }
 
     .editor-input .tiptap img {
@@ -189,7 +189,7 @@ export class OLMarkdownEditor extends LitElement {
     .editor-input .tiptap blockquote {
       margin-left: var(--spacing-lg);
       padding: var(--spacing-sm) var(--spacing-lg);
-      border-left: var(--border-width-thick) solid var(--beige-deep);
+      border-left: var(--border-width-thick) solid var(--color-border-subtle);
       color: var(--darker-grey);
       background: var(--off-white);
       font-style: italic;
@@ -202,7 +202,7 @@ export class OLMarkdownEditor extends LitElement {
 
     .editor-input .tiptap code {
       background: var(--grey-f4f4f4);
-      border: 1px solid var(--lighter-grey);
+      border: 1px solid var(--color-border-subtle);
       border-radius: var(--border-radius-input);
       padding: 0.1em 0.3em;
       font-family: monospace;
@@ -211,7 +211,7 @@ export class OLMarkdownEditor extends LitElement {
 
     .editor-input .tiptap pre {
       background: var(--grey-f4f4f4);
-      border: 1px solid var(--lighter-grey);
+      border: 1px solid var(--color-border-subtle);
       border-radius: var(--border-radius-card);
       padding: var(--spacing-inset-sm);
       margin: 0 0 0.55em;
@@ -311,8 +311,8 @@ export class OLMarkdownEditor extends LitElement {
     .error-state {
       padding: var(--spacing-inset-sm);
       border: var(--border-width-control) solid var(--color-border-error);
-      background: var(--baby-pink);
-      color: var(--dark-red);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
       border-radius: var(--border-radius-notification);
       font-family: var(--font-family-body);
       margin-bottom: var(--spacing-stack-sm);
@@ -347,7 +347,7 @@ export class OLMarkdownEditor extends LitElement {
       border: var(--border-width-none);
       border-radius: 0 0 var(--border-radius-card) var(--border-radius-card);
       background: var(--white);
-      color: var(--dark-grey);
+      color: var(--color-text);
       font-family: monospace;
       font-size: 0.75rem;
       line-height: 1.5;

--- a/openlibrary/components/lit/OlMenuPopover.js
+++ b/openlibrary/components/lit/OlMenuPopover.js
@@ -80,7 +80,7 @@ export class OlMenuPopover extends LitElement {
         .menu-heading {
             margin: 0;
             padding: var(--spacing-inset-sm) var(--spacing-inset-md) var(--spacing-inset-xs);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: 12px;
             font-weight: 700;
             letter-spacing: 0.04em;

--- a/openlibrary/components/lit/OlOptionsPopover.js
+++ b/openlibrary/components/lit/OlOptionsPopover.js
@@ -96,7 +96,7 @@ export class OlOptionsPopover extends FormAssociatedMixin(LitElement) {
         .group-heading {
             margin: 0;
             padding: var(--spacing-inset-sm) var(--spacing-inset-md) var(--spacing-inset-xs);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: 12px;
             font-weight: 700;
             letter-spacing: 0.04em;
@@ -171,26 +171,26 @@ export class OlOptionsPopover extends FormAssociatedMixin(LitElement) {
         }
 
         .item--selected .item-label {
-            color: var(--link-blue);
+            color: var(--color-link);
             font-weight: 600;
         }
 
         .item-description {
             display: block;
             margin-top: 2px;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: 12px;
             line-height: 1.35;
         }
 
         .item--selected .item-description {
-            color: var(--link-blue);
+            color: var(--color-link);
         }
 
         .item-count {
             flex-shrink: 0;
             margin-left: var(--spacing-inline-md);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: 13px;
             font-variant-numeric: tabular-nums;
         }

--- a/openlibrary/components/lit/OlSegmentedControl.js
+++ b/openlibrary/components/lit/OlSegmentedControl.js
@@ -145,10 +145,10 @@ export class OlSegmentedControl extends FormAssociatedMixin(LitElement) {
 
         /* The selected segment's text. Doubled class (.segment.segment--ghost)
            so this beats the later, equal-specificity ".segment" color rule —
-           otherwise the cascade resolves the ghost to --accessible-grey and the
+           otherwise the cascade resolves the ghost to --color-text-muted and the
            selected segment looks dimmed instead of full-strength #333. */
         .segment.segment--ghost {
-            color: var(--dark-grey);
+            color: var(--color-text);
         }
 
         /* The sliding white pill — carries the raised look the selected segment
@@ -216,7 +216,7 @@ export class OlSegmentedControl extends FormAssociatedMixin(LitElement) {
             background-color: transparent;
             /* Non-selected segments are dimmed so the selected one reads as
                active; hover and the selected pill darken back to full strength. */
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-family: var(--font-family-button);
             font-size: var(--font-size-body-medium);
             line-height: var(--line-height-control);
@@ -246,7 +246,7 @@ export class OlSegmentedControl extends FormAssociatedMixin(LitElement) {
 
         @media (hover: hover) and (pointer: fine) {
             .segment:not([aria-checked="true"]):not(:disabled):hover {
-                color: var(--dark-grey);
+                color: var(--color-text);
             }
         }
 

--- a/openlibrary/components/lit/OlSelectPopover.js
+++ b/openlibrary/components/lit/OlSelectPopover.js
@@ -137,7 +137,7 @@ export class OlSelectPopover extends FormAssociatedMixin(LitElement) {
         }
 
         .filter-input::placeholder {
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
         }
 
         .filter-input:focus {
@@ -158,7 +158,7 @@ export class OlSelectPopover extends FormAssociatedMixin(LitElement) {
             left: calc(var(--spacing-inset-sm) + 10px);
             width: 14px;
             height: 14px;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             pointer-events: none;
             transform: translateY(-50%);
         }
@@ -192,7 +192,7 @@ export class OlSelectPopover extends FormAssociatedMixin(LitElement) {
         .group-heading {
             margin: 0;
             padding: var(--spacing-inset-sm) var(--spacing-inset-md) var(--spacing-inset-xs);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-label-medium);
             font-weight: 700;
             letter-spacing: 0.04em;
@@ -260,7 +260,7 @@ export class OlSelectPopover extends FormAssociatedMixin(LitElement) {
         .empty-state {
             padding: var(--spacing-inset-md);
             text-align: center;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-body-medium);
         }
 
@@ -278,7 +278,7 @@ export class OlSelectPopover extends FormAssociatedMixin(LitElement) {
             background: transparent;
             border: 1px solid transparent;
             border-radius: var(--border-radius-button);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font: inherit;
             font-size: var(--font-size-label-large);
             font-weight: 500;

--- a/openlibrary/components/lit/OlToast.js
+++ b/openlibrary/components/lit/OlToast.js
@@ -214,7 +214,7 @@ export class OlToast extends LitElement {
         }
 
         .toast--info .toast__icon {
-            background-color: var(--primary-blue);
+            background-color: var(--color-primary);
         }
 
         .toast--success .toast__icon {
@@ -247,7 +247,7 @@ export class OlToast extends LitElement {
         .toast__description {
             display: block;
             margin-top: 2px;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-label-medium);
             font-weight: normal;
         }
@@ -265,7 +265,7 @@ export class OlToast extends LitElement {
             background: none;
             border: none;
             border-radius: var(--border-radius-sm);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             cursor: pointer;
         }
 

--- a/openlibrary/components/lit/OlToggle.js
+++ b/openlibrary/components/lit/OlToggle.js
@@ -229,7 +229,7 @@ export class OlToggle extends FormAssociatedMixin(FocusableHostMixin(LitElement)
                 /* Nudge the border a touch darker in step with the fill (both
                    drop ~7% in lightness), matching ol-button[variant="secondary"]
                    so the whole control reads as one shape on hover. */
-                --_toggle-border: var(--light-grey);
+                --_toggle-border: var(--color-border-muted);
                 --_toggle-inset-highlight: color-mix(in srgb, var(--white) 35%, var(--lightest-grey));
             }
 

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -772,7 +772,7 @@ export class SearchModal extends LitElement {
                blanking its blue on hover while the text stays white. */
             ol-button[variant="secondary"] > button:hover {
                 background-color: var(--lightest-grey);
-                border-color: var(--light-grey);
+                border-color: var(--color-border-muted);
                 --control-surface: var(--lightest-grey);
             }
 

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -147,7 +147,7 @@ export class SearchModal extends LitElement {
             flex-shrink: 0;
             width: 20px;
             height: 20px;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
         }
 
         .search-input {
@@ -162,7 +162,7 @@ export class SearchModal extends LitElement {
             line-height: 1.4;
         }
 
-        .search-input::placeholder { color: var(--accessible-grey); }
+        .search-input::placeholder { color: var(--color-text-muted); }
         .search-input:focus         { outline: none; }
 
         /* Drop the native type="search" clear affordance — the modal renders
@@ -181,7 +181,7 @@ export class SearchModal extends LitElement {
             background: var(--white);
             border: 1px solid var(--color-border-subtle);
             border-radius: var(--border-radius-button);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font: inherit;
             font-size: var(--font-size-label-medium);
             font-weight: 600;
@@ -217,7 +217,7 @@ export class SearchModal extends LitElement {
             background: transparent;
             border: none;
             border-radius: var(--border-radius-button);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             cursor: pointer;
         }
 
@@ -248,7 +248,7 @@ export class SearchModal extends LitElement {
             background: transparent;
             border: none;
             border-radius: var(--border-radius-circle);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             cursor: pointer;
         }
 
@@ -352,7 +352,7 @@ export class SearchModal extends LitElement {
         .results-heading {
             margin: 0;
             padding: var(--spacing-sm) var(--spacing-lg) var(--spacing-2xs);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-label-small);
             font-weight: 700;
             letter-spacing: 0.04em;
@@ -430,7 +430,7 @@ export class SearchModal extends LitElement {
             width: 36px;
             height: 36px;
             overflow: hidden;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             background: var(--lightest-grey);
             border-radius: var(--border-radius-avatar);
         }
@@ -465,7 +465,7 @@ export class SearchModal extends LitElement {
         .result__author {
             display: block;
             overflow: hidden;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: 13px;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -473,7 +473,7 @@ export class SearchModal extends LitElement {
 
         .result__year {
             display: block;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-label-medium);
             font-weight: 400;
         }
@@ -508,7 +508,7 @@ export class SearchModal extends LitElement {
            readable copy isn't in the patron's site language. Informational, not
            a button — muted so it sits below the pill without competing with it. */
         .result__lang {
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-label-small);
             font-weight: 400;
             white-space: nowrap;
@@ -516,7 +516,7 @@ export class SearchModal extends LitElement {
 
         .empty, .loading {
             padding: var(--spacing-lg) var(--spacing-lg);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             font-size: var(--font-size-body-medium);
             text-align: center;
         }
@@ -572,7 +572,7 @@ export class SearchModal extends LitElement {
             align-items: center;
             justify-content: center;
             height: 28px;
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
         }
 
         .result__recent-icon svg { width: 18px; height: 18px; }
@@ -591,7 +591,7 @@ export class SearchModal extends LitElement {
             background: transparent;
             border: none;
             border-radius: var(--border-radius-button);
-            color: var(--accessible-grey);
+            color: var(--color-text-muted);
             cursor: pointer;
             opacity: 0;
             transition: opacity 100ms ease;
@@ -728,7 +728,7 @@ export class SearchModal extends LitElement {
             background-color: var(--white);
             border: 1px solid var(--color-border-subtle);
             border-radius: var(--border-radius-button);
-            color: var(--dark-grey);
+            color: var(--color-text);
             /* Strength of the specular top edge. Full on the light secondary fill;
                the dark primary fill dials it down below. */
             --control-highlight-strength: 35%;
@@ -745,8 +745,8 @@ export class SearchModal extends LitElement {
         /* Primary — opt-in via variant="primary" (the footer action). */
         ol-button[variant="primary"]:not([hydrated]),
         ol-button[variant="primary"] > button {
-            background-color: var(--primary-blue);
-            border-color: var(--primary-blue);
+            background-color: var(--color-primary);
+            border-color: var(--color-primary);
             color: var(--white);
             /* Tone the specular highlight to the blue fill and soften it — the
                white edge reads much louder on a dark fill than on white. */
@@ -761,7 +761,7 @@ export class SearchModal extends LitElement {
         ol-button[selected] > button {
             background-color: var(--color-control-selected-bg);
             border-color: var(--color-control-selected-border);
-            color: var(--link-blue);
+            color: var(--color-link);
             /* Opaque twin of the tint — a translucent surface washes out the highlight. */
             --control-surface: var(--color-control-selected-surface);
         }

--- a/static/css/base/common.css
+++ b/static/css/base/common.css
@@ -32,7 +32,7 @@ h1 {
 body,
 p,
 li {
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 body {
   font-size: 100%;
@@ -54,10 +54,10 @@ hr {
 }
 li {
   list-style: none;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 a:link {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 a:hover {
@@ -77,7 +77,7 @@ h4,
 h5,
 h6 {
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-weight: 600;
 }
 div.head {

--- a/static/css/base/headings.css
+++ b/static/css/base/headings.css
@@ -40,17 +40,17 @@ h2.publisher {
 }
 h2.edition-title {
   margin: var(--spacing-stack-sm) 0 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-title);
   font-weight: normal;
   font-size: var(--font-size-title-medium);
 }
 h2 a {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: none;
 }
 h2 a:hover {
-  color: var(--dark-green);
+  color: var(--color-success-fg);
   text-decoration: underline;
 }
 
@@ -75,7 +75,7 @@ h3.Question {
   color: var(--brown);
   margin-top: var(--spacing-stack-sm);
   padding-top: var(--spacing-inset-sm);
-  border-top: 1px dotted var(--lighter-grey);
+  border-top: 1px dotted var(--color-border-subtle);
 }
 
 h4 {
@@ -150,7 +150,7 @@ h6.title {
   font-size: var(--font-size-label-medium);
   font-weight: normal !important;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin: 0;
   padding: 0;
 }

--- a/static/css/base/headings.css
+++ b/static/css/base/headings.css
@@ -10,7 +10,7 @@ h1 span.subtitle {
 }
 /* TODO: Check if this class is still used. */
 h1.publisher {
-  color: var(--brown);
+  color: var(--color-text-heading);
   font-size: var(--font-size-headline-medium);
   font-family: var(--font-family-serif) !important;
   font-weight: normal !important;
@@ -24,12 +24,12 @@ h2 {
   font-size: var(--font-size-headline-small);
 }
 h2.author {
-  color: var(--brown);
+  color: var(--color-text-heading);
   font-size: var(--font-size-title-medium);
   font-weight: normal;
 }
 h2.authorEdition {
-  color: var(--brown);
+  color: var(--color-text-heading);
   font-size: var(--font-size-title-small);
   font-weight: normal;
   margin: 0;
@@ -72,7 +72,7 @@ h3.Question {
   font-family: var(--font-family-serif);
   font-size: var(--font-size-title-large);
   font-weight: normal;
-  color: var(--brown);
+  color: var(--color-text-heading);
   margin-top: var(--spacing-stack-sm);
   padding-top: var(--spacing-inset-sm);
   border-top: 1px dotted var(--color-border-subtle);

--- a/static/css/base/helpers-common.css
+++ b/static/css/base/helpers-common.css
@@ -58,7 +58,7 @@ a.hoverlink {
 }
 
 .local-date-time {
-  color: var(--dark-green);
+  color: var(--color-success-fg);
   font-size: var(--font-size-label-small);
   text-align: center;
 }

--- a/static/css/base/helpers-misc.css
+++ b/static/css/base/helpers-misc.css
@@ -84,7 +84,7 @@ button.larger {
 .valid,
 .darkgreen,
 .pos {
-  color: var(--dark-green) !important;
+  color: var(--color-success-fg) !important;
 }
 
 .black {
@@ -108,7 +108,7 @@ button.larger {
 }
 
 .lightgreen {
-  color: var(--olive) !important;
+  color: var(--color-success-fg) !important;
 }
 .lightgrey,
 .lightgray {
@@ -116,7 +116,7 @@ button.larger {
 }
 
 .blue {
-  color: var(--link-blue) !important;
+  color: var(--color-link) !important;
 }
 
 .invalid,
@@ -139,12 +139,12 @@ button.larger {
 .lighter,
 .gray,
 .grey {
-  color: var(--grey) !important;
+  color: var(--color-text-secondary) !important;
 }
 
 .darkgray,
 .darkgrey {
-  color: var(--dark-grey) !important;
+  color: var(--color-text) !important;
 }
 
 .plain {

--- a/static/css/components/admin-table.css
+++ b/static/css/components/admin-table.css
@@ -1,7 +1,7 @@
 .measurements {
   width: 100%;
   margin: var(--spacing-stack-sm) 0 var(--spacing-stack-xl);
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 .measurements th {
   font-family: var(--font-family-body);

--- a/static/css/components/buttonBtn.css
+++ b/static/css/components/buttonBtn.css
@@ -10,7 +10,7 @@
 .btn.primary {
   /* For input[type=submit] */
   border: none;
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   /* Important is necessary to override default link color */
   color: var(--white) !important;
   border-radius: 5px;
@@ -42,7 +42,7 @@ a.btn {
 }
 
 .chip--selected {
-  border-color: var(--primary-blue);
+  border-color: var(--color-primary);
   color: var(--primary-blue);
   background-color: var(--grey-e7e7e7);
 }

--- a/static/css/components/buttonCta--js.css
+++ b/static/css/components/buttonCta--js.css
@@ -1,12 +1,12 @@
 .cta-btn--available--load,
 a.cta-btn--available--load {
   background: url(/static/images/indicator.gif) center center no-repeat;
-  background-color: var(--primary-blue) !important;
+  background-color: var(--color-primary) !important;
   opacity: 0.6;
 }
 .cta-btn--unavailable--load,
 a.cta-btn--unavailable--load {
   background: url(/static/images/indicator.gif) center center no-repeat;
-  background-color: var(--primary-blue) !important;
+  background-color: var(--color-primary) !important;
   opacity: 0.6;
 }

--- a/static/css/components/buttonCta.css
+++ b/static/css/components/buttonCta.css
@@ -68,7 +68,7 @@ a.cta-btn--no-pointer {
 a.cta-btn--available,
 a.cta-btn--preview,
 a.cta-btn--primary {
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   color: var(--white);
 }
 
@@ -102,7 +102,7 @@ a.cta-btn--external {
 
 .cta-btn--unavailable,
 a.cta-btn--unavailable {
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   color: var(--white);
 }
 
@@ -123,7 +123,7 @@ a.cta-btn--shell,
 a.cta-btn--shell:link,
 a.cta-btn--shell:visited {
   background-color: var(--white);
-  border: 2px solid var(--primary-blue);
+  border: 2px solid var(--color-primary);
   color: var(--primary-blue);
 }
 
@@ -149,7 +149,7 @@ a.cta-btn--vanilla:link {
   padding: var(--spacing-inset-xs);
   border: 2px solid var(--light-grey);
   background: var(--white);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border-radius: 6px;
 }
 
@@ -161,7 +161,7 @@ a.cta-btn--unstyled:visited,
 a.cta-btn--unstyled:link {
   padding: var(--spacing-inset-sm);
   background: var(--white);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border-radius: 6px;
 }
 
@@ -176,7 +176,7 @@ a.cta-btn--cancel {
 .cta-btn--cancel:visited,
 a.cta-btn--delete:visited,
 a.cta-btn--cancel:visited {
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .cta-btn--delete:hover,
@@ -197,7 +197,7 @@ a.cta-btn.cta-btn--w-icon {
 .cta-btn--sponsor:visited,
 a.cta-btn--sponsor:link,
 a.cta-btn--sponsor:visited {
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 
 .cta-btn--sponsor:hover,
@@ -244,7 +244,7 @@ a.cta-btn__badge {
   margin: 0;
   border: 1px solid var(--dark-beige);
   background-color: var(--light-beige);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .waitinglist-message {
@@ -348,7 +348,7 @@ form.return-form .cta-btn {
   border: none;
   padding: 0;
   cursor: pointer;
-  color: var(--dark-grey);
+  color: var(--color-text);
   display: flex;
   align-items: center;
 }

--- a/static/css/components/buttonCta.css
+++ b/static/css/components/buttonCta.css
@@ -129,7 +129,7 @@ a.cta-btn--shell:visited {
 
 .cta-btn--shell:disabled,
 a.cta-btn--shell:disabled {
-  border: 2px solid var(--light-grey);
+  border: 2px solid var(--color-border-muted);
   color: var(--light-grey);
   cursor: default;
 }
@@ -147,7 +147,7 @@ a.cta-btn--vanilla,
 a.cta-btn--vanilla:visited,
 a.cta-btn--vanilla:link {
   padding: var(--spacing-inset-xs);
-  border: 2px solid var(--light-grey);
+  border: 2px solid var(--color-border-muted);
   background: var(--white);
   color: var(--color-text-secondary);
   border-radius: 6px;
@@ -242,7 +242,7 @@ a.cta-btn__badge {
   width: auto;
   display: inline-block;
   margin: 0;
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   background-color: var(--light-beige);
   color: var(--color-text-secondary);
 }

--- a/static/css/components/buttonLink.css
+++ b/static/css/components/buttonLink.css
@@ -8,7 +8,7 @@
   padding: var(--spacing-inset-sm);
   display: inline-block;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border: 1px solid var(--mid-grey);
   cursor: pointer;
   transition: background-color 0.2s;
@@ -21,5 +21,5 @@
 a.linkButton {
   text-decoration: none;
   /* Need to duplicate to override base style specificity */
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }

--- a/static/css/components/buttonsAndLinks.css
+++ b/static/css/components/buttonsAndLinks.css
@@ -12,11 +12,11 @@ a.borrowResults:visited {
   text-decoration: none;
 }
 a.borrowResults:hover {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 a.borrowResults:active {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 a.coverLook {
@@ -29,7 +29,7 @@ a.facetSubject:visited {
 }
 a.facetSubject:hover,
 a.facetSubject:active {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 /* Can possibly be removed provided there are no usages of .results
@@ -43,11 +43,11 @@ a.results:visited {
   text-decoration: none;
 }
 a.results:hover {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 a.results:active {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 a.toggle {
@@ -71,7 +71,7 @@ button.plainText {
   cursor: pointer;
 }
 button.plainText:hover {
-  color: var(--dark-green);
+  color: var(--color-success-fg);
 }
 button.plain {
   border: none;
@@ -82,7 +82,7 @@ button.plain {
   cursor: pointer;
 }
 button.plain:hover {
-  color: var(--dark-green);
+  color: var(--color-success-fg);
 }
 button.addAnother {
   width: 32px;

--- a/static/css/components/carousel.css
+++ b/static/css/components/carousel.css
@@ -12,7 +12,7 @@
 .home-h2 {
   font-size: var(--font-size-title-medium);
   font-weight: normal;
-  color: var(--link-blue);
+  color: var(--color-link);
   margin-bottom: 0.5em;
   margin-top: 1.75em;
 }
@@ -101,13 +101,13 @@
 .carousel .book .book-title {
   font-size: 0.8em;
   margin: var(--spacing-stack-xs) 0;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-weight: normal;
 }
 
 /* stylelint-disable-next-line selector-max-specificity */
 .carousel .book .book-title a {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: none;
 }
 
@@ -170,7 +170,7 @@
 
 .carousel__item__blankcover--authors {
   position: relative;
-  color: var(--dark-grey-two);
+  color: var(--color-text-secondary);
   padding: var(--spacing-inset-xs) var(--spacing-inset-xs) 0;
   font-size: 0.6875em;
   font-style: oblique;

--- a/static/css/components/category-item.css
+++ b/static/css/components/category-item.css
@@ -17,7 +17,7 @@ p.category-count {
   text-align: center;
   font-size: 0.7em;
   line-height: 1;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   padding: 0 0 1px;
   margin: 0;
   margin-top: var(--spacing-stack-xs);

--- a/static/css/components/cbox.css
+++ b/static/css/components/cbox.css
@@ -75,7 +75,7 @@
   position: relative;
   background: var(--white);
   padding: var(--spacing-inset-sm);
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-overlay);
   -webkit-box-shadow: 1px 3px 5px var(--darker-grey);
   box-shadow: 1px 3px 5px var(--darker-grey);
@@ -286,7 +286,7 @@ div.floaterBody p {
 
 .ol-cover-form .carousel .cta-btn {
   color: var(--color-text-secondary);
-  border: 2px solid var(--light-grey);
+  border: 2px solid var(--color-border-muted);
   border-radius: 6px;
   position: relative;
 }

--- a/static/css/components/cbox.css
+++ b/static/css/components/cbox.css
@@ -113,7 +113,7 @@
 }
 
 .dialog--close {
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1.2em;
   /* Increase clickable area to the recommended size (44x44px) according to */
   /* https://www.w3.org/WAI/WCAG21/Understanding/target-size.html */
@@ -148,7 +148,7 @@ div.coverFloatHead {
 
 div.coverFloatHead h2 {
   font-weight: normal;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1em;
   margin: 0;
   padding: 0;
@@ -172,7 +172,7 @@ div.floaterHead {
 div.floaterHead h2 {
   font-weight: normal;
   text-align: center;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1.25em;
   margin: 0;
   padding: 0;
@@ -285,7 +285,7 @@ div.floaterBody p {
 }
 
 .ol-cover-form .carousel .cta-btn {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border: 2px solid var(--light-grey);
   border-radius: 6px;
   position: relative;

--- a/static/css/components/chart.css
+++ b/static/css/components/chart.css
@@ -34,7 +34,7 @@
   -o-transform: rotate(-90deg);
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   font-size: 10px;
-  color: var(--olive);
+  color: var(--color-success-fg);
   text-transform: uppercase;
 }
 .chartXaxis {
@@ -44,7 +44,7 @@
   width: 100%;
   text-align: center;
   font-size: 10px;
-  color: var(--olive);
+  color: var(--color-success-fg);
   text-transform: uppercase;
 }
 .chartZoom {

--- a/static/css/components/check-in.css
+++ b/static/css/components/check-in.css
@@ -60,7 +60,7 @@
   padding: var(--spacing-inset-xs) 0;
   margin-top: -15px;
   margin-bottom: var(--spacing-stack-xs);
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   font-size: var(--font-size-label-medium);
   text-align: center;
   background: linear-gradient(to bottom, transparent 80%, var(--lightest-grey));

--- a/static/css/components/editions.css
+++ b/static/css/components/editions.css
@@ -86,7 +86,7 @@ table#editions div.title,
 table#editions div.links,
 .editions-table div.links {
   font-size: var(--font-size-label-medium);
-  color: var(--dark-grey);
+  color: var(--color-text);
   line-height: 1.5em;
 }
 
@@ -141,7 +141,7 @@ table#editions .highlight,
 }
 
 .lists table#editions td {
-  color: var(--dark-grey);
+  color: var(--color-text);
   vertical-align: top;
 }
 
@@ -204,7 +204,7 @@ table#editions .highlight,
   table#editions tr {
     display: flex;
     flex-direction: column;
-    border-bottom: 1px solid var(--lighter-grey);
+    border-bottom: 1px solid var(--color-border-subtle);
     padding-bottom: var(--spacing-inset-sm);
     overflow: visible;
   }

--- a/static/css/components/editions.css
+++ b/static/css/components/editions.css
@@ -21,7 +21,7 @@ table#editions .cta-button-group,
 
 table#editions thead,
 .editions-table thead {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
 }
 
 table#editions thead tr,
@@ -134,7 +134,7 @@ table#editions .highlight,
   text-align: left;
   font-weight: normal;
   font-size: 0.6875em;
-  color: var(--brown);
+  color: var(--color-text-heading);
   padding: 0 0 var(--spacing-inset-sm);
   border-left: none;
   border-right: none;

--- a/static/css/components/flash-messages.css
+++ b/static/css/components/flash-messages.css
@@ -56,7 +56,7 @@
 .flash-messages .bookadded h3 em {
   font-style: italic;
   font-weight: 700;
-  color: var(--dark-green);
+  color: var(--color-success-fg);
 }
 
 .flash-messages .bookadded .close {

--- a/static/css/components/footer.css
+++ b/static/css/components/footer.css
@@ -39,7 +39,7 @@ footer h2 {
 
 footer hr {
   border: 0;
-  border-top: 1px solid var(--dark-beige);
+  border-top: 1px solid var(--color-border-muted);
   margin: 20px 0;
 }
 
@@ -101,7 +101,7 @@ div#version-details {
 /* FIXME: merge with above CSS rule? */
 .version {
   color: var(--color-text);
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   border-radius: 3px;
   padding: var(--spacing-inset-sm);
 }

--- a/static/css/components/footer.css
+++ b/static/css/components/footer.css
@@ -26,13 +26,13 @@ footer {
 }
 
 footer #footer-details {
-  color: var(--dark-grey);
+  color: var(--color-text);
   display: flex;
   width: 100%;
 }
 
 footer h2 {
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1em;
   margin: 0;
 }
@@ -100,7 +100,7 @@ div#version-details {
 
 /* FIXME: merge with above CSS rule? */
 .version {
-  color: var(--dark-grey);
+  color: var(--color-text);
   border: 1px solid var(--dark-beige);
   border-radius: 3px;
   padding: var(--spacing-inset-sm);

--- a/static/css/components/form.olform.css
+++ b/static/css/components/form.olform.css
@@ -190,7 +190,7 @@
 /* "You can search by author name (like j k rowling) or by Open Library ID (like OL23919A)." */
 .olform .tip {
   font-size: var(--font-size-label-small);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-body) !important;
 }
 

--- a/static/css/components/fulltext-search-suggestion-item.css
+++ b/static/css/components/fulltext-search-suggestion-item.css
@@ -91,7 +91,7 @@
   color: var(--black);
 }
 .fsi__book-title a:hover {
-  color: var(--header-nav-hover-color);
+  color: var(--color-link);
 }
 .fsi__book-author {
   line-height: 1.2em;

--- a/static/css/components/fulltext-search-suggestion.css
+++ b/static/css/components/fulltext-search-suggestion.css
@@ -51,7 +51,7 @@
   text-decoration: none;
 }
 .fulltext-suggestions__title a:hover {
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 .fulltext-suggestions__footer {
   display: flex;

--- a/static/css/components/fulltext-snippet.css
+++ b/static/css/components/fulltext-snippet.css
@@ -24,7 +24,7 @@
   line-height: 1.6em;
 }
 .fsi-snippet__main__page-num a {
-  color: var(--dark-grey);
+  color: var(--color-text);
   display: inline;
   text-decoration: none;
   font-family: var(--font-family-body);
@@ -39,7 +39,7 @@
   color: var(--black);
 }
 .fsi-snippet__main a:hover {
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 .fsi-snippet__full-results {
   border-bottom: 1px solid var(--lightest-grey);

--- a/static/css/components/generic-dropper.css
+++ b/static/css/components/generic-dropper.css
@@ -25,7 +25,7 @@
 }
 
 .generic-dropper__actions * {
-  color: var(--dark-grey);
+  color: var(--color-text);
   background-color: var(--lightest-grey);
 }
 
@@ -48,7 +48,7 @@
 /* stylelint-enable max-nesting-depth */
 
 .generic-dropper__actions .generic-dropper__dropclick {
-  border-left: 1px solid var(--lighter-grey);
+  border-left: 1px solid var(--color-border-subtle);
   text-decoration: none;
   height: inherit;
   width: 32px;
@@ -82,7 +82,7 @@
 .generic-dropper__dropdown {
   display: none;
   width: 100%;
-  border-top: 1px solid var(--lighter-grey);
+  border-top: 1px solid var(--color-border-subtle);
   position: absolute;
   font-size: var(--font-size-label-medium);
 }
@@ -139,7 +139,7 @@
 /* dropdown containing Listen/Search/Download/Locate buttons */
 .dropper-menu {
   z-index: var(--z-index-level-4);
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 5px;
   background-color: var(--white);
   position: absolute;
@@ -177,7 +177,7 @@
 }
 
 .dropper-menu li + li {
-  border-top: 1px solid var(--lighter-grey);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .dropper-menu li:first-child,

--- a/static/css/components/header-bar--desktop.css
+++ b/static/css/components/header-bar--desktop.css
@@ -14,7 +14,7 @@
 }
 
 .header-bar .logo-component {
-  /* border-right: 1px solid var(--dark-beige); */
+  /* border-right: 1px solid var(--color-border-muted); */
   padding-right: var(--spacing-inset-md);
 }
 
@@ -31,7 +31,7 @@
 
 .header-bar .navigation-component .dropdown-menu {
   border-radius: 3px;
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
 }
 
 /* stylelint-disable-next-line max-nesting-depth, selector-max-specificity */
@@ -49,7 +49,7 @@
 .header-bar .search-component .search-bar-component {
   width: 100%;
   background-color: var(--grey-fafafa);
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   border-radius: 6px;
 }
 

--- a/static/css/components/header-bar.css
+++ b/static/css/components/header-bar.css
@@ -54,7 +54,7 @@
 .header-bar .dropdown-menu {
   text-align: left;
   background-color: var(--light-beige);
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   border-radius: 3px;
 }
 
@@ -150,7 +150,7 @@
 }
 
 .header-bar .app-drawer .subsection:first-child {
-  border-top: 1px solid var(--dark-beige);
+  border-top: 1px solid var(--color-border-muted);
 }
 
 .header-bar .app-drawer .login-links {

--- a/static/css/components/header-bar.css
+++ b/static/css/components/header-bar.css
@@ -44,7 +44,7 @@
 
 .header-bar .auth-component li button,
 .header-bar .auth-component li a {
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 .header-bar .auth-component .hide-me {
@@ -59,7 +59,7 @@
 }
 
 .header-bar .dropdown-menu li {
-  border-bottom: 1px solid var(--beige-two);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 /* stylelint-disable max-nesting-depth, selector-max-specificity */
@@ -74,7 +74,7 @@
 .header-bar .dropdown-menu li button,
 .header-bar .dropdown-menu li a {
   text-decoration: none;
-  color: var(--dark-grey);
+  color: var(--color-text);
   white-space: nowrap;
   font-size: 0.9em;
   padding: var(--spacing-inset-md) var(--spacing-inset-sm);
@@ -108,7 +108,7 @@
 
 .header-bar .app-drawer .app-drawer__badge {
   color: var(--white);
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   font-size: 0.9em;
   padding: var(--spacing-inset-xs) var(--spacing-inset-xs) 1px;
   border-radius: 4px;
@@ -175,7 +175,7 @@
 }
 
 .header-bar .app-drawer .login-links .login-links__primary {
-  background: var(--primary-blue);
+  background: var(--color-primary);
   color: var(--white);
 }
 
@@ -184,7 +184,7 @@
 }
 
 .header-bar .app-drawer .login-links .login-links__secondary {
-  color: var(--link-blue);
+  color: var(--color-link);
   border: 2px solid var(--link-blue);
 }
 
@@ -304,7 +304,7 @@
 
 .header-bar .header-dropdown .mr-notifications {
   position: absolute;
-  background: var(--primary-blue);
+  background: var(--color-primary);
   color: var(--white);
   border-radius: var(--border-radius-notification);
   padding: var(--spacing-inset-xs) var(--spacing-inset-sm);
@@ -406,14 +406,14 @@
 /* stylelint-disable max-nesting-depth, selector-max-specificity */
 .header-bar .navigation-component li button,
 .header-bar .navigation-component li a {
-  color: var(--dark-grey);
+  color: var(--color-text);
   text-decoration: none;
   display: block;
 }
 
 .header-bar .navigation-component li button:visited,
 .header-bar .navigation-component li a:visited {
-  color: var(--dark-grey);
+  color: var(--color-text);
   text-decoration: none;
 }
 
@@ -509,7 +509,7 @@
   text-align: left;
   font-weight: 300;
   font-size: 0.9em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin: var(--spacing-stack-xs);
   padding: 0;
   line-height: 0;
@@ -638,7 +638,7 @@
   border: 0;
   border-radius: var(--border-radius-md);
   background: none;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font: inherit;
   cursor: pointer;
   /* Hover is instant (see docs/ai/design.md); only the :active press animates. */
@@ -706,7 +706,7 @@
   gap: var(--spacing-inline-md);
   padding: var(--spacing-inset-sm);
   border-radius: var(--border-radius-md);
-  color: var(--dark-grey);
+  color: var(--color-text);
   text-decoration: none;
 }
 
@@ -783,7 +783,7 @@
   display: block;
   padding: var(--spacing-2xs) var(--spacing-inset-sm);
   border-radius: var(--border-radius-md);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-body-medium);
   text-decoration: none;
 }
@@ -814,7 +814,7 @@
   background: transparent;
   border: 0;
   border-radius: var(--border-radius-input);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: inherit;
   font-size: 1em;
   cursor: pointer;
@@ -845,7 +845,7 @@
   width: 38px;
   min-height: 38px;
   border-radius: var(--border-radius-input);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   opacity: 0.7;
   transition:
     background-color 0.15s ease,

--- a/static/css/components/home.css
+++ b/static/css/components/home.css
@@ -51,7 +51,7 @@ div.tutorial__item img {
 /* stylelint-disable selector-max-specificity */
 div.chartHome a:hover,
 #home-stats-charts .statschart:hover a {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 
@@ -135,7 +135,7 @@ div.chartHome a:hover,
   font-size: 18px;
   line-height: var(--line-height-body);
   font-family: var(--font-family-serif);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-weight: normal;
 }
 /* stylelint-enable selector-max-specificity */

--- a/static/css/components/illustration.css
+++ b/static/css/components/illustration.css
@@ -56,7 +56,7 @@
   margin-left: -54px;
   height: 100px;
   margin-top: -50px;
-  color: var(--dark-grey);
+  color: var(--color-text);
   overflow-wrap: break-word;
 }
 .illustration .author .BookTitle {
@@ -71,7 +71,7 @@
   display: none;
 }
 .illustration .Author {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-style: italic;
   padding: var(--spacing-inset-xs) var(--spacing-inset-xs) 0;
   font-size: var(--font-size-label-small);

--- a/static/css/components/jquery.autocomplete.css
+++ b/static/css/components/jquery.autocomplete.css
@@ -23,7 +23,7 @@
   font-family: var(--font-family-body);
   font-size: var(--font-size-label-medium);
   cursor: pointer;
-  color: var(--dark-grey);
+  color: var(--color-text);
   /*
   it is very important, if line-height not set or set
   in relative units scroll will be broken in firefox
@@ -55,12 +55,12 @@
 
 .ac_author .action {
   font-size: 9px;
-  color: var(--olive);
+  color: var(--color-success-fg);
 }
 
 .ac_author .books {
   font-size: var(--font-size-label-medium);
-  color: var(--dark-green);
+  color: var(--color-success-fg);
   font-weight: 700;
   padding: 0;
 }
@@ -105,7 +105,7 @@
 
 .ac_work .edition_count {
   font-size: var(--font-size-label-medium);
-  color: var(--dark-green);
+  color: var(--color-success-fg);
   font-weight: 700;
   padding: 0;
 }

--- a/static/css/components/jquery.autocomplete.css
+++ b/static/css/components/jquery.autocomplete.css
@@ -10,7 +10,7 @@
   max-height: 290px;
   max-width: 600px;
   background-color: var(--white);
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   opacity: 0.95;
   text-align: left;
   list-style: none;
@@ -30,7 +30,7 @@
   */
   line-height: 16px;
   overflow: hidden;
-  border-bottom: 1px solid var(--light-grey);
+  border-bottom: 1px solid var(--color-border-muted);
 }
 
 .ac_results li:last-child {

--- a/static/css/components/language.css
+++ b/static/css/components/language.css
@@ -31,7 +31,7 @@
 }
 
 .language-dropdown-component .dropdown-menu li {
-  border-bottom: 1px solid var(--beige-two);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 /* stylelint-disable-next-line selector-max-specificity */
@@ -46,7 +46,7 @@
 
 .language-dropdown-component .dropdown-menu li a {
   text-decoration: none;
-  color: var(--dark-grey);
+  color: var(--color-text);
   white-space: nowrap;
   font-size: 0.9em;
   display: block;

--- a/static/css/components/librarian-dashboard.css
+++ b/static/css/components/librarian-dashboard.css
@@ -1,5 +1,5 @@
 details.librarian-dashboard {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-stack-md);
   max-width: 700px;
 }
@@ -21,7 +21,7 @@ details.librarian-dashboard {
   border: 0;
   background: none;
   text-decoration: underline;
-  color: var(--link-blue);
+  color: var(--color-link);
   cursor: pointer;
   float: right;
 }

--- a/static/css/components/link-box.css
+++ b/static/css/components/link-box.css
@@ -10,7 +10,7 @@
 }
 
 .link-box h3 {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin: 0 0 var(--spacing-stack-sm);
   padding: 0;
   text-transform: uppercase;

--- a/static/css/components/list-entry.css
+++ b/static/css/components/list-entry.css
@@ -20,7 +20,7 @@
 }
 .listEntry .name {
   font-size: 0.6875em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 .listEntry .name .title {
   font-weight: bold;
@@ -29,12 +29,12 @@
 .listEntry .description p,
 .listEntry .description li {
   font-size: 0.8125em;
-  color: var(--dark-grey);
+  color: var(--color-text);
   margin: 0 !important;
 }
 .listEntry .meta {
   font-size: 0.6875em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   line-height: 1.5em;
   margin: var(--spacing-stack-xs) 0;
 }

--- a/static/css/components/list-follow.css
+++ b/static/css/components/list-follow.css
@@ -100,7 +100,7 @@ a.list-follow-card__header {
 
 a.list-follow-card__username-link {
   text-decoration: none;
-  color: var(--dark-grey-two);
+  color: var(--color-text-secondary);
   padding-bottom: var(--spacing-inset-xs);
   text-overflow: ellipsis;
   overflow: hidden;

--- a/static/css/components/listLists.css
+++ b/static/css/components/listLists.css
@@ -9,7 +9,7 @@ ul.listLists {
 }
 ul.listLists span {
   display: block;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 ul.listLists li {
   /* See #1388

--- a/static/css/components/lists-page-cta.css
+++ b/static/css/components/lists-page-cta.css
@@ -8,7 +8,7 @@
   font-size: 1.5em;
   font-family: var(--font-family-title);
   font-weight: normal;
-  color: var(--dark-grey);
+  color: var(--color-text);
   margin: 0 0 var(--spacing-stack-sm);
 }
 .lists-page-cta p {

--- a/static/css/components/manage-covers.css
+++ b/static/css/components/manage-covers.css
@@ -5,12 +5,12 @@
   border-radius: 3px;
   border: 3px solid var(--dark-grey);
   background-color: var(--white);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-label-medium);
   cursor: pointer;
 }
 .manageCovers a {
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 .manageCoversContainer {
   width: 100%;

--- a/static/css/components/merge-form.css
+++ b/static/css/components/merge-form.css
@@ -15,7 +15,7 @@ div.merge .entry {
   padding: var(--spacing-inset-sm) 0;
   float: left;
   clear: right;
-  border-bottom: 1px solid var(--lighter-grey);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 div.merge .header {
@@ -23,7 +23,7 @@ div.merge .header {
   padding: 0 !important;
   float: left;
   clear: right;
-  border-bottom: 1px solid var(--lighter-grey);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 div.merge .header div {
@@ -58,7 +58,7 @@ div.merge .record ul {
 }
 
 div.merge .record li {
-  color: var(--grey) !important;
+  color: var(--color-text-secondary) !important;
   font-size: 0.75em;
 }
 
@@ -73,7 +73,7 @@ div.merge .metaDate {
 }
 
 div.merge .metaSubject {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: 0.8125em;
   display: block;
 }
@@ -97,7 +97,7 @@ div.merge .name a:visited {
 
 div.merge .name a:hover,
 div.merge .name a:active {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 /* stylelint-enable selector-max-specificity */

--- a/static/css/components/merge-request-table.css
+++ b/static/css/components/merge-request-table.css
@@ -53,7 +53,7 @@
 }
 
 .mr-dropdown {
-  color: var(--dark-grey);
+  color: var(--color-text);
   cursor: pointer;
   font-size: 13px;
 }
@@ -157,8 +157,8 @@
   justify-content: space-between;
   align-items: flex-start;
   padding: var(--spacing-inset-sm);
-  border-top: 1px solid var(--lighter-grey);
-  border-bottom: 1px solid var(--lighter-grey);
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border-subtle);
   background: var(--grey-fafafa);
 }
 
@@ -265,7 +265,7 @@
 }
 
 .comment-panel__input .comment-panel__reply-btn {
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   color: var(--white);
   text-decoration: none;
   border: none;
@@ -310,7 +310,7 @@
   justify-content: center;
   width: 76px;
   height: 41px;
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   color: var(--white);
   font-size: 13px;
   font-style: normal;
@@ -337,7 +337,7 @@
 
 .mr-comment-toggle__comment-expand.cta-btn {
   background-color: var(--grey-f4f4f4);
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 5px;
   margin-top: var(--spacing-stack-lg);
 }

--- a/static/css/components/merge-request-table.css
+++ b/static/css/components/merge-request-table.css
@@ -15,7 +15,7 @@
 
 /* Table wrapper */
 .librarian-queue-wrapper {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: 5px;
 }
 
@@ -66,7 +66,7 @@
   height: 275px;
   width: 269px;
   background: var(--white);
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   box-shadow:
     0 4px 4px var(--light-mid-grey),
     0 4px 4px var(--light-mid-grey);
@@ -87,7 +87,7 @@
   height: 34px;
   border-width: 1px 0;
   border-style: solid;
-  border-color: var(--light-grey);
+  border-color: var(--color-border-muted);
   cursor: default;
 }
 
@@ -125,7 +125,7 @@
   padding: var(--spacing-inset-sm);
   border-width: 1px 0;
   border-style: solid;
-  border-color: var(--light-grey);
+  border-color: var(--color-border-muted);
   height: 34px;
   cursor: pointer;
 }
@@ -229,7 +229,7 @@
 }
 
 .comment-panel__comment-display {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   background-color: var(--white);
   border-radius: 5px;
   margin-bottom: var(--spacing-stack-sm);
@@ -259,7 +259,7 @@
   min-width: 337px;
   height: 100%;
   resize: none;
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-input);
   margin-right: var(--spacing-inline-sm);
 }

--- a/static/css/components/mybooks-details.css
+++ b/static/css/components/mybooks-details.css
@@ -209,10 +209,10 @@
 }
 
 .pending-action-container .page-banner--dismissable {
-  background: var(--lightest-blue);
+  background: var(--color-primary-subtle);
   border: var(--border-input-focused);
   border-radius: var(--border-radius-notification);
-  color: var(--dark-grey);
+  color: var(--color-text);
   box-shadow:
     0 4px 12px var(--icon-link-grey),
     0 1px 3px var(--icon-link-grey);

--- a/static/css/components/mybooks-dropper.css
+++ b/static/css/components/mybooks-dropper.css
@@ -52,7 +52,7 @@
 .generic-dropper__dropdown p {
   margin-bottom: var(--spacing-stack-xs);
   margin-top: 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .generic-dropper__dropdown p a {

--- a/static/css/components/mybooks-list.css
+++ b/static/css/components/mybooks-list.css
@@ -26,7 +26,7 @@
 
 .mybooks-list h4.work-subtitle {
   font-family: var(--font-family-subtitle);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: 1em;
   font-weight: normal;
   font-style: italic;
@@ -97,7 +97,7 @@
 .mybooks-list--clean span.editions {
   margin-top: 0;
   font-size: 0.6875em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   padding-top: var(--spacing-inset-xs);
   padding-bottom: var(--spacing-inset-xs);
 }

--- a/static/css/components/mybooks-menu.css
+++ b/static/css/components/mybooks-menu.css
@@ -33,7 +33,7 @@
 
 .mybooks-menu a {
   display: block;
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 
 .mybooks-menu a:link,
@@ -90,9 +90,9 @@
   text-transform: uppercase;
   font-weight: bold;
   font-size: 0.8em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   background: var(--background-grey);
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-left: 0;
   border-right: 0;
   margin-bottom: var(--spacing-stack-xs);
@@ -111,8 +111,8 @@
   padding: var(--spacing-inset-xs) 5%;
   font-size: 0.96em;
   background-color: var(--background-grey);
-  border: 1px solid var(--lighter-grey);
-  color: var(--grey);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
 }
 
 /* stylelint-disable selector-max-specificity */
@@ -148,7 +148,7 @@
   float: right;
   font-size: 0.9em;
   margin-top: 1px;
-  color: var(--count-blue-grey);
+  color: var(--color-text-secondary);
   margin-left: var(--spacing-inline-sm);
 }
 
@@ -191,7 +191,7 @@
 
   .mybooks-menu-mobile a {
     text-decoration: none;
-    color: var(--link-blue);
+    color: var(--color-link);
   }
 
   /* all uls */
@@ -240,9 +240,9 @@
     text-transform: uppercase;
     font-weight: bold;
     font-size: 0.8em;
-    color: var(--grey);
+    color: var(--color-text-secondary);
     background: var(--background-grey);
-    border: 1px solid var(--lighter-grey);
+    border: 1px solid var(--color-border-subtle);
     border-left: 0;
     border-right: 0;
     margin-bottom: var(--spacing-stack-xs);
@@ -274,14 +274,14 @@
   .mybooks-menu-mobile hr {
     height: 0;
     margin: var(--spacing-stack-xs) var(--spacing-inline-xl);
-    border-bottom: 1px solid var(--lighter-grey);
+    border-bottom: 1px solid var(--color-border-subtle);
   }
 
   .mybooks-menu-mobile .li-count {
     float: right;
     font-size: 0.9em;
     margin-top: 1px;
-    color: var(--count-blue-grey);
+    color: var(--color-text-secondary);
     margin-left: var(--spacing-inline-sm);
   }
 

--- a/static/css/components/native-dialog.css
+++ b/static/css/components/native-dialog.css
@@ -7,7 +7,7 @@
 }
 
 .native-dialog--close {
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1.2em;
 }
 

--- a/static/css/components/native-dialog.css
+++ b/static/css/components/native-dialog.css
@@ -1,6 +1,6 @@
 .native-dialog {
   padding: 10px;
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-overlay);
   -webkit-box-shadow: 1px 3px 5px var(--darker-grey);
   box-shadow: 1px 3px 5px var(--darker-grey);

--- a/static/css/components/nav-bar.css
+++ b/static/css/components/nav-bar.css
@@ -19,7 +19,7 @@
   justify-content: center;
   height: 30px;
   text-decoration: none;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   padding: 0 12px;
   line-height: var(--line-height-control);
   border-bottom: 2px solid transparent;
@@ -27,7 +27,7 @@
 
 /* stylelint-disable selector-max-specificity */
 .nav-bar:not(.work-menu) li.selected a {
-  color: var(--link-blue);
+  color: var(--color-link);
   border-bottom: 2px solid var(--link-blue);
 }
 
@@ -125,7 +125,7 @@
   /* stylelint-disable max-nesting-depth */
   .nav-bar-wrapper .nav-bar.work-menu li:hover {
     background-color: var(
-      --header-nav-hover-color
+      --color-primary-hover
     ); /* hsl(206, 95%, 30%) — passes 4.5:1 with white */
   }
 
@@ -136,7 +136,7 @@
 
 .nav-bar-wrapper .nav-bar.work-menu li.selected {
   background-color: var(
-    --primary-blue
+    --color-primary
   ); /* hsl(206, 95%, 39%) — passes 4.5:1 with white */
 }
 

--- a/static/css/components/navEdition.css
+++ b/static/css/components/navEdition.css
@@ -9,7 +9,7 @@ div.navEdition {
 }
 
 span.booktitle {
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-family: var(--font-family-title);
   font-weight: bold;
 }

--- a/static/css/components/notes-view.css
+++ b/static/css/components/notes-view.css
@@ -73,7 +73,7 @@
 
 /* Observations view */
 .observations-header {
-  color: var(--dark-grey);
+  color: var(--color-text);
   padding: 1em 1em 0;
   text-decoration: underline;
 }

--- a/static/css/components/observationStats.css
+++ b/static/css/components/observationStats.css
@@ -54,7 +54,7 @@
   margin-top: 3px;
   margin-right: 3px;
   padding: 4px 8px;
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: 16px;
   font-size: var(--font-size-label-large);
   text-indent: 0;

--- a/static/css/components/observationStats.css
+++ b/static/css/components/observationStats.css
@@ -28,7 +28,7 @@
 .reviews__label {
   font-weight: bold;
   margin-top: 4px;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-size: 0.7em;
@@ -46,7 +46,7 @@
   font-weight: 500;
   margin-right: 5px;
   font-size: 0.9em;
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
 }
 
 .reviews__pill {
@@ -63,7 +63,7 @@
 
 .reviews__pill .percentage {
   font-size: 0.8em;
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
 }
 
 .reviews-header {

--- a/static/css/components/ol-banner.css
+++ b/static/css/components/ol-banner.css
@@ -130,7 +130,7 @@ ol-banner > .ol-banner__close {
   background: none;
   border: none;
   border-radius: var(--border-radius-sm);
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
   cursor: pointer;
 }
 

--- a/static/css/components/ol-button.css
+++ b/static/css/components/ol-button.css
@@ -75,7 +75,7 @@ ol-button > button {
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--border-radius-button);
   background-color: var(--white);
-  color: var(--dark-grey);
+  color: var(--color-text);
   /* Strength of the specular top edge. Full on light fills (secondary); the
      dark-filled variants (primary/destructive) dial it down — see below. */
   --control-highlight-strength: 35%;
@@ -123,8 +123,8 @@ ol-button[size="large"] > button {
 /* Primary — opt-in via variant="primary". */
 ol-button[variant="primary"]:not([hydrated]),
 ol-button[variant="primary"] > button {
-  background-color: var(--primary-blue);
-  border-color: var(--primary-blue);
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
   color: var(--white);
   /* Tone the specular highlight to the blue fill instead of pure white, and
      soften it — the white edge reads much louder on a dark fill than on white. */
@@ -137,14 +137,14 @@ ol-button[variant="secondary"]:not([hydrated]),
 ol-button[variant="secondary"] > button {
   background-color: var(--white);
   border-color: var(--color-border-subtle);
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 /* Destructive — solid red fill, mirroring primary but in the danger hue. */
 ol-button[variant="destructive"]:not([hydrated]),
 ol-button[variant="destructive"] > button {
   background-color: var(--red);
-  border-color: var(--red);
+  border-color: var(--color-border-error);
   color: var(--white);
   /* Tone the specular highlight to the red fill and soften it, matching primary. */
   --control-surface: var(--red);
@@ -158,7 +158,7 @@ ol-button[selected]:not([hydrated]),
 ol-button[selected] > button {
   background-color: var(--color-control-selected-bg);
   border-color: var(--color-control-selected-border);
-  color: var(--link-blue);
+  color: var(--color-link);
   /* Opaque twin of the tint — a translucent surface washes out the highlight. */
   --control-surface: var(--color-control-selected-surface);
 }

--- a/static/css/components/ol-button.css
+++ b/static/css/components/ol-button.css
@@ -174,7 +174,7 @@ ol-button[selected] > button {
     /* Nudge the border a touch darker in step with the fill (both drop ~7%
        in lightness) so the whole button reads as one shape on hover, rather
        than the fill darkening inside a static outline. */
-    border-color: var(--light-grey);
+    border-color: var(--color-border-muted);
     --control-surface: var(--color-control-hover);
   }
 

--- a/static/css/components/page-banner.css
+++ b/static/css/components/page-banner.css
@@ -8,7 +8,7 @@
   font-family: var(--font-family-body);
   background: var(--dark-grey);
   padding: 15px;
-  border-bottom: 1px solid var(--beige);
+  border-bottom: 1px solid var(--color-border-subtle);
   z-index: var(--z-index-level-2);
 }
 .page-banner-mybooks {
@@ -70,7 +70,7 @@
   font-family: var(--font-family-body);
   background: var(--dark-grey);
   padding: 15px;
-  border-bottom: 1px solid var(--beige);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 .page-banner--dismissable-content {
   flex: 1;

--- a/static/css/components/page-heading-search-box.css
+++ b/static/css/components/page-heading-search-box.css
@@ -17,7 +17,7 @@
   padding: 10px;
   display: inline-block;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border: 1px solid var(--mid-grey);
   cursor: pointer;
   transition: background-color 0.2s;
@@ -27,5 +27,5 @@
 }
 .subjectTagEdit a.editTagButton {
   text-decoration: none;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }

--- a/static/css/components/page-history.css
+++ b/static/css/components/page-history.css
@@ -99,7 +99,7 @@ table#pageHistory td.compare-against {
 
 /* stylelint-disable-next-line selector-max-specificity */
 table#pageHistory .compare-against a {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-button);
   color: var(--color-text);
   display: inline-block;
@@ -197,7 +197,7 @@ table#pageHistory .compare-against a:hover {
 /* Match the bordered style of the in-table Changes / vs current buttons. */
 /* Qualify with `a` so this beats the global `a:link` underline/blue rule. */
 a.page-history-compare__submit {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-button);
   background: var(--white);
   color: var(--color-text);

--- a/static/css/components/page-history.css
+++ b/static/css/components/page-history.css
@@ -42,7 +42,7 @@ table.history tr:last-child {
 table.history td {
   font-size: 0.6875em;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   border-bottom: var(--border-table);
 }
 
@@ -77,7 +77,7 @@ table#pageHistory tbody td {
 
 /* stylelint-disable-next-line selector-max-specificity */
 table#pageHistory td.when {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   white-space: nowrap;
 }
 
@@ -101,7 +101,7 @@ table#pageHistory td.compare-against {
 table#pageHistory .compare-against a {
   border: 1px solid var(--light-grey);
   border-radius: var(--border-radius-button);
-  color: var(--dark-grey);
+  color: var(--color-text);
   display: inline-block;
   min-width: 64px;
   font-size: var(--font-size-label-small);
@@ -122,14 +122,14 @@ table#pageHistory .compare-against a + a {
 table#pageHistory td.number a,
 table#pageHistory td.when a,
 table#pageHistory td.who a {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 /* stylelint-enable selector-max-specificity */
 
 /* stylelint-disable-next-line selector-max-specificity */
 table#pageHistory td.comment a {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: none;
 }
 
@@ -186,7 +186,7 @@ table#pageHistory .compare-against a:hover {
   border: var(--border-card);
   border-radius: var(--border-radius-card);
   background: var(--beige-pale);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-label-medium);
 }
 
@@ -200,7 +200,7 @@ a.page-history-compare__submit {
   border: 1px solid var(--light-grey);
   border-radius: var(--border-radius-button);
   background: var(--white);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-label-small);
   font-weight: 500;
   padding: 3px 10px;
@@ -212,7 +212,7 @@ a.page-history-compare__submit {
 }
 
 .page-history-compare__submit.is-disabled {
-  border-color: var(--lighter-grey);
+  border-color: var(--color-border-subtle);
   background: transparent;
   color: var(--mid-grey);
   cursor: not-allowed;
@@ -229,7 +229,7 @@ a.page-history-compare__submit {
   border: 0;
   border-radius: var(--border-radius-button);
   background: transparent;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
@@ -237,7 +237,7 @@ a.page-history-compare__submit {
 
 .page-history-compare__clear:hover {
   background: var(--light-grey);
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 /* Mark the rows chosen as A / B with a left accent bar in the selection */

--- a/static/css/components/rating-form.css
+++ b/static/css/components/rating-form.css
@@ -27,7 +27,7 @@
 }
 
 .review .review-btn {
-  border-left: 1px solid var(--lighter-grey);
+  border-left: 1px solid var(--color-border-subtle);
   width: 35px;
   height: 35px;
 }

--- a/static/css/components/read-panel.css
+++ b/static/css/components/read-panel.css
@@ -21,7 +21,7 @@
   margin-bottom: 10px;
   background-color: var(--white);
   border-radius: 5px;
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   margin-top: 0;
 }
 
@@ -72,7 +72,7 @@
   mask: url(/static/images/icons/open-book.svg);
   -webkit-mask-size: cover;
   mask-size: cover;
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
 }
 /* stylelint-enable selector-max-specificity */
 
@@ -230,7 +230,7 @@ ul.ebook-download-options li {
   }
 
   .readers-stats__wrapper.mobile {
-    border: 1px solid var(--lighter-grey);
+    border: 1px solid var(--color-border-subtle);
     border-radius: 5px;
     padding: 10px 0;
   }
@@ -253,7 +253,7 @@ ul.ebook-download-options li {
   /* stylelint-disable max-nesting-depth*/
   /* stylelint-disable selector-max-specificity */
   .readers-stats__wrapper.mobile .readers-stats li {
-    border-right: 1px solid var(--lighter-grey);
+    border-right: 1px solid var(--color-border-subtle);
     display: flex;
     flex-direction: column-reverse;
     flex: 1 1 auto;
@@ -267,7 +267,7 @@ ul.ebook-download-options li {
   }
 
   .readers-stats__wrapper.mobile .readers-stats li + li {
-    border-right: solid 1px var(--lighter-grey);
+    border-right: solid 1px var(--color-border-subtle);
   }
 
   .readers-stats__wrapper.mobile .readers-stats li:last-child {

--- a/static/css/components/read-statuses.css
+++ b/static/css/components/read-statuses.css
@@ -13,7 +13,7 @@
   border: none;
   background: none;
   cursor: pointer;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-weight: bold;
   width: 100%;
   text-align: left;

--- a/static/css/components/readerStats.css
+++ b/static/css/components/readerStats.css
@@ -21,7 +21,7 @@
 }
 
 .readers-stats {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-label-large);
   margin-bottom: 20px;
 }

--- a/static/css/components/reading-goal.css
+++ b/static/css/components/reading-goal.css
@@ -20,7 +20,7 @@
 
 .goal-form__learn-more {
   font-size: var(--font-size-label-small);
-  color: var(--dark-grey);
+  color: var(--color-text);
   text-decoration: none;
 }
 
@@ -36,7 +36,7 @@
 
 .goal-form__note {
   margin: 0;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-label-small);
   text-align: center;
 }
@@ -50,13 +50,13 @@
   padding: 8px 12px;
   font-size: var(--font-size-label-large);
   text-align: center;
-  border: 2px solid var(--lighter-grey);
+  border: 2px solid var(--color-border-subtle);
   border-radius: var(--border-radius-input);
   outline: none;
 }
 
 .goal-form__input-section input:focus {
-  border-color: var(--primary-blue);
+  border-color: var(--color-border-focused);
   box-shadow: 0 0 0 2px hsla(202, 96%, 37%, 0.2);
 }
 
@@ -103,7 +103,7 @@
 
 /* Styles for the yearly reading goal progress component */
 .reading-goal-progress {
-  color: var(--dark-grey);
+  color: var(--color-text);
   padding: 5px 0;
 }
 
@@ -122,7 +122,7 @@
 
 .reading-goal-progress__completed {
   display: inline-block;
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
   height: inherit;
   border-radius: inherit;
 }

--- a/static/css/components/search-result-item.css
+++ b/static/css/components/search-result-item.css
@@ -39,7 +39,7 @@
   mask: url(/static/images/icons/open-book.svg);
   -webkit-mask-size: cover;
   mask-size: cover;
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
 }
 /* stylelint-enable selector-max-specificity */
 
@@ -78,7 +78,7 @@
   display: block;
   margin: 0;
   padding: 0;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1.1em;
   font-weight: 700;
   font-family: var(--font-family-title);
@@ -97,7 +97,7 @@
 
 .searchResultItem .resultStats {
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-body);
   display: block;
 }
@@ -266,7 +266,7 @@
   border-top: 1px dashed currentColor;
   margin-top: var(--spacing-stack-sm);
   margin-bottom: calc(-1 * var(--spacing-stack-xs));
-  color: var(--grey);
+  color: var(--color-text-secondary);
   padding: var(--spacing-inset-sm) 0;
   line-height: var(--line-height-meta);
   transition: color 0.2s;
@@ -283,7 +283,7 @@
   }
 
   .search-result-item__preview-covers :hover img {
-    border-color: var(--primary-blue);
+    border-color: var(--color-primary);
   }
 }
 

--- a/static/css/components/searchbox.css
+++ b/static/css/components/searchbox.css
@@ -25,7 +25,7 @@
   margin: 0 !important;
   border: 0;
   background: transparent;
-  color: var(--grey) !important;
+  color: var(--color-text-secondary) !important;
   flex-grow: 1;
   font-size: 1em !important;
   min-width: 0;

--- a/static/css/components/shareLinks.css
+++ b/static/css/components/shareLinks.css
@@ -63,5 +63,5 @@
 .shareLinks .share-source {
   font-size: 0.8em;
   text-align: center;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }

--- a/static/css/components/tagging-menu.css
+++ b/static/css/components/tagging-menu.css
@@ -3,7 +3,7 @@
   height: fit-content;
   right: 30px;
   bottom: 50px;
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   box-shadow: 0 5px 5px 2px var(--accessible-grey);
   background-color: var(--white);
   border-radius: var(--border-radius-card);
@@ -27,8 +27,8 @@
 }
 
 .search-subject-container {
-  border-top: 1px solid var(--light-grey);
-  border-bottom: 1px solid var(--light-grey);
+  border-top: 1px solid var(--color-border-muted);
+  border-bottom: 1px solid var(--color-border-muted);
   width: 100%;
   padding: 5px;
 }
@@ -38,7 +38,7 @@
   height: 100%;
   padding: 5px;
   margin: 0;
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: 5px;
   background: var(--white);
   font-size: var(--font-size-label-large);
@@ -121,8 +121,8 @@
   flex-direction: column;
   justify-content: center;
   padding: 9px 10px;
-  border-bottom: 1px solid var(--light-grey);
-  border-top: 1px solid var(--light-grey);
+  border-bottom: 1px solid var(--color-border-muted);
+  border-top: 1px solid var(--color-border-muted);
 }
 
 .search-subject-row-name.search-subject-row-name-create

--- a/static/css/components/tagging-menu.css
+++ b/static/css/components/tagging-menu.css
@@ -46,7 +46,7 @@
 }
 
 .subjects-search-input:focus {
-  border-color: var(--blue-3366ff);
+  border-color: var(--color-border-focused);
 }
 
 /* Menu option containers: */
@@ -101,7 +101,7 @@
 }
 
 .subject-type-option--subject {
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
 }
 
 .subject-type-option--collection {
@@ -199,7 +199,7 @@
 }
 
 .selected-tag .selected-tag__type--subject {
-  background-color: var(--primary-blue);
+  background-color: var(--color-primary);
 }
 
 .selected-tag .selected-tag__type--collection {

--- a/static/css/components/toc.css
+++ b/static/css/components/toc.css
@@ -19,13 +19,13 @@
 
 .toc__entry .toc__dots {
   flex: 1;
-  border-bottom: 1px dotted var(--lighter-grey);
+  border-bottom: 1px dotted var(--color-border-subtle);
   height: 1.2em;
 }
 
 .toc__entry .toc__subtitle {
   font-style: oblique;
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
 }
 
 .toc__entry .toc__subtitle,
@@ -89,6 +89,6 @@ a.toc__main:hover::after {
 
   .toc__pagenum {
     font-size: var(--font-size-label-large);
-    color: var(--accessible-grey);
+    color: var(--color-text-muted);
   }
 }

--- a/static/css/components/ui-dialog.css
+++ b/static/css/components/ui-dialog.css
@@ -15,7 +15,7 @@
 .ui-dialog .ui-dialog-titlebar {
   position: relative;
   font-weight: normal;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 1em;
   margin: 0.2em 0;
   padding: 8px 0;

--- a/static/css/components/ui-tabs.css
+++ b/static/css/components/ui-tabs.css
@@ -43,11 +43,11 @@
 /* stylelint-disable max-nesting-depth */
 .ui-tabs-nav a:link,
 .ui-tabs-nav a:visited {
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 
 .ui-tabs-nav a:hover {
-  color: var(--link-blue);
+  color: var(--color-link);
   text-decoration: underline;
 }
 /* stylelint-enable max-nesting-depth */

--- a/static/css/components/widget-box.css
+++ b/static/css/components/widget-box.css
@@ -3,7 +3,7 @@
  * https://docs.openlibrary.org/designers/design-pattern-library.html#widgetbox
  */
 .widget-box .head > div {
-  color: var(--olive) !important;
+  color: var(--color-success-fg) !important;
   font-size: 10px;
 }
 

--- a/static/css/components/work-title-and-author.css
+++ b/static/css/components/work-title-and-author.css
@@ -14,7 +14,7 @@
 .work-title-and-author h1.work-title {
   font-family: var(--font-family-title);
   margin: 0;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: var(--font-size-headline-large);
   overflow-wrap: break-word;
 }
@@ -22,7 +22,7 @@
 .work-title-and-author h2.work-subtitle {
   font-family: var(--font-family-subtitle);
   margin: 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: 1.3em;
   font-weight: normal;
   font-style: italic;
@@ -31,18 +31,18 @@
 .work-title-and-author h2.edition-byline {
   font-size: var(--font-size-title-medium);
   font-weight: normal;
-  color: var(--dark-grey);
+  color: var(--color-text);
   margin: 10px 0 20px;
   line-height: var(--line-height-meta);
 }
 
 .work-title-and-author .work-line {
   font-style: oblique;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .work-title-and-author .work-line a {
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .work-title-and-author .series-line a {
@@ -51,7 +51,7 @@
 }
 
 .work-title-and-author .first-published-date {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-label-medium);
 }
 
@@ -109,7 +109,7 @@
   }
 
   .work-title-and-author .share-modal-link .icon-link__text {
-    color: var(--dark-grey);
+    color: var(--color-text);
     font-size: 0.675em;
   }
 

--- a/static/css/components/work.css
+++ b/static/css/components/work.css
@@ -74,7 +74,7 @@ div.editionAbout p.featured-count {
 }
 
 .workFooter .lists-heading a {
-  color: var(--link-blue);
+  color: var(--color-link);
   font-size: var(--font-size-title-medium);
 }
 /* stylelint-enable selector-max-specificity */
@@ -147,14 +147,14 @@ div.editionAbout p.featured-count {
 
 .edition-overview .edition-title {
   margin-bottom: 0;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 .edition-overview .edition-subtitle {
   margin-top: 5px;
   font-size: 1.4em;
   font-weight: normal;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 a.section-anchor {
@@ -190,7 +190,7 @@ div.editionTools {
 }
 
 div.editionTools p {
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 @media only screen and (min-width: 960px) {
@@ -246,7 +246,7 @@ div.editionTools p {
   flex: 1;
   padding: 9px;
   margin: 0 4px;
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 5px;
   font-size: var(--font-size-body-medium);
   word-break: break-word;
@@ -257,7 +257,7 @@ div.editionTools p {
 .edition-omniline-item div {
   margin-bottom: 4px;
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   word-wrap: break-word;
 }
 
@@ -288,20 +288,20 @@ div.editionTools p {
 
 .tab-section {
   padding: 10px;
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 5px;
   clear: both;
 }
 
 .preview-languages {
   font-size: 0.8em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .list-heading {
   font-size: 1.2em;
   font-weight: normal;
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 
 @media only screen and (max-width: 960px) {

--- a/static/css/js-all.css
+++ b/static/css/js-all.css
@@ -48,7 +48,7 @@
 .tools a.on,
 .tools a.on:hover,
 .tools a.on:active {
-  color: var(--dark-grey);
+  color: var(--color-text);
   cursor: default;
   text-decoration: none;
 }

--- a/static/css/layout/index.css
+++ b/static/css/layout/index.css
@@ -11,7 +11,7 @@
   margin: 0 auto;
   background-color: var(--white);
   border-radius: 5px;
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
   z-index: var(--z-index-level-1);
   position: relative;
 }

--- a/static/css/legacy-borrowTable-adminUser.css
+++ b/static/css/legacy-borrowTable-adminUser.css
@@ -35,7 +35,7 @@
   background: var(--admin-row-background) !important;
 }
 .borrow-table tr.row-available .status-value {
-  color: var(--dark-green);
+  color: var(--color-success-fg);
 }
 
 .borrow-table td.status,

--- a/static/css/legacy-borrowTable-adminUser.css
+++ b/static/css/legacy-borrowTable-adminUser.css
@@ -17,7 +17,7 @@
   vertical-align: bottom;
   padding-bottom: var(--spacing-inset-sm);
   font-family: var(--font-family-body);
-  color: var(--brown);
+  color: var(--color-text-heading);
   font-weight: 600;
   font-size: 0.6875em;
   text-transform: uppercase;

--- a/static/css/legacy-datatables.css
+++ b/static/css/legacy-datatables.css
@@ -35,7 +35,7 @@
   margin-left: -125px;
   margin-top: -15px;
   padding: 14px 0 5px;
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   text-align: center;
   color: var(--light-grey);
   font-size: var(--font-size-label-large);
@@ -43,14 +43,14 @@
 
 .dataTables_length {
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   display: inline-block;
 }
 
 .dataTables_info {
   width: 100%;
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin-top: 20px;
 }
 
@@ -61,7 +61,7 @@
   /* stylelint-enable declaration-block-no-duplicate-properties */
   text-align: right;
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 /* Pagination nested */
@@ -159,19 +159,19 @@ table.KeyTable td {
 }
 
 table.KeyTable td.focus {
-  border: 3px solid var(--blue-3366ff);
+  border: 3px solid var(--color-border-focused);
 }
 
 table.display tr.gradeA {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 table.display tr.gradeC {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 table.display tr.gradeX {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 table.display tr.gradeU {
@@ -183,7 +183,7 @@ div.box {
   padding: var(--spacing-inset-sm);
   overflow: auto;
   border: 1px solid var(--dark-baby-blue);
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -215,7 +215,7 @@ tfoot input {
 }
 
 tfoot input.search_init {
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 td.group {
@@ -234,7 +234,7 @@ div.dataTables_filter {
   text-align: right;
   font-size: var(--font-size-label-medium);
   margin: 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .dataTables_filter input {
@@ -260,7 +260,7 @@ div.dataTables_filter {
   font-size: var(--font-size-label-small);
   padding: var(--spacing-inset-sm);
   margin: 0 var(--spacing-inline-sm);
-  color: var(--link-blue);
+  color: var(--color-link);
   cursor: pointer;
 }
 
@@ -298,23 +298,23 @@ tr.odd.gradeA td.sorting_1 {
 }
 
 tr.odd.gradeA td.sorting_2 {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 tr.odd.gradeA td.sorting_3 {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 tr.even.gradeA td.sorting_1 {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 tr.even.gradeA td.sorting_2 {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 tr.even.gradeA td.sorting_3 {
-  background-color: var(--baby-green);
+  background-color: var(--color-success-bg);
 }
 
 tr.odd.gradeC td.sorting_1 {
@@ -322,23 +322,23 @@ tr.odd.gradeC td.sorting_1 {
 }
 
 tr.odd.gradeC td.sorting_2 {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 tr.odd.gradeC td.sorting_3 {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 tr.even.gradeC td.sorting_1 {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 tr.even.gradeC td.sorting_2 {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 tr.even.gradeC td.sorting_3 {
-  background-color: var(--baby-blue);
+  background-color: var(--color-primary-subtle);
 }
 
 tr.odd.gradeX td.sorting_1 {
@@ -346,23 +346,23 @@ tr.odd.gradeX td.sorting_1 {
 }
 
 tr.odd.gradeX td.sorting_2 {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 tr.odd.gradeX td.sorting_3 {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 tr.even.gradeX td.sorting_1 {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 tr.even.gradeX td.sorting_2 {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 tr.even.gradeX td.sorting_3 {
-  background-color: var(--baby-pink);
+  background-color: var(--color-error-bg);
 }
 
 tr.odd.gradeU td.sorting_1 {

--- a/static/css/legacy-datatables.css
+++ b/static/css/legacy-datatables.css
@@ -148,7 +148,7 @@ table.display thead th {
 
 tr.even,
 tr.odd {
-  border-bottom: 1px solid var(--light-grey);
+  border-bottom: 1px solid var(--color-border-muted);
 }
 
 /*

--- a/static/css/legacy-tools.css
+++ b/static/css/legacy-tools.css
@@ -204,7 +204,7 @@
 }
 
 .Tools h3.closed span.head {
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .Tools h4 {
@@ -236,13 +236,13 @@
   list-style-type: none;
   font-size: 0.75em;
   margin-top: 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .Tools .panel p {
   font-size: 0.75em;
   margin-top: 0;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .Tools div.icon {

--- a/static/css/legacy.css
+++ b/static/css/legacy.css
@@ -93,7 +93,7 @@ table#pageHistory td.number {
 table#pageHistory th,
 table.changeHistory th {
   border-bottom: 1px solid var(--color-border-subtle);
-  color: var(--brown);
+  color: var(--color-text-heading);
   text-transform: uppercase !important;
   font-size: 0.6875em;
   padding: var(--spacing-inset-sm);
@@ -457,7 +457,7 @@ div#content {
   width: 958px;
   background-color: var(--white);
   border-radius: 5px;
-  border: 1px solid var(--dark-beige);
+  border: 1px solid var(--color-border-muted);
 }
 
 div#content div.contentLists {
@@ -1911,7 +1911,7 @@ div#subjectLists p {
   }
 
   .header-bar .logo-component {
-    /* border-right: 1px solid var(--dark-beige); */
+    /* border-right: 1px solid var(--color-border-muted); */
     padding-right: 15px;
   }
 
@@ -1928,7 +1928,7 @@ div#subjectLists p {
 
   .header-bar .navigation-component .dropdown-menu {
     border-radius: 3px;
-    border: 1px solid var(--dark-beige);
+    border: 1px solid var(--color-border-muted);
   }
 
   .header-bar .navigation-component li .dropdown-menu {
@@ -1942,7 +1942,7 @@ div#subjectLists p {
   .header-bar .search-component .search-bar-component {
     width: 100%;
     background-color: var(--grey-fafafa);
-    border: 1px solid var(--dark-beige);
+    border: 1px solid var(--color-border-muted);
     border-radius: 6px;
   }
 

--- a/static/css/legacy.css
+++ b/static/css/legacy.css
@@ -92,7 +92,7 @@ table#pageHistory td.number {
 /* openlibrary/templates/admin/people/edits.html */
 table#pageHistory th,
 table.changeHistory th {
-  border-bottom: 1px solid var(--grey-e7e7e7);
+  border-bottom: 1px solid var(--color-border-subtle);
   color: var(--brown);
   text-transform: uppercase !important;
   font-size: 0.6875em;
@@ -101,10 +101,10 @@ table.changeHistory th {
 
 table#pageHistory td,
 table.changeHistory td {
-  border-bottom: 1px solid var(--grey-e7e7e7);
+  border-bottom: 1px solid var(--color-border-subtle);
   padding: var(--spacing-inset-sm);
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 table.changeHistory {
@@ -130,14 +130,14 @@ table.changeHistory .comment__cover {
 /* https://openlibrary.org/help/markdown */
 table.help {
   margin: 20px 0;
-  border-top: 1px solid var(--grey-e7e7e7);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 table.help th {
   font-size: 0.75em;
   font-family: var(--font-family-body);
-  color: var(--grey);
-  border-bottom: 1px solid var(--grey-e7e7e7);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
   padding: var(--spacing-inset-xs);
   vertical-align: top;
   background-color: var(--lightest-grey);
@@ -146,8 +146,8 @@ table.help th {
 table.help td {
   font-size: 0.75em;
   font-family: var(--font-family-body);
-  color: var(--grey);
-  border-bottom: 1px solid var(--grey-e7e7e7);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
   padding: var(--spacing-inset-xs);
   vertical-align: top;
 }
@@ -255,7 +255,7 @@ div.unordered {
 div.superNav {
   font-size: 0.6875em;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-stack-xs);
 }
 
@@ -271,7 +271,7 @@ span.link {
 
 span.tools {
   font-size: var(--font-size-label-medium);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-weight: normal !important;
   font-family: var(--font-family-body);
 }
@@ -295,7 +295,7 @@ span.tools span.list {
 
 span.tag {
   font-size: 13px;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 span.count {
@@ -313,7 +313,7 @@ span.merge {
 
 span.resultTitle {
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 span.resultTitle span.resultType {
@@ -325,7 +325,7 @@ span.resultTitle span.resultType {
 span.resultTitle .bookauthor,
 span.resultTitle .resultPublisher {
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-body);
   font-weight: normal;
 }
@@ -394,8 +394,8 @@ input.repeat-add {
 }
 
 input.invalid {
-  border-color: var(--red);
-  color: var(--dark-grey);
+  border-color: var(--color-border-error);
+  color: var(--color-text);
 }
 
 input.highlight {
@@ -431,7 +431,7 @@ input.highlight {
 /* Search v2 */
 /* openlibrary/macros/SearchResultsWork.html */
 .serp-extras {
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   background-color: var(--white);
   padding: 0 10px 10px;
   margin-top: var(--spacing-stack-sm);
@@ -470,7 +470,7 @@ div#content div.contentLists {
 div#content div#contentLists {
   float: left;
   position: relative;
-  border-top: 1px solid var(--lighter-grey);
+  border-top: 1px solid var(--color-border-subtle);
   background: var(--white) url(/static/images/back_results.png) repeat-x;
 }
 /* stylelint-enable selector-max-specificity */
@@ -499,7 +499,7 @@ div.note {
   margin: 0 auto;
   padding: var(--spacing-inset-sm);
   text-align: left;
-  border: 1px solid var(--dark-yellow);
+  border: 1px solid var(--color-warning-border);
 }
 
 /* openlibrary/templates/lib/not_logged.html */
@@ -684,7 +684,7 @@ div.siteSearch input[type="text"] {
 .searchPlus {
   font-family: var(--font-family-body);
   font-size: 0.75em;
-  color: var(--dark-grey);
+  color: var(--color-text);
   padding: var(--spacing-inset-md) 0;
 }
 
@@ -784,7 +784,7 @@ div.verify span {
 
 .forgot-email-form label {
   font-family: var(--font-family-body);
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-weight: 600;
 }
 
@@ -899,7 +899,7 @@ div#searchResults .SRPCoverBlank a {
   font-family: var(--font-family-body);
   font-size: 0.7em;
   margin-bottom: -1.5em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   padding: 0.2em;
 }
 
@@ -913,7 +913,7 @@ div#searchResults .SRPCoverBlank a {
   margin-bottom: 1.5em;
   max-width: 800px;
   font-size: 1em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .authorList .cover {
@@ -934,7 +934,7 @@ div#searchResults .SRPCoverBlank a {
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
 }
 
 /* The result count rides the "Books" label but reads as data, not a label. */
@@ -977,7 +977,7 @@ div#searchResults .SRPCoverBlank a {
   width: 48px;
   height: 48px;
   overflow: hidden;
-  color: var(--accessible-grey);
+  color: var(--color-text-muted);
   background: var(--lightest-grey);
   border-radius: var(--border-radius-avatar);
 }
@@ -1076,7 +1076,7 @@ div.list .copy {
 div.list h5 {
   font-family: var(--font-family-serif);
   font-weight: normal;
-  color: var(--dark-grey);
+  color: var(--color-text);
   margin-bottom: var(--spacing-stack-xs);
 }
 
@@ -1088,14 +1088,14 @@ div.list h5 span {
 div.list .tags {
   font-family: var(--font-family-body);
   font-size: 0.6875em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-stack-xs);
 }
 
 div.list .owner {
   font-family: var(--font-family-body);
   font-size: 0.6875em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   text-align: right;
 }
 
@@ -1205,11 +1205,11 @@ div.books .BookTitle {
   margin-left: -31px;
   height: 93px;
   margin-top: -46px;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 div.books .Author {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-style: italic;
   padding: var(--spacing-inset-xs) var(--spacing-inset-xs) 0;
   font-size: 0.6875em;
@@ -1248,8 +1248,8 @@ div.excerpt .attribution {
 /* openlibrary/templates/books/edit/edition.html */
 /* openlibrary/templates/admin/imports-add.html */
 .identifiers td {
-  color: var(--dark-grey);
-  border-bottom: 1px solid var(--lighter-grey);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border-subtle);
   padding: var(--spacing-inset-xs);
 }
 
@@ -1342,14 +1342,14 @@ ul.clean li span.resultTitle {
   height: 100px;
   margin-top: -50px;
   vertical-align: middle;
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 0.875em;
   line-height: normal;
 }
 
 /* openlibrary/templates/covers/book_cover.html */
 .Author {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-style: italic;
   padding: var(--spacing-inset-xs) var(--spacing-inset-xs) 0;
   font-size: var(--font-size-label-small);
@@ -1467,7 +1467,7 @@ ul.list-books .resultTitle {
   display: block;
   margin: 0 !important;
   font-family: var(--font-family-body);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 /* `span.resultTitle .bookauthor` is used in: */
@@ -1478,7 +1478,7 @@ ul.list-books .resultTitle {
 ul.list-books .resultTitle .bookauthor,
 ul.list-books span.resultPublisher {
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-body);
 }
 
@@ -1665,7 +1665,7 @@ div.postSubmit {
 /* openlibrary/templates/type/list/exports.html */
 #listTools ul {
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-family: var(--font-family-body);
   margin: 0 0 20px !important;
 }
@@ -1780,7 +1780,7 @@ div#subjectLists p {
   background: inherit;
   border: none;
   padding: 0;
-  color: var(--link-blue);
+  color: var(--color-link);
   border-bottom: 1px solid var(--link-blue);
   margin-bottom: var(--spacing-stack-md);
 }

--- a/static/css/markdown.css
+++ b/static/css/markdown.css
@@ -26,7 +26,7 @@
 .markdown-content blockquote {
   margin-left: 1rem;
   padding: 0.5rem 1rem;
-  border-left: 2px solid var(--beige-deep);
+  border-left: 2px solid var(--color-border-subtle);
   color: var(--darker-grey);
   background: var(--off-white);
   font-style: italic;

--- a/static/css/page-admin.css
+++ b/static/css/page-admin.css
@@ -50,7 +50,7 @@ table.services th {
   font-size: var(--font-size-label-small);
   font-weight: bold;
   text-transform: uppercase;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 table.services td {
   padding: var(--spacing-inset-xs);
@@ -71,7 +71,7 @@ table.services td.node {
 #adminHistory th {
   background-color: var(--lightest-grey);
   border-bottom: 1px solid var(--admin-table-border);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: 0.8675em;
   font-weight: 700;
   padding: var(--spacing-inset-sm);
@@ -107,7 +107,7 @@ div#prolific span {
   font-size: 0.5625em;
   font-family: var(--font-family-body);
   font-weight: normal;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   text-transform: uppercase;
 }
 

--- a/static/css/page-book-widget.css
+++ b/static/css/page-book-widget.css
@@ -22,7 +22,7 @@ body {
 
 .cta {
   font-family: var(--font-family-body);
-  background: var(--primary-blue);
+  background: var(--color-primary);
   border-radius: 3px;
   width: 130px;
   margin: 0 auto;
@@ -78,7 +78,7 @@ a.noshow {
   font-family: var(--font-family-body);
   font-size: 0.7em;
   font-weight: normal;
-  color: var(--grey);
+  color: var(--color-text-secondary);
   margin: 5px auto 7px;
   width: 130px;
 }

--- a/static/css/page-book-widget.css
+++ b/static/css/page-book-widget.css
@@ -65,7 +65,7 @@ img.bookcover {
 .title {
   font-family: var(--font-family-title);
   margin: 7px auto 0;
-  color: var(--grey-555);
+  color: var(--color-text-heading);
   font-size: 0.8em;
   width: 130px;
 }

--- a/static/css/page-edit.css
+++ b/static/css/page-edit.css
@@ -72,11 +72,11 @@ textarea {
 .formElement select {
   font-size: 1em;
   font-family: var(--font-family-body);
-  color: var(--dark-grey);
+  color: var(--color-text);
   padding: var(--spacing-inset-xs);
 }
 table.code {
-  border: 1px solid var(--grey-e7e7e7);
+  border: 1px solid var(--color-border-subtle);
   width: 100%;
   margin-right: 10px;
   margin-bottom: 40px;
@@ -139,7 +139,7 @@ div#bottom,
 div.adminDelete {
   margin-top: 8px;
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 /* @width-breakpoint-desktop = 960px */

--- a/static/css/page-form.css
+++ b/static/css/page-form.css
@@ -62,7 +62,7 @@ div#revertLink,
   background-color: var(--light-yellow);
   margin: 0 10px;
   border-radius: 8px;
-  border: 1px solid var(--dark-yellow);
+  border: 1px solid var(--color-warning-border);
 }
 .portlet {
   margin: 7px 13px 13px 7px;
@@ -70,7 +70,7 @@ div#revertLink,
   width: 70px;
   height: 70px;
   overflow: hidden;
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 6px;
   cursor: move;
 }
@@ -94,7 +94,7 @@ div#revertLink,
 .imageSaved {
   width: 300px;
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 .imageSaved .imageSaved__button {
   text-decoration: none;

--- a/static/css/page-list-edit.css
+++ b/static/css/page-list-edit.css
@@ -108,7 +108,7 @@
   list-style: none;
   width: 90%;
   margin-top: var(--spacing-stack-xs);
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-input);
   padding: var(--spacing-inset-sm);
   background: var(--grey-fafafa);

--- a/static/css/page-plain.css
+++ b/static/css/page-plain.css
@@ -53,7 +53,7 @@ div.nav {
 
 .borrow-table table th.expires {
   font-family: var(--font-family-body);
-  color: var(--brown);
+  color: var(--color-text-heading);
   font-weight: 600;
   font-size: 0.6875em;
   text-transform: uppercase;

--- a/static/css/page-plain.css
+++ b/static/css/page-plain.css
@@ -102,7 +102,7 @@ ul.link li {
 }
 #faq p {
   font-size: 0.75em;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 
 p.help {
@@ -136,7 +136,7 @@ div.navBorrow {
 }
 .panel {
   background-color: var(--white);
-  border: 1px solid var(--beige-two);
+  border: 1px solid var(--color-border-subtle);
   padding: 30px 20px;
   margin-bottom: 20px;
 }
@@ -157,16 +157,16 @@ div.navBorrow {
 }
 .borrow span.author {
   font-size: 0.875em;
-  color: var(--dark-grey);
+  color: var(--color-text);
 }
 .borrow span.publisher,
 .borrow span.contributor {
-  color: var(--dark-grey);
+  color: var(--color-text);
   font-size: 0.875em;
 }
 .borrow div.date {
   font-size: 0.75em;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 .borrow span.expires {
   font-size: 1em;

--- a/static/css/page-signup.css
+++ b/static/css/page-signup.css
@@ -134,7 +134,7 @@
 }
 
 .ol-signup-form .ol-signup-form__input input {
-  border: 1px solid var(--light-grey);
+  border: 1px solid var(--color-border-muted);
   border-radius: var(--border-radius-input);
   width: 100%;
   padding: 6px 4px;

--- a/static/css/page-signup.css
+++ b/static/css/page-signup.css
@@ -64,7 +64,7 @@
 }
 
 .ol-signup-hero .ol-signup-hero__subtitle {
-  color: var(--grey);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-title-large);
 }
 
@@ -99,7 +99,7 @@
   gap: 10px;
   margin-top: 10px;
   max-width: 600px;
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .ol-signup-form .ol-signup-form__big-or::before,
@@ -126,7 +126,7 @@
 
 .ol-signup-form .ol-signup-form__note {
   font-size: var(--font-size-label-large);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .ol-signup-form .ol-signup-form__input {
@@ -141,7 +141,7 @@
 }
 
 .ol-signup-form .ol-signup-form__input input.invalid {
-  border: 1px solid var(--red);
+  border: 1px solid var(--color-border-error);
 }
 
 .ol-signup-form .ol-signup-form__input label,
@@ -170,7 +170,7 @@
 
 .ol-signup-form .ol-signup-form__suffix {
   font-size: var(--font-size-label-medium);
-  color: var(--grey);
+  color: var(--color-text-secondary);
 }
 
 .ol-signup-form .input {
@@ -209,7 +209,7 @@
 
 .ol-signup-form .ol-signup-form__tos {
   font-size: var(--font-size-label-large);
-  color: var(--grey);
+  color: var(--color-text-secondary);
   display: block;
   margin-top: 5px;
   margin-bottom: 10px;
@@ -222,7 +222,7 @@
 }
 
 .ol-signup-form .ol-signup-form__login-hint a {
-  color: var(--link-blue);
+  color: var(--color-link);
 }
 
 .ol-signup-form .ol-signup-form__select {

--- a/static/css/page-user.css
+++ b/static/css/page-user.css
@@ -172,7 +172,7 @@ div.lists {
 }
 
 th.toggle-all {
-  background: var(--primary-blue);
+  background: var(--color-primary);
 }
 
 .div-class {

--- a/static/css/tokens/colors.css
+++ b/static/css/tokens/colors.css
@@ -97,9 +97,16 @@
 
   /* Text */
   --color-text: var(--neutral-800);
+  --color-text-heading: var(--neutral-700); /* headings sit a step lighter than body ink */
   --color-text-secondary: var(--neutral-600);
   --color-text-muted: var(--neutral-500); /* AA only on white / neutral-50 */
   --color-text-inverse: var(--white);
+
+  /* Icons. Decorative tier only — 2.5:1 on white, so it can't carry an icon
+     that conveys meaning on its own (WCAG 1.4.11 wants 3:1). Use it for inert
+     chrome: chevrons beside a visible label, inactive glyphs, placeholder
+     marks. A meaningful standalone icon takes --color-text-muted or darker. */
+  --color-icon-muted: var(--neutral-400);
 
   /* Surfaces */
   --color-background: var(--paper); /* page canvas — what body paints */
@@ -160,6 +167,7 @@
   --color-border-hover: var(--neutral-600);
   --color-border-focused: var(--blue-500);
   --color-border-error: var(--red-500);
+  --color-border-muted: var(--neutral-300); /* dividers — decorative, 1.6:1 on white */
   --color-border-subtle: var(--neutral-200);
   --color-focus-ring: var(--blue-500);
 
@@ -191,6 +199,7 @@
  * | You are styling… | Use |
  * |---|---|
  * | Body text | `--color-text` |
+ * | A heading | `--color-text-heading` |
  * | Supporting text (subtitles, descriptions) | `--color-text-secondary` |
  * | Muted metadata (bylines, counts, timestamps) | `--color-text-muted` — AA on white and `--neutral-50` only, not on the page canvas |
  * | Text on a dark or primary fill | `--color-text-inverse` / `--color-on-primary` |
@@ -200,7 +209,8 @@
  * | Header / footer chrome | `--color-surface-header` |
  * | A link | `--color-link`, with `-hover` and `-visited` |
  * | A primary button | `--color-primary` (+ `-hover`, `-active`) with `--color-on-primary` text |
- * | A default border | `--color-border`; hairline dividers → `--color-border-subtle` |
+ * | A default border | `--color-border`; dividers → `--color-border-muted`, hairlines → `--color-border-subtle` |
+ * | An inert icon (chevron beside a label, placeholder glyph) | `--color-icon-muted` — decorative only, see its note above |
  * | Hovering a flat row (popover/menu/list item) | `--color-hover-overlay` — an overlay, so it works on any surface |
  * | Hovering a raised control | `--color-control-hover` — opaque, safe to feed `--control-surface` |
  * | Success / error / warning notices | `--color-{success,error,warning}-{fg,bg,border}` |

--- a/static/css/tokens/colors.css
+++ b/static/css/tokens/colors.css
@@ -334,7 +334,6 @@
   --account-icon-border: var(--neutral-300);
   --light-yellow: var(--amber-100);
   --lighter-yellow: var(--amber-50);
-  --dark-beige: var(--neutral-300);
   --light-beige: var(--neutral-100);
   --cream: var(--neutral-100);
   --off-white: var(--neutral-50);

--- a/static/css/tokens/colors.css
+++ b/static/css/tokens/colors.css
@@ -274,7 +274,6 @@
   /* Admin & merge UI (out of redesign scope — kept verbatim) */
   --admin-row-background: hsl(58, 66%, 81%);
   --admin-table-border: hsl(48, 26%, 73%);
-  --nagios-green: hsl(108, 100%, 50%);
   --merged-purple: hsl(266, 100%, 75%);
   --heart-color: hsl(358, 100%, 74%);
 }
@@ -291,26 +290,18 @@
   /* Blues → blue ramp @deprecated */
   --primary-blue: var(--blue-500);
   --link-blue: var(--blue-600);
-  --lightest-blue: var(--blue-50);
   --mid-blue: var(--blue-400);
   --dark-blue: var(--blue-800);
-  --darker-brand-blue: var(--blue-500);
-  --header-nav-hover-color: var(--blue-600);
   --blue-b0bed9: var(--blue-200);
-  --count-blue-grey: var(--neutral-600);
   --grey-blue: var(--blue-100);
   --button-hover-blue: var(--blue-400);
   --dark-baby-blue: var(--blue-200);
   --mid-baby-blue: var(--blue-100);
-  --baby-blue: var(--blue-50);
   --blue-9fafd1: var(--blue-300);
-  --blue-3366ff: var(--blue-500);
-  --blue-5e88B9: var(--blue-400);
 
   /* Greens → green ramp @deprecated */
   --green: var(--green-500);
   --mid-baby-green: var(--green-100);
-  --baby-green: var(--green-50);
   --dark-green: var(--green-600);
   --soft-green: var(--green-200);
   --soft-green-two: var(--green-300);
@@ -324,7 +315,6 @@
   --orange-three: var(--amber-200);
   --orange-four: var(--amber-200);
   --orange-five: var(--amber-500);
-  --burnt-sienna: var(--amber-600);
 
   /* Reds → red ramp @deprecated */
   --red: var(--red-500);
@@ -334,12 +324,9 @@
 
   /* Pinks @deprecated */
   --mid-baby-pink: var(--red-100);
-  --baby-pink: var(--red-50);
 
   /* Yellows & beiges → neutral / amber ramps @deprecated */
   --dark-yellow: var(--amber-200);
-  --beige-deep: var(--neutral-200);
-  --beige-two: var(--neutral-200);
   --beige-three: var(--neutral-300);
   --beige: var(--neutral-200);
   --beige-pale: var(--neutral-100);
@@ -359,7 +346,6 @@
   --grey-464646: var(--neutral-700);
   --darker-grey: var(--neutral-700);
   --grey-555: var(--neutral-700);
-  --dark-grey-two: var(--neutral-600);
   --grey: var(--neutral-600);
   --accessible-grey: var(--neutral-500);
   --mid-grey: var(--neutral-400);
@@ -385,7 +371,6 @@
   /* Kept literals @deprecated — niche hues with no ramp home (admin, merge
      UI, charts) and alpha tokens (var() indirection can't carry the alpha). */
   --teal: hsl(184, 100%, 21%);
-  --purple: hsl(283, 97%, 61%);
   --magenta: hsl(300, 100%, 50%);
   --blue: hsl(240, 100%, 50%);
   --boxshadow-black: hsla(0, 0%, 0%, 0.15);

--- a/tests/unit/js/token-contrast.test.js
+++ b/tests/unit/js/token-contrast.test.js
@@ -65,6 +65,9 @@ const MATRIX = [
     ['--color-text', '--color-surface', 4.5],
     ['--color-text', '--color-background', 4.5],
     ['--color-text', '--color-surface-sunken', 4.5],
+    ['--color-text-heading', '--color-surface', 4.5],
+    ['--color-text-heading', '--color-background', 4.5],
+    ['--color-text-heading', '--color-surface-sunken', 4.5],
     ['--color-text-secondary', '--color-surface', 4.5],
     ['--color-text-secondary', '--color-background', 4.5],
     ['--color-text-secondary', '--color-surface-sunken', 4.5],
@@ -88,7 +91,11 @@ const MATRIX = [
     ['--color-error-fg', '--color-error-bg', 4.5],
     ['--color-warning-fg', '--color-surface', 4.5],
     ['--color-warning-fg', '--color-warning-bg', 4.5],
-    // Non-text UI (3:1): default input border, focus ring, disabled text
+    // Non-text UI (3:1): default input border, focus ring, disabled text.
+    // --color-border-muted and --color-icon-muted are absent on purpose: they
+    // are the decorative tier (1.6:1 and 2.5:1 on white) and carry that caveat
+    // in colors.css. Asserting 3:1 on them would be asserting a promise the
+    // system doesn't make.
     ['--color-border', '--color-surface', 3],
     ['--color-focus-ring', '--color-surface', 3],
     ['--color-focus-ring', '--color-background', 3],


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

Follow-up to #13102 — finishes the deprecated-alias migration. [refactor]

**Nothing renders differently.** Every swap resolves through the `var()` chain to the same primitive; this is purely about getting consumers onto the semantic layer, which is the dark-mode seam.

Three tiers of the neutral ramp had no semantic name, so ~125 call sites had nothing to migrate *to*. This adds the names and then uses them:

| Token | Ramp | Sites migrated |
|---|---|---|
| `--color-border-muted` | `--neutral-300` | 45 — `--light-grey` / `--dark-beige` borders |
| `--color-text-heading` | `--neutral-700` | 9 — `--brown` / `--grey-555` on headings |
| `--color-icon-muted` | `--neutral-400` | 0 — see below |

Plus the previously-staged migration of 341 sites across 86 files. **16 deprecated aliases are now deleted** (15 from that commit, plus `--dark-beige`), each verified unreferenced repo-wide.

### Technical
Swaps are scoped by property and by role, never applied globally. `--light-grey` migrates only where it styles a border — its 9 `color:` and 6 background sites stay put, because neutral-300 as text is 1.6:1 and deserves a real decision rather than a rename. `--brown` / `--grey-555` migrate only on sites that are genuinely headings.

`--color-text-heading` clears WCAG AA everywhere (8.3:1 on white, 6.2:1 on the page canvas) and is added to the contrast matrix. `--color-border-muted` and `--color-icon-muted` can't (1.6:1 and 2.5:1), so they're documented as an explicit **decorative tier** and deliberately left out of the matrix rather than asserting a 3:1 promise the system doesn't make.

Two findings I left as follow-ups rather than folding in:

- **Most neutral-700 text isn't headings.** Only 9 of 46 `color:` sites are; the rest is body/UI text (toasts, banners, breadcrumbs, form fields, menu items) sitting a step lighter than body ink for no stated reason. Naming that tier is a design call.
- **Nothing at neutral-400 is an icon.** All 29 sites are borders (17), text (6), backgrounds (4), shadows (2) — so `--color-icon-muted` currently has no consumers. The 17 borders want a `--color-border-strong` at neutral-400 that doesn't exist yet. Happy to drop the token from this PR if you'd rather not merge an unused name.

Also adds `--allow-empty-input` to the stylelint pre-commit hook — `.stylelintignore` covers `static/css/tokens/` wholesale, so a commit touching only that directory failed with `AllFilesIgnoredError`.

### Testing
Every changed line was verified byte-identical apart from the token name (checked programmatically across all 26 touched files), and each old→new pair resolves to the same computed color.

- `npm run test:js` — 552 pass; contrast matrix 26 → 29
- `npm run lint:css` / `eslint` on changed files — clean
- `pytest openlibrary/plugins/openlibrary/tests/test_design_tokens.py` — 51 pass; confirmed each new token lands in the right Foundations group

### Screenshot
No visual change by construction — see the equivalence check above.

### Stakeholders

