### PR TITLE
feat(account): Add direct profile picture upload and removal via FastAPI endpoints

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -1,6 +1,7 @@
 """ """
 
 import base64
+import contextlib
 import datetime
 import hashlib
 import hmac
@@ -120,6 +121,26 @@ def parse_s3_cookie(s3_cookie: str | None) -> dict | None:
         return {"access": access, "secret": secret}
     except InvalidToken:
         return None
+
+
+def get_s3_keys(account, s3_cookie: str | None = None) -> dict | None:
+    """Return S3 keys from the session cookie, falling back to the account store.
+
+    New logins set an encrypted ``s3`` cookie; this fallback handles sessions
+    that predate the cookie-based approach.
+    """
+    if s3_cookie and (keys := parse_s3_cookie(s3_cookie)):
+        return keys
+
+    with contextlib.suppress(AttributeError, KeyError):
+        if (token := web.cookies().get("s3")) and (keys := parse_s3_cookie(token)):
+            return keys
+
+    if account_key := getattr(account, "_key", None):
+        return web.ctx.site.store.get(account_key, {}).get("s3_keys")
+    if isinstance(account, dict):
+        return account.get("s3_keys")
+    return None
 
 
 def create_verification_cookie_value() -> str:

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -136,11 +136,13 @@ def get_s3_keys(account, s3_cookie: str | None = None) -> dict | None:
         if (token := web.cookies().get("s3")) and (keys := parse_s3_cookie(token)):
             return keys
 
-    if account_key := getattr(account, "_key", None):
-        return web.ctx.site.store.get(account_key, {}).get("s3_keys")
     if isinstance(account, dict):
         return account.get("s3_keys")
-    return None
+
+    account_key = getattr(account, "_key", None)
+    if not account_key:
+        return None
+    return site.get().store.get(account_key, {}).get("s3_keys")
 
 
 def create_verification_cookie_value() -> str:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1041,6 +1041,15 @@ class User(Thing):
             url += f"?v={avatar_updated}"
         return url
 
+    @classmethod
+    def invalidate_avatar_url_cache(cls, username: str) -> None:
+        """Drop the memoized get_avatar_url entry for this user.
+
+        The key must match the one computed by the memoize decorator's keyfunc
+        on get_avatar_url above; update both if that lambda changes.
+        """
+        cache.memcache_cache.delete(f"user-avatar-{username}")
+
     @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
     def _get_lists_cached(self):
         return self._get_lists_uncached(limit=100, offset=0)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1032,9 +1032,14 @@ class User(Thing):
     def get_avatar_url(cls, username: str) -> str:
         username = username.rsplit("/people/", maxsplit=1)[-1]
         user = site.get().get(f"/people/{username}")
-        itemname = user.get_account().get("internetarchive_itemname")
-
-        return f"https://archive.org/services/img/{itemname}"
+        account = user.get_account() if user else {}
+        itemname = account.get("internetarchive_itemname") or f"@{username}"
+        if not itemname.startswith("@"):
+            itemname = f"@{itemname}"
+        url = f"https://archive.org/services/img/{itemname}"
+        if avatar_updated := account.get("avatar_updated"):
+            url += f"?v={avatar_updated}"
+        return url
 
     @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
     def _get_lists_cached(self):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -4,19 +4,24 @@ FastAPI account endpoints for authentication.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import logging
 import os
+import time
 from typing import Annotated
 from urllib.parse import unquote, urlencode, urlparse
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
+import internetarchive as ia
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import JSONResponse
+from PIL import Image, ImageOps
 from pydantic import BaseModel, Field
 
 from infogami import config
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
-from openlibrary.accounts.model import audit_accounts, encrypt_s3_keys, generate_login_code_for_user
+from openlibrary.accounts.model import audit_accounts, encrypt_s3_keys, generate_login_code_for_user, get_s3_keys
 from openlibrary.core import stats
 from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.env import get_ol_env
@@ -28,6 +33,7 @@ from openlibrary.fastapi.auth import (
 )
 from openlibrary.fastapi.utils import set_flash_cookie
 from openlibrary.plugins.upstream import account as legacy_account
+from openlibrary.plugins.upstream import models
 from openlibrary.plugins.upstream.account import get_login_error
 from openlibrary.utils.request_context import site
 
@@ -575,3 +581,182 @@ async def anonymize_account(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
 
     return AnonymizeResponse(**result)
+
+
+class AvatarUploadResponse(BaseModel):
+    status: str = Field(description="Status of the upload operation")
+    avatar_url: str = Field(description="The updated avatar URL with cache-busting version query param")
+    message: str = Field(description="User-facing status message")
+
+
+@router.post(
+    "/account/avatar",
+    response_model=AvatarUploadResponse,
+    summary="Upload profile picture to Internet Archive",
+    description="Allows authenticated user to upload and sanitize a profile picture for their account.",
+    tags=["account"],
+)
+async def upload_avatar(  # noqa: PLR0915
+    request: Request,
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    file: Annotated[UploadFile | None, File()] = None,
+) -> AvatarUploadResponse:
+    if file is None:
+        try:
+            form = await request.form()
+            uploaded = form.get("file")
+            if isinstance(uploaded, UploadFile):
+                file = uploaded
+        except Exception:  # noqa: BLE001
+            pass
+
+    if not file or not file.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No file provided")
+
+    # Read and check file size (max 5 MB)
+    contents = await file.read()
+    if len(contents) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File size exceeds 5MB limit")
+
+    # Validate image format and sanitize using Pillow
+    try:
+        image = Image.open(io.BytesIO(contents))
+        image.verify()  # Validate image headers/structure
+        image = Image.open(io.BytesIO(contents))  # Re-open after verify
+
+        allowed_formats = {"JPEG", "PNG", "WEBP", "GIF"}
+        if image.format not in allowed_formats:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported image format: {image.format}. Allowed formats: JPEG, PNG, WEBP, GIF",
+            )
+
+        # Convert to RGB mode if in RGBA or palette mode for JPEG output
+        if image.mode in ("RGBA", "P"):
+            image = image.convert("RGB")
+
+        # Resize to max 500x500
+        image.thumbnail((500, 500))
+
+        out_buffer = io.BytesIO()
+        image.save(out_buffer, format="JPEG", quality=85)
+        out_buffer.seek(0)
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"Image processing failed for user {user.username}: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or corrupt image file")
+
+    # Retrieve account details and S3 keys
+    ol_account = OpenLibraryAccount.get_by_username(user.username)
+    if not ol_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User account not found")
+
+    itemname = ol_account.get("internetarchive_itemname")
+    if not itemname:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User account is missing Internet Archive item identifier",
+        )
+
+    # Decrypt S3 keys from request session cookie or account store
+    s3_keys = None
+    if s3_cookie := request.cookies.get("s3"):
+        try:
+            access, secret = decrypt_s3_keys(s3_cookie)
+            s3_keys = {"access": access, "secret": secret}
+        except InvalidToken:
+            pass
+
+    if not s3_keys and isinstance(ol_account, dict):
+        s3_keys = ol_account.get("s3_keys")
+    elif not s3_keys and hasattr(ol_account, "_key"):
+        s3_keys = site.get().store.get(ol_account._key, {}).get("s3_keys")
+
+    is_mock = s3_keys and s3_keys.get("access", "").startswith("mock_")
+    is_local_dev = os.getenv("LOCAL_DEV") is not None or is_mock
+    if is_local_dev and (not s3_keys or not s3_keys.get("access") or is_mock):
+        logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar S3 upload for user {user.username}")
+    else:
+        if not s3_keys or not s3_keys.get("access") or not s3_keys.get("secret"):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing Internet Archive S3 credentials. Please log out and log in again.",
+            )
+
+        # Perform S3 upload to Archive.org item
+        try:
+            item = ia.get_item(itemname)
+            headers = {
+                "x-archive-meta-image": "avatar.jpg",
+            }
+            item.upload(
+                {"avatar.jpg": out_buffer},
+                headers=headers,
+                access_key=s3_keys["access"],
+                secret_key=s3_keys["secret"],
+                queue_derive=True,
+                retries=1,
+                verify=False,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error(f"Internet Archive S3 upload failed for user {user.username}: {err}")
+            if not get_ol_env().LOCAL_DEV:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Failed to upload profile picture to Internet Archive: {err}",
+                )
+
+    # Save avatar_updated timestamp on account and invalidate Memcached
+    timestamp = int(time.time())
+
+    # Save timestamp in store
+    account_key = f"account/{user.username}"
+    account_data = site.get().store.get(account_key, {})
+    account_data["avatar_updated"] = timestamp
+    site.get().store[account_key] = account_data
+
+    # Invalidate Memcached user-avatar cache
+    with contextlib.suppress(Exception):
+        cache.memcache_cache.delete(f"user-avatar-{user.username}")
+
+    new_avatar_url = models.User.get_avatar_url(user.username)
+
+    return AvatarUploadResponse(
+        status="success",
+        avatar_url=new_avatar_url,
+        message="Profile picture uploaded successfully",
+    )
+
+
+@router.delete(
+    "/account/avatar",
+    response_model=AvatarUploadResponse,
+    summary="Remove user profile picture",
+    description="Removes custom profile picture timestamp and resets avatar URL.",
+    tags=["account"],
+)
+async def delete_avatar(
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+) -> AvatarUploadResponse:
+    account_key = f"account/{user.username}"
+    account_data = site.get().store.get(account_key, {})
+    if "avatar_updated" not in account_data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No custom profile picture exists to remove",
+        )
+    account_data.pop("avatar_updated", None)
+    site.get().store[account_key] = account_data
+
+    # Invalidate Memcached user-avatar cache
+    with contextlib.suppress(Exception):
+        cache.memcache_cache.delete(f"user-avatar-{user.username}")
+
+    new_avatar_url = models.User.get_avatar_url(user.username)
+
+    return AvatarUploadResponse(
+        status="success",
+        avatar_url=new_avatar_url,
+        message="Profile picture removed successfully",
+    )

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -4,25 +4,23 @@ FastAPI account endpoints for authentication.
 
 from __future__ import annotations
 
-import contextlib
 import io
 import logging
 import os
 import time
-from typing import Annotated
-from urllib.parse import unquote, urlencode, urlparse
+from typing import Annotated, Literal
+from urllib.parse import unquote, urlparse
 
 import internetarchive as ia
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
-from fastapi.responses import JSONResponse
 from PIL import Image, ImageOps
 from pydantic import BaseModel, Field
 
 from infogami import config
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
-from openlibrary.accounts.model import audit_accounts, encrypt_s3_keys, generate_login_code_for_user, get_s3_keys
-from openlibrary.core import cache, stats
+from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user, get_s3_keys, parse_s3_cookie
+from openlibrary.core import stats
 from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.env import get_ol_env
 from openlibrary.core.follows import PubSub
@@ -584,7 +582,7 @@ async def anonymize_account(
 
 
 class AvatarUploadResponse(BaseModel):
-    status: str = Field(description="Status of the upload operation")
+    status: Literal["success"] = Field(description="Status of the operation")
     avatar_url: str = Field(description="The updated avatar URL with cache-busting version query param")
     message: str = Field(description="User-facing status message")
 
@@ -595,7 +593,7 @@ def sanitize_image(contents: bytes, username: str) -> io.BytesIO:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File size exceeds 5MB limit")
 
     try:
-        image = Image.open(io.BytesIO(contents))
+        image: Image.Image = Image.open(io.BytesIO(contents))
         image.verify()  # Validate image headers/structure
         image = Image.open(io.BytesIO(contents))  # Re-open after verify
 
@@ -605,6 +603,11 @@ def sanitize_image(contents: bytes, username: str) -> io.BytesIO:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Unsupported image format: {image.format}. Allowed formats: JPEG, PNG, WEBP, GIF",
             )
+
+        # Bake EXIF orientation into the pixels, else re-encoding strips the
+        # orientation tag and phone photos come out rotated on the derive side.
+        # (Returns a copy, so this must come after the format check above.)
+        image = ImageOps.exif_transpose(image)
 
         # Convert to RGB mode if in RGBA or palette mode for JPEG output
         if image.mode in ("RGBA", "P"):
@@ -624,22 +627,30 @@ def sanitize_image(contents: bytes, username: str) -> io.BytesIO:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or corrupt image file")
 
 
-def invalidate_avatar_cache(username: str, avatar_updated: int | None = None) -> str:
-    """Update or clear avatar_updated timestamp on account store and invalidate Memcached."""
-    account_key = f"account/{username}"
-    account_data = site.get().store.get(account_key, {})
+def _avatar_account_data(username: str) -> dict:
+    """Read (and allow mutating) this user's account store entry."""
+    return site.get().store.get(f"account/{username}", {})
 
-    if avatar_updated is not None:
-        account_data["avatar_updated"] = avatar_updated
-    else:
+
+def _set_avatar_updated(username: str, avatar_updated: int | None) -> None:
+    """Set or clear the avatar_updated timestamp on the account store."""
+    account_data = _avatar_account_data(username)
+    if avatar_updated is None:
         account_data.pop("avatar_updated", None)
+    else:
+        account_data["avatar_updated"] = avatar_updated
+    site.get().store[f"account/{username}"] = account_data
 
-    site.get().store[account_key] = account_data
 
-    with contextlib.suppress(Exception):
-        cache.memcache_cache.delete(f"user-avatar-{username}")
+def _resolve_s3_keys(request: Request, ol_account: dict) -> dict | None:
+    """Return the user's Internet Archive S3 keys.
 
-    return models.User.get_avatar_url(username)
+    Prefers the encrypted ``s3`` cookie, falling back to the account store
+    (via get_s3_keys) for sessions that predate the cookie.
+    """
+    if (s3_cookie := request.cookies.get("s3")) and (keys := parse_s3_cookie(s3_cookie)):
+        return keys
+    return get_s3_keys(ol_account)
 
 
 @router.post(
@@ -654,15 +665,6 @@ async def upload_avatar(
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     file: Annotated[UploadFile | None, File()] = None,
 ) -> AvatarUploadResponse:
-    if file is None:
-        try:
-            form = await request.form()
-            uploaded = form.get("file")
-            if isinstance(uploaded, UploadFile):
-                file = uploaded
-        except Exception:  # noqa: BLE001
-            pass
-
     if not file or not file.filename:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No file provided")
 
@@ -681,32 +683,27 @@ async def upload_avatar(
             detail="User account is missing Internet Archive item identifier",
         )
 
-    # Resolve S3 keys from cookie or store helper
-    s3_keys = None
-    if s3_cookie := request.cookies.get("s3"):
-        try:
-            access, secret = decrypt_s3_keys(s3_cookie)
-            s3_keys = {"access": access, "secret": secret}
-        except InvalidToken:
-            pass
-
-    if not s3_keys:
-        s3_keys = get_s3_keys(ol_account)
-
-    is_mock = s3_keys and s3_keys.get("access", "").startswith("mock_")
-    is_local_dev = get_ol_env().LOCAL_DEV or is_mock
-    if is_local_dev and (not s3_keys or not s3_keys.get("access") or is_mock):
+    s3_keys = _resolve_s3_keys(request, ol_account) or {}
+    is_mock = s3_keys.get("access", "").startswith("mock_")
+    if get_ol_env().LOCAL_DEV or is_mock:
         logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar S3 upload for user {user.username}")
+    elif not (s3_keys.get("access") and s3_keys.get("secret")):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Internet Archive S3 credentials. Please log out and log in again.",
+        )
     else:
-        if not s3_keys or not s3_keys.get("access") or not s3_keys.get("secret"):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing Internet Archive S3 credentials. Please log out and log in again.",
-            )
-
-        # Perform S3 upload to Archive.org item
+        # Perform S3 upload to Archive.org item. Note the derived avatar image
+        # served by https://archive.org/services/img/{itemname} only regenerates
+        # once archive.org's derive queue processes the upload, so the new
+        # picture can lag the upload by a short while.
         try:
             item = ia.get_item(itemname)
+            # Meta header telling archive.org which file is the item image.
+            # Note the derived image served by
+            # https://archive.org/services/img/{itemname} only regenerates once
+            # archive.org's derive queue processes the upload, so the new
+            # picture can lag the upload by a short while.
             headers = {
                 "x-archive-meta-image": "avatar.jpg",
             }
@@ -717,6 +714,7 @@ async def upload_avatar(
                 secret_key=s3_keys["secret"],
                 queue_derive=True,
                 retries=1,
+                # Skip TLS verification locally, where IA creds are faked.
                 verify=not get_ol_env().LOCAL_DEV,
             )
         except Exception as err:  # noqa: BLE001
@@ -727,12 +725,15 @@ async def upload_avatar(
                     detail=f"Failed to upload profile picture to Internet Archive: {err}",
                 )
 
+    # Bump the timestamp before invalidating so any get_avatar_url call that
+    # repopulates the cache in between still sees the new URL.
     timestamp = int(time.time())
-    new_avatar_url = invalidate_avatar_cache(user.username, avatar_updated=timestamp)
+    _set_avatar_updated(user.username, timestamp)
+    models.User.invalidate_avatar_url_cache(user.username)
 
     return AvatarUploadResponse(
         status="success",
-        avatar_url=new_avatar_url,
+        avatar_url=models.User.get_avatar_url(user.username),
         message="Profile picture uploaded successfully",
     )
 
@@ -747,18 +748,17 @@ async def upload_avatar(
 async def delete_avatar(
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> AvatarUploadResponse:
-    account_key = f"account/{user.username}"
-    account_data = site.get().store.get(account_key, {})
-    if "avatar_updated" not in account_data:
+    if "avatar_updated" not in _avatar_account_data(user.username):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No custom profile picture exists to remove",
         )
 
-    new_avatar_url = invalidate_avatar_cache(user.username, avatar_updated=None)
+    _set_avatar_updated(user.username, None)
+    models.User.invalidate_avatar_url_cache(user.username)
 
     return AvatarUploadResponse(
         status="success",
-        avatar_url=new_avatar_url,
+        avatar_url=models.User.get_avatar_url(user.username),
         message="Profile picture removed successfully",
     )

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -33,6 +33,7 @@ from openlibrary.fastapi.utils import set_flash_cookie
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream import models
 from openlibrary.plugins.upstream.account import get_login_error
+from openlibrary.utils.avatar import delete_local_avatar, read_local_avatar, write_local_avatar
 from openlibrary.utils.request_context import site
 
 logger = logging.getLogger("openlibrary.fastapi.account")
@@ -585,7 +586,8 @@ class AvatarUploadResponse(BaseModel):
     status: Literal["success"] = Field(description="Status of the operation")
     avatar_url: str | None = Field(
         default=None,
-        description="The updated avatar URL with cache-busting version query param. None in dev-mock mode, where nothing was uploaded to Internet Archive.",
+        description="The updated avatar URL with cache-busting version query param. "
+        "In dev-mock mode this is the local /people/{username}/avatar route that serves the stored file.",
     )
     message: str = Field(description="User-facing status message")
 
@@ -711,13 +713,17 @@ async def upload_avatar(
                 detail=f"Failed to upload profile picture to Internet Archive: {err}",
             )
 
-    # Nothing was actually uploaded in mock mode (local dev, fake keys), so do
-    # not pretend otherwise: leave the account store and avatar URL untouched.
+    # Mock mode (local dev, fake test keys): archive.org is never written, so
+    # keep the sanitized bytes in a local file and point the avatar at the
+    # /people/{username}/avatar route, which serves them in LOCAL_DEV. The
+    # account store and get_avatar_url cache are left untouched.
     if is_mock:
+        logger.info(f"[LOCAL_DEV] Storing mock avatar locally for user {user.username}")
+        write_local_avatar(user.username, out_buffer.getvalue())
         return AvatarUploadResponse(
             status="success",
-            avatar_url=None,
-            message="Mock upload succeeded (dev only; nothing sent to Internet Archive)",
+            avatar_url=f"/people/{user.username}/avatar?v={int(time.time())}",
+            message="Mock upload succeeded (dev only; stored locally, not sent to Internet Archive)",
         )
 
     # Bump the timestamp before invalidating so any get_avatar_url call that
@@ -744,7 +750,8 @@ async def delete_avatar(
     request: Request,
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> AvatarUploadResponse:
-    if "avatar_updated" not in _avatar_account_data(user.username):
+    account_data = _avatar_account_data(user.username)
+    if "avatar_updated" not in account_data and read_local_avatar(user.username) is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No custom profile picture exists to remove",
@@ -765,6 +772,7 @@ async def delete_avatar(
     is_mock = get_ol_env().LOCAL_DEV or s3_keys.get("access", "").startswith("mock_")
     if is_mock:
         logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar removal for user {user.username}")
+        delete_local_avatar(user.username)
     elif not (s3_keys.get("access") and s3_keys.get("secret")):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from infogami import config
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
-from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user, get_s3_keys, parse_s3_cookie
+from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user, get_s3_keys
 from openlibrary.core import stats
 from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.env import get_ol_env
@@ -583,7 +583,10 @@ async def anonymize_account(
 
 class AvatarUploadResponse(BaseModel):
     status: Literal["success"] = Field(description="Status of the operation")
-    avatar_url: str = Field(description="The updated avatar URL with cache-busting version query param")
+    avatar_url: str | None = Field(
+        default=None,
+        description="The updated avatar URL with cache-busting version query param. None in dev-mock mode, where nothing was uploaded to Internet Archive.",
+    )
     message: str = Field(description="User-facing status message")
 
 
@@ -642,17 +645,6 @@ def _set_avatar_updated(username: str, avatar_updated: int | None) -> None:
     site.get().store[f"account/{username}"] = account_data
 
 
-def _resolve_s3_keys(request: Request, ol_account: dict) -> dict | None:
-    """Return the user's Internet Archive S3 keys.
-
-    Prefers the encrypted ``s3`` cookie, falling back to the account store
-    (via get_s3_keys) for sessions that predate the cookie.
-    """
-    if (s3_cookie := request.cookies.get("s3")) and (keys := parse_s3_cookie(s3_cookie)):
-        return keys
-    return get_s3_keys(ol_account)
-
-
 @router.post(
     "/account/avatar",
     response_model=AvatarUploadResponse,
@@ -683,9 +675,9 @@ async def upload_avatar(
             detail="User account is missing Internet Archive item identifier",
         )
 
-    s3_keys = _resolve_s3_keys(request, ol_account) or {}
-    is_mock = s3_keys.get("access", "").startswith("mock_")
-    if get_ol_env().LOCAL_DEV or is_mock:
+    s3_keys = get_s3_keys(ol_account, s3_cookie=request.cookies.get("s3")) or {}
+    is_mock = get_ol_env().LOCAL_DEV or s3_keys.get("access", "").startswith("mock_")
+    if is_mock:
         logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar S3 upload for user {user.username}")
     elif not (s3_keys.get("access") and s3_keys.get("secret")):
         raise HTTPException(
@@ -700,10 +692,6 @@ async def upload_avatar(
         try:
             item = ia.get_item(itemname)
             # Meta header telling archive.org which file is the item image.
-            # Note the derived image served by
-            # https://archive.org/services/img/{itemname} only regenerates once
-            # archive.org's derive queue processes the upload, so the new
-            # picture can lag the upload by a short while.
             headers = {
                 "x-archive-meta-image": "avatar.jpg",
             }
@@ -714,16 +702,23 @@ async def upload_avatar(
                 secret_key=s3_keys["secret"],
                 queue_derive=True,
                 retries=1,
-                # Skip TLS verification locally, where IA creds are faked.
-                verify=not get_ol_env().LOCAL_DEV,
+                verify=True,
             )
         except Exception as err:  # noqa: BLE001
             logger.error(f"Internet Archive S3 upload failed for user {user.username}: {err}")
-            if not get_ol_env().LOCAL_DEV:
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"Failed to upload profile picture to Internet Archive: {err}",
-                )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to upload profile picture to Internet Archive: {err}",
+            )
+
+    # Nothing was actually uploaded in mock mode (local dev, fake keys), so do
+    # not pretend otherwise: leave the account store and avatar URL untouched.
+    if is_mock:
+        return AvatarUploadResponse(
+            status="success",
+            avatar_url=None,
+            message="Mock upload succeeded (dev only; nothing sent to Internet Archive)",
+        )
 
     # Bump the timestamp before invalidating so any get_avatar_url call that
     # repopulates the cache in between still sees the new URL.
@@ -746,6 +741,7 @@ async def upload_avatar(
     tags=["account"],
 )
 async def delete_avatar(
+    request: Request,
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> AvatarUploadResponse:
     if "avatar_updated" not in _avatar_account_data(user.username):
@@ -753,6 +749,62 @@ async def delete_avatar(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No custom profile picture exists to remove",
         )
+
+    ol_account = OpenLibraryAccount.get_by_username(user.username)
+    if not ol_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User account not found")
+
+    itemname = ol_account.get("internetarchive_itemname")
+    if not itemname:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User account is missing Internet Archive item identifier",
+        )
+
+    s3_keys = get_s3_keys(ol_account, s3_cookie=request.cookies.get("s3")) or {}
+    is_mock = get_ol_env().LOCAL_DEV or s3_keys.get("access", "").startswith("mock_")
+    if is_mock:
+        logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar removal for user {user.username}")
+    elif not (s3_keys.get("access") and s3_keys.get("secret")):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Internet Archive S3 credentials. Please log out and log in again.",
+        )
+    else:
+        # Actually remove the avatar from the archive.org item: drop the item
+        # image metadata first (so services/img/{item} falls back to the
+        # default portrait even if the file delete below fails), then delete
+        # the uploaded file. Without this the derived image keeps serving the
+        # old photo after the OL-side timestamp is cleared.
+        try:
+            item = ia.get_item(itemname)
+            item.refresh()
+            if item.item_metadata.get("metadata", {}).get("image"):
+                item.modify_metadata(
+                    {"image": None},
+                    access_key=s3_keys["access"],
+                    secret_key=s3_keys["secret"],
+                )
+            avatar_file = item.get_file("avatar.jpg")
+            resp = avatar_file.delete(
+                access_key=s3_keys["access"],
+                secret_key=s3_keys["secret"],
+                retries=1,
+            )
+            # 404 just means the file was already gone; that's fine.
+            if resp.status_code not in (204, 404):
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Failed to remove avatar.jpg from Internet Archive (HTTP {resp.status_code})",
+                )
+        except HTTPException:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.error(f"Internet Archive avatar removal failed for user {user.username}: {err}")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to remove profile picture from Internet Archive: {err}",
+            )
 
     _set_avatar_updated(user.username, None)
     models.User.invalidate_avatar_url_cache(user.username)

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -9,17 +9,18 @@ import logging
 import os
 import time
 from typing import Annotated, Literal
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urlencode, urlparse
 
 import internetarchive as ia
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi.responses import JSONResponse
 from PIL import Image, ImageOps
 from pydantic import BaseModel, Field
 
 from infogami import config
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
-from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user, get_s3_keys
+from openlibrary.accounts.model import audit_accounts, encrypt_s3_keys, generate_login_code_for_user, get_s3_keys
 from openlibrary.core import stats
 from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.env import get_ol_env

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -22,7 +22,7 @@ from infogami import config
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
 from openlibrary.accounts.model import audit_accounts, encrypt_s3_keys, generate_login_code_for_user, get_s3_keys
-from openlibrary.core import stats
+from openlibrary.core import cache, stats
 from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.env import get_ol_env
 from openlibrary.core.follows import PubSub
@@ -589,36 +589,11 @@ class AvatarUploadResponse(BaseModel):
     message: str = Field(description="User-facing status message")
 
 
-@router.post(
-    "/account/avatar",
-    response_model=AvatarUploadResponse,
-    summary="Upload profile picture to Internet Archive",
-    description="Allows authenticated user to upload and sanitize a profile picture for their account.",
-    tags=["account"],
-)
-async def upload_avatar(  # noqa: PLR0915
-    request: Request,
-    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
-    file: Annotated[UploadFile | None, File()] = None,
-) -> AvatarUploadResponse:
-    if file is None:
-        try:
-            form = await request.form()
-            uploaded = form.get("file")
-            if isinstance(uploaded, UploadFile):
-                file = uploaded
-        except Exception:  # noqa: BLE001
-            pass
-
-    if not file or not file.filename:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No file provided")
-
-    # Read and check file size (max 5 MB)
-    contents = await file.read()
+def sanitize_image(contents: bytes, username: str) -> io.BytesIO:
+    """Validate, sanitize, resize (max 500x500), and re-encode avatar image bytes to JPEG."""
     if len(contents) > 5 * 1024 * 1024:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File size exceeds 5MB limit")
 
-    # Validate image format and sanitize using Pillow
     try:
         image = Image.open(io.BytesIO(contents))
         image.verify()  # Validate image headers/structure
@@ -641,11 +616,58 @@ async def upload_avatar(  # noqa: PLR0915
         out_buffer = io.BytesIO()
         image.save(out_buffer, format="JPEG", quality=85)
         out_buffer.seek(0)
+        return out_buffer
     except HTTPException:
         raise
     except Exception as e:  # noqa: BLE001
-        logger.error(f"Image processing failed for user {user.username}: {e}")
+        logger.error(f"Image processing failed for user {username}: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or corrupt image file")
+
+
+def invalidate_avatar_cache(username: str, avatar_updated: int | None = None) -> str:
+    """Update or clear avatar_updated timestamp on account store and invalidate Memcached."""
+    account_key = f"account/{username}"
+    account_data = site.get().store.get(account_key, {})
+
+    if avatar_updated is not None:
+        account_data["avatar_updated"] = avatar_updated
+    else:
+        account_data.pop("avatar_updated", None)
+
+    site.get().store[account_key] = account_data
+
+    with contextlib.suppress(Exception):
+        cache.memcache_cache.delete(f"user-avatar-{username}")
+
+    return models.User.get_avatar_url(username)
+
+
+@router.post(
+    "/account/avatar",
+    response_model=AvatarUploadResponse,
+    summary="Upload profile picture to Internet Archive",
+    description="Allows authenticated user to upload and sanitize a profile picture for their account.",
+    tags=["account"],
+)
+async def upload_avatar(
+    request: Request,
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    file: Annotated[UploadFile | None, File()] = None,
+) -> AvatarUploadResponse:
+    if file is None:
+        try:
+            form = await request.form()
+            uploaded = form.get("file")
+            if isinstance(uploaded, UploadFile):
+                file = uploaded
+        except Exception:  # noqa: BLE001
+            pass
+
+    if not file or not file.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No file provided")
+
+    contents = await file.read()
+    out_buffer = sanitize_image(contents, user.username)
 
     # Retrieve account details and S3 keys
     ol_account = OpenLibraryAccount.get_by_username(user.username)
@@ -659,7 +681,7 @@ async def upload_avatar(  # noqa: PLR0915
             detail="User account is missing Internet Archive item identifier",
         )
 
-    # Decrypt S3 keys from request session cookie or account store
+    # Resolve S3 keys from cookie or store helper
     s3_keys = None
     if s3_cookie := request.cookies.get("s3"):
         try:
@@ -668,13 +690,11 @@ async def upload_avatar(  # noqa: PLR0915
         except InvalidToken:
             pass
 
-    if not s3_keys and isinstance(ol_account, dict):
-        s3_keys = ol_account.get("s3_keys")
-    elif not s3_keys and hasattr(ol_account, "_key"):
-        s3_keys = site.get().store.get(ol_account._key, {}).get("s3_keys")
+    if not s3_keys:
+        s3_keys = get_s3_keys(ol_account)
 
     is_mock = s3_keys and s3_keys.get("access", "").startswith("mock_")
-    is_local_dev = os.getenv("LOCAL_DEV") is not None or is_mock
+    is_local_dev = get_ol_env().LOCAL_DEV or is_mock
     if is_local_dev and (not s3_keys or not s3_keys.get("access") or is_mock):
         logger.info(f"[LOCAL_DEV] Mocking Internet Archive avatar S3 upload for user {user.username}")
     else:
@@ -697,7 +717,7 @@ async def upload_avatar(  # noqa: PLR0915
                 secret_key=s3_keys["secret"],
                 queue_derive=True,
                 retries=1,
-                verify=False,
+                verify=not get_ol_env().LOCAL_DEV,
             )
         except Exception as err:  # noqa: BLE001
             logger.error(f"Internet Archive S3 upload failed for user {user.username}: {err}")
@@ -707,20 +727,8 @@ async def upload_avatar(  # noqa: PLR0915
                     detail=f"Failed to upload profile picture to Internet Archive: {err}",
                 )
 
-    # Save avatar_updated timestamp on account and invalidate Memcached
     timestamp = int(time.time())
-
-    # Save timestamp in store
-    account_key = f"account/{user.username}"
-    account_data = site.get().store.get(account_key, {})
-    account_data["avatar_updated"] = timestamp
-    site.get().store[account_key] = account_data
-
-    # Invalidate Memcached user-avatar cache
-    with contextlib.suppress(Exception):
-        cache.memcache_cache.delete(f"user-avatar-{user.username}")
-
-    new_avatar_url = models.User.get_avatar_url(user.username)
+    new_avatar_url = invalidate_avatar_cache(user.username, avatar_updated=timestamp)
 
     return AvatarUploadResponse(
         status="success",
@@ -746,14 +754,8 @@ async def delete_avatar(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No custom profile picture exists to remove",
         )
-    account_data.pop("avatar_updated", None)
-    site.get().store[account_key] = account_data
 
-    # Invalidate Memcached user-avatar cache
-    with contextlib.suppress(Exception):
-        cache.memcache_cache.delete(f"user-avatar-{user.username}")
-
-    new_avatar_url = models.User.get_avatar_url(user.username)
+    new_avatar_url = invalidate_avatar_cache(user.username, avatar_updated=None)
 
     return AvatarUploadResponse(
         status="success",

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4004,7 +4004,7 @@ msgstr ""
 msgid "Upload Image"
 msgstr ""
 
-#: covers/add.html
+#: covers/add.html type/user/avatar_i18n.html
 msgid "Uploading..."
 msgstr ""
 
@@ -6795,6 +6795,30 @@ msgstr ""
 
 #: type/type/view.html
 msgid "Backreferences"
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Please choose an image file first."
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Uploaded successfully!"
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Upload failed."
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Removing..."
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Photo removed successfully!"
+msgstr ""
+
+#: type/user/avatar_i18n.html
+msgid "Failed to remove photo."
 msgstr ""
 
 #: type/user/edit.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6807,6 +6807,18 @@ msgid "Currently Editing:"
 msgstr ""
 
 #: type/user/edit.html
+msgid "Profile Picture"
+msgstr ""
+
+#: type/user/edit.html
+msgid "Upload Photo"
+msgstr ""
+
+#: type/user/edit.html
+msgid "Remove Photo"
+msgstr ""
+
+#: type/user/edit.html
 msgid "Display Name"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/avatar.js
+++ b/openlibrary/plugins/openlibrary/js/avatar.js
@@ -1,0 +1,164 @@
+/**
+ * Avatar (Profile Picture) Upload & Removal module.
+ * Consumed by openlibrary/templates/type/user/edit.html.
+ */
+import '../../../../static/css/components/avatar--js.css';
+
+export const DEFAULT_AVATAR_STRINGS = {
+    chooseImagePrompt: 'Please choose an image file first.',
+    uploading: 'Uploading...',
+    uploadSuccess: 'Uploaded successfully!',
+    uploadFailed: 'Upload failed.',
+    removing: 'Removing...',
+    removeSuccess: 'Photo removed successfully!',
+    removeFailed: 'Failed to remove photo.',
+};
+
+/**
+ * Extracts and merges i18n string overrides from the element's data-i18n attribute.
+ *
+ * @param {HTMLElement} el
+ * @returns {typeof DEFAULT_AVATAR_STRINGS}
+ */
+export function avatarStringsFromElement(el) {
+    let overrides = null;
+    try {
+        const raw = el?.dataset?.i18n;
+        if (raw) {
+            overrides = JSON.parse(raw);
+        }
+    } catch {
+        /* fall back to defaults */
+    }
+    return overrides ? { ...DEFAULT_AVATAR_STRINGS, ...overrides } : DEFAULT_AVATAR_STRINGS;
+}
+
+/**
+ * Updates status text and styling class.
+ *
+ * @param {HTMLElement|null} statusSpan
+ * @param {string} text
+ * @param {'info' | 'success' | 'error'} state
+ */
+export function setStatus(statusSpan, text, state) {
+    if (!statusSpan) return;
+    statusSpan.textContent = text;
+    statusSpan.classList.remove(
+        'avatar-upload-status--info',
+        'avatar-upload-status--success',
+        'avatar-upload-status--error'
+    );
+    if (state) {
+        statusSpan.classList.add(`avatar-upload-status--${state}`);
+    }
+}
+
+/**
+ * Initializes avatar upload and removal handlers for a given container element.
+ *
+ * @param {HTMLElement} [container] - The container element (defaults to document).
+ */
+export function initAvatarUpload(container = document) {
+    const uploadBtn = container.querySelector('#avatar-upload-btn');
+    const removeBtn = container.querySelector('#avatar-remove-btn');
+    const fileInput = container.querySelector('#avatar-file-input');
+    const statusSpan = container.querySelector('#avatar-upload-status');
+    const img = container.querySelector('#avatar-preview-img');
+    const i18nTarget = container.closest?.('.formElement.avatar')
+        || container.querySelector?.('.formElement.avatar')
+        || container;
+    const strings = avatarStringsFromElement(i18nTarget);
+
+    if (fileInput && img) {
+        fileInput.addEventListener('change', () => {
+            if (fileInput.files && fileInput.files[0]) {
+                img.src = URL.createObjectURL(fileInput.files[0]);
+                setStatus(statusSpan, '', 'info');
+            }
+        });
+    }
+
+    if (uploadBtn && fileInput) {
+        uploadBtn.addEventListener('click', async() => {
+            if (!fileInput.files || !fileInput.files[0]) {
+                setStatus(statusSpan, strings.chooseImagePrompt, 'error');
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('file', fileInput.files[0]);
+
+            setStatus(statusSpan, strings.uploading, 'info');
+
+            try {
+                const res = await fetch('/account/avatar', {
+                    method: 'POST',
+                    body: formData,
+                });
+
+                if (!res.ok) {
+                    let msg = strings.uploadFailed;
+                    try {
+                        const data = await res.json();
+                        if (typeof data.detail === 'string') {
+                            msg = data.detail;
+                        } else if (Array.isArray(data.detail)) {
+                            msg = data.detail
+                                .map((e) => `${e.loc ? e.loc.join('.') : ''}: ${e.msg}`)
+                                .join('; ');
+                        }
+                    } catch {
+                        // ignore json parse error
+                    }
+                    throw new Error(msg);
+                }
+
+                const data = await res.json();
+                setStatus(statusSpan, strings.uploadSuccess, 'success');
+                if (fileInput.files && fileInput.files[0] && img) {
+                    img.src = URL.createObjectURL(fileInput.files[0]);
+                } else if (data.avatar_url && img) {
+                    img.src = data.avatar_url;
+                }
+            } catch (err) {
+                setStatus(statusSpan, err.message || strings.uploadFailed, 'error');
+            }
+        });
+    }
+
+    if (removeBtn) {
+        removeBtn.addEventListener('click', async() => {
+            setStatus(statusSpan, strings.removing, 'info');
+
+            try {
+                const res = await fetch('/account/avatar', {
+                    method: 'DELETE',
+                });
+
+                if (!res.ok) {
+                    let msg = strings.removeFailed;
+                    try {
+                        const data = await res.json();
+                        if (data && data.detail) {
+                            msg = data.detail;
+                        }
+                    } catch {
+                        // ignore json parse error
+                    }
+                    throw new Error(msg);
+                }
+
+                setStatus(statusSpan, strings.removeSuccess, 'success');
+                if (fileInput) {
+                    fileInput.value = '';
+                }
+                if (img) {
+                    const basePath = img.getAttribute('data-base-src') || img.src.split('?')[0];
+                    img.src = `${basePath}?t=${Date.now()}`;
+                }
+            } catch (err) {
+                setStatus(statusSpan, err.message || strings.removeFailed, 'error');
+            }
+        });
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/avatar.js
+++ b/openlibrary/plugins/openlibrary/js/avatar.js
@@ -64,15 +64,27 @@ export function initAvatarUpload(container = document) {
     const fileInput = container.querySelector('#avatar-file-input');
     const statusSpan = container.querySelector('#avatar-upload-status');
     const img = container.querySelector('#avatar-preview-img');
-    const i18nTarget = container.closest?.('.formElement.avatar')
-        || container.querySelector?.('.formElement.avatar')
-        || container;
-    const strings = avatarStringsFromElement(i18nTarget);
+    const strings = avatarStringsFromElement(container);
+
+    // Object URL for the current local file preview; revoked when replaced
+    // or cleared so each selected file doesn't leak until page unload.
+    let previewObjectUrl = null;
+    const clearPreviewObjectUrl = () => {
+        if (previewObjectUrl && URL.revokeObjectURL) {
+            URL.revokeObjectURL(previewObjectUrl);
+        }
+        previewObjectUrl = null;
+    };
+    const setPreviewBlob = (file) => {
+        clearPreviewObjectUrl();
+        previewObjectUrl = URL.createObjectURL(file);
+        img.src = previewObjectUrl;
+    };
 
     if (fileInput && img) {
         fileInput.addEventListener('change', () => {
             if (fileInput.files && fileInput.files[0]) {
-                img.src = URL.createObjectURL(fileInput.files[0]);
+                setPreviewBlob(fileInput.files[0]);
                 setStatus(statusSpan, '', 'info');
             }
         });
@@ -115,10 +127,15 @@ export function initAvatarUpload(container = document) {
 
                 const data = await res.json();
                 setStatus(statusSpan, strings.uploadSuccess, 'success');
-                if (fileInput.files && fileInput.files[0] && img) {
-                    img.src = URL.createObjectURL(fileInput.files[0]);
-                } else if (data.avatar_url && img) {
-                    img.src = data.avatar_url;
+                if (img) {
+                    if (data.avatar_url) {
+                        // Show what the server actually stored (sanitized,
+                        // resized, cache-busted), not the raw local file.
+                        clearPreviewObjectUrl();
+                        img.src = data.avatar_url;
+                    } else if (fileInput.files && fileInput.files[0]) {
+                        setPreviewBlob(fileInput.files[0]);
+                    }
                 }
             } catch (err) {
                 setStatus(statusSpan, err.message || strings.uploadFailed, 'error');
@@ -153,6 +170,7 @@ export function initAvatarUpload(container = document) {
                     fileInput.value = '';
                 }
                 if (img) {
+                    clearPreviewObjectUrl();
                     const basePath = img.getAttribute('data-base-src') || img.src.split('?')[0];
                     img.src = `${basePath}?t=${Date.now()}`;
                 }

--- a/openlibrary/plugins/openlibrary/js/main.js
+++ b/openlibrary/plugins/openlibrary/js/main.js
@@ -166,7 +166,7 @@ $(function() {
     // conditionally load for avatar / profile picture upload on user edit page
     const avatarContainer = document.querySelector('.formElement.avatar');
     if (avatarContainer) {
-        import(/* webpackChunkName: "avatar" */ './avatar')
+        import('./avatar')
             .then(module => module.initAvatarUpload(avatarContainer));
     }
 

--- a/openlibrary/plugins/openlibrary/js/main.js
+++ b/openlibrary/plugins/openlibrary/js/main.js
@@ -163,6 +163,13 @@ $(function() {
             .then(module => module.initTypeChanger(typeChanger));
     }
 
+    // conditionally load for avatar / profile picture upload on user edit page
+    const avatarContainer = document.querySelector('.formElement.avatar');
+    if (avatarContainer) {
+        import(/* webpackChunkName: "avatar" */ './avatar')
+            .then(module => module.initAvatarUpload(avatarContainer));
+    }
+
     // conditionally load validation and submission js for registration form
     if (document.querySelector('form[name=signup]')) {
         import('./signup.js')

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -20,6 +20,7 @@ from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.cache import memcache_memoize
+from openlibrary.core.env import get_ol_env
 from openlibrary.core.follows import PubSub
 from openlibrary.core.lending import add_availability, get_loan_history_data, get_loans_of_user
 from openlibrary.core.models import LoggedBooksData, User
@@ -30,6 +31,7 @@ from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
 from openlibrary.plugins.worksearch.schemes.works import get_fulltext_min
 from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.async_utils import async_bridge
+from openlibrary.utils.avatar import read_local_avatar
 from openlibrary.utils.dateutil import current_year
 from openlibrary.utils.request_context import caching_prethread, site
 
@@ -48,6 +50,12 @@ class avatar(delegate.page):
     path = "/people/([^/]+)/avatar"
 
     def GET(self, username: str):
+        # In local dev the upload endpoint stores avatars locally (see
+        # openlibrary/utils/avatar.py) since archive.org isn't writable, so
+        # serve that file directly; otherwise redirect to the derived image.
+        if get_ol_env().LOCAL_DEV and (avatar := read_local_avatar(username)) is not None:
+            web.header("Cache-Control", "no-cache")
+            return delegate.RawText(avatar, content_type="image/jpeg")
         url = User.get_avatar_url(username)
         raise web.seeother(url)
 

--- a/openlibrary/templates/type/user/avatar_i18n.html
+++ b/openlibrary/templates/type/user/avatar_i18n.html
@@ -1,0 +1,16 @@
+$def with ()
+$# Translated strings for profile picture / avatar upload UI (avatar.js):
+$# status messages and error alerts. Rendered into the avatar container's
+$# `data-i18n` attribute and read client-side by avatar.js
+$# (avatarStringsFromElement). The keys and English source strings here must
+$# match DEFAULT_AVATAR_STRINGS in that same file.
+$ avatar_i18n = {
+$     "chooseImagePrompt": _("Please choose an image file first."),
+$     "uploading":         _("Uploading..."),
+$     "uploadSuccess":     _("Uploaded successfully!"),
+$     "uploadFailed":      _("Upload failed."),
+$     "removing":          _("Removing..."),
+$     "removeSuccess":     _("Photo removed successfully!"),
+$     "removeFailed":      _("Failed to remove photo."),
+$ }
+$json_encode(avatar_i18n)

--- a/openlibrary/templates/type/user/edit.html
+++ b/openlibrary/templates/type/user/edit.html
@@ -16,29 +16,29 @@ $var title: $_('Editing %(name)s', name=page.displayname)
     <form method="POST" class="olform">
         <input type="hidden" name="type.key" id="type.key" value="/type/user"/>
 
-        <div class="formElement avatar">
+        <div class="formElement avatar" data-i18n="$:render_template('type/user/avatar_i18n')">
             <div class="label">
                 <label for="avatar-file-input">$_("Profile Picture")</label>
             </div>
-            <div class="input" style="display: flex; align-items: center; gap: 20px;">
-                <div style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; border: 2px solid #ddd; background-color: #f5f5f5; flex-shrink: 0; display: flex; align-items: center; justify-content: center;">
+            <div class="input avatar-container">
+                <div class="avatar-preview-container">
                     <img id="avatar-preview-img"
                          src="$(page.key)/avatar"
+                         data-base-src="$(page.key)/avatar"
                          alt=""
                          width="80"
                          height="80"
-                         style="width: 100%; height: 100%; object-fit: cover; display: block;"
                          onerror="this.onerror=null; this.src='https://archive.org/images/person2.png';" />
                 </div>
-                <div style="display: flex; flex-direction: column; gap: 8px;">
+                <div class="avatar-controls">
                     <div>
-                        <input type="file" id="avatar-file-input" accept="image/jpeg,image/png,image/webp,image/gif" style="font-size: 0.9em;" />
+                        <input type="file" id="avatar-file-input" accept="image/jpeg,image/png,image/webp,image/gif" />
                     </div>
-                    <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-                        <button type="button" id="avatar-upload-btn" style="display: inline-block; width: auto; padding: 5px 12px; font-size: 13px; font-weight: 600; color: #333; background: #f0f0f0; border: 1px solid #ccc; border-radius: 4px; cursor: pointer;">$_("Upload Photo")</button>
-                        <button type="button" id="avatar-remove-btn" style="display: inline-block; width: auto; padding: 5px 12px; font-size: 13px; font-weight: 600; color: #a00; background: #fff; border: 1px solid #ccc; border-radius: 4px; cursor: pointer;">$_("Remove Photo")</button>
+                    <div class="avatar-button-group">
+                        <button type="button" id="avatar-upload-btn" class="avatar-btn avatar-btn--upload">$_("Upload Photo")</button>
+                        <button type="button" id="avatar-remove-btn" class="avatar-btn avatar-btn--remove">$_("Remove Photo")</button>
                     </div>
-                    <span id="avatar-upload-status" style="font-size: 0.85em; font-weight: 500;"></span>
+                    <span id="avatar-upload-status" class="avatar-upload-status" role="status" aria-live="polite"></span>
                 </div>
             </div>
         </div>
@@ -71,101 +71,3 @@ $var title: $_('Editing %(name)s', name=page.displayname)
         $:macros.EditButtons(comment=page.comment_)
     </form>
 </div>
-
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        var btn = document.getElementById('avatar-upload-btn');
-        var fileInput = document.getElementById('avatar-file-input');
-        var statusSpan = document.getElementById('avatar-upload-status');
-        var img = document.getElementById('avatar-preview-img');
-
-        if (fileInput && img) {
-            fileInput.addEventListener('change', function() {
-                if (fileInput.files && fileInput.files[0]) {
-                    img.src = URL.createObjectURL(fileInput.files[0]);
-                }
-            });
-        }
-
-        if (btn && fileInput) {
-            btn.addEventListener('click', function() {
-                if (!fileInput.files || !fileInput.files[0]) {
-                    statusSpan.textContent = 'Please choose an image file first.';
-                    statusSpan.style.color = 'red';
-                    return;
-                }
-
-                var formData = new FormData();
-                formData.append('file', fileInput.files[0]);
-
-                statusSpan.textContent = 'Uploading...';
-                statusSpan.style.color = '#333';
-
-                fetch('/account/avatar', {
-                    method: 'POST',
-                    body: formData
-                })
-                .then(function(res) {
-                    if (!res.ok) {
-                        return res.json().then(function(data) {
-                            var msg = 'Upload failed';
-                            if (typeof data.detail === 'string') {
-                                msg = data.detail;
-                            } else if (Array.isArray(data.detail)) {
-                                msg = data.detail.map(function(e) { return (e.loc ? e.loc.join('.') : '') + ': ' + e.msg; }).join('; ');
-                            }
-                            throw new Error(msg);
-                        });
-                    }
-                    return res.json();
-                })
-                .then(function(data) {
-                    statusSpan.textContent = 'Uploaded successfully!';
-                    statusSpan.style.color = 'green';
-                    if (fileInput.files && fileInput.files[0] && img) {
-                        img.src = URL.createObjectURL(fileInput.files[0]);
-                    } else if (data.avatar_url && img) {
-                        img.src = data.avatar_url;
-                    }
-                })
-                .catch(function(err) {
-                    statusSpan.textContent = err.message || 'Failed to upload photo.';
-                    statusSpan.style.color = 'red';
-                });
-            });
-        }
-
-        var removeBtn = document.getElementById('avatar-remove-btn');
-        if (removeBtn) {
-            removeBtn.addEventListener('click', function() {
-                statusSpan.textContent = 'Removing...';
-                statusSpan.style.color = '#333';
-
-                fetch('/account/avatar', {
-                    method: 'DELETE'
-                })
-                .then(function(res) {
-                    if (!res.ok) {
-                        return res.json().then(function(data) {
-                            var msg = (data && data.detail) ? data.detail : 'Failed to remove photo.';
-                            throw new Error(msg);
-                        });
-                    }
-                    return res.json();
-                })
-                .then(function(data) {
-                    statusSpan.textContent = 'Photo removed successfully!';
-                    statusSpan.style.color = 'green';
-                    if (fileInput) fileInput.value = '';
-                    if (img) {
-                        img.src = '$(page.key)/avatar?t=' + Date.now();
-                    }
-                })
-                .catch(function(err) {
-                    statusSpan.textContent = err.message || 'Failed to remove photo.';
-                    statusSpan.style.color = 'red';
-                });
-            });
-        }
-    });
-</script>

--- a/openlibrary/templates/type/user/edit.html
+++ b/openlibrary/templates/type/user/edit.html
@@ -16,6 +16,33 @@ $var title: $_('Editing %(name)s', name=page.displayname)
     <form method="POST" class="olform">
         <input type="hidden" name="type.key" id="type.key" value="/type/user"/>
 
+        <div class="formElement avatar">
+            <div class="label">
+                <label for="avatar-file-input">$_("Profile Picture")</label>
+            </div>
+            <div class="input" style="display: flex; align-items: center; gap: 20px;">
+                <div style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; border: 2px solid #ddd; background-color: #f5f5f5; flex-shrink: 0; display: flex; align-items: center; justify-content: center;">
+                    <img id="avatar-preview-img"
+                         src="$(page.key)/avatar"
+                         alt=""
+                         width="80"
+                         height="80"
+                         style="width: 100%; height: 100%; object-fit: cover; display: block;"
+                         onerror="this.onerror=null; this.src='https://archive.org/images/person2.png';" />
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 8px;">
+                    <div>
+                        <input type="file" id="avatar-file-input" accept="image/jpeg,image/png,image/webp,image/gif" style="font-size: 0.9em;" />
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                        <button type="button" id="avatar-upload-btn" style="display: inline-block; width: auto; padding: 5px 12px; font-size: 13px; font-weight: 600; color: #333; background: #f0f0f0; border: 1px solid #ccc; border-radius: 4px; cursor: pointer;">$_("Upload Photo")</button>
+                        <button type="button" id="avatar-remove-btn" style="display: inline-block; width: auto; padding: 5px 12px; font-size: 13px; font-weight: 600; color: #a00; background: #fff; border: 1px solid #ccc; border-radius: 4px; cursor: pointer;">$_("Remove Photo")</button>
+                    </div>
+                    <span id="avatar-upload-status" style="font-size: 0.85em; font-weight: 500;"></span>
+                </div>
+            </div>
+        </div>
+
         <div class="formElement title">
             <div class="label">
                 <label for="title">$_("Display Name")</label>
@@ -44,3 +71,101 @@ $var title: $_('Editing %(name)s', name=page.displayname)
         $:macros.EditButtons(comment=page.comment_)
     </form>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var btn = document.getElementById('avatar-upload-btn');
+        var fileInput = document.getElementById('avatar-file-input');
+        var statusSpan = document.getElementById('avatar-upload-status');
+        var img = document.getElementById('avatar-preview-img');
+
+        if (fileInput && img) {
+            fileInput.addEventListener('change', function() {
+                if (fileInput.files && fileInput.files[0]) {
+                    img.src = URL.createObjectURL(fileInput.files[0]);
+                }
+            });
+        }
+
+        if (btn && fileInput) {
+            btn.addEventListener('click', function() {
+                if (!fileInput.files || !fileInput.files[0]) {
+                    statusSpan.textContent = 'Please choose an image file first.';
+                    statusSpan.style.color = 'red';
+                    return;
+                }
+
+                var formData = new FormData();
+                formData.append('file', fileInput.files[0]);
+
+                statusSpan.textContent = 'Uploading...';
+                statusSpan.style.color = '#333';
+
+                fetch('/account/avatar', {
+                    method: 'POST',
+                    body: formData
+                })
+                .then(function(res) {
+                    if (!res.ok) {
+                        return res.json().then(function(data) {
+                            var msg = 'Upload failed';
+                            if (typeof data.detail === 'string') {
+                                msg = data.detail;
+                            } else if (Array.isArray(data.detail)) {
+                                msg = data.detail.map(function(e) { return (e.loc ? e.loc.join('.') : '') + ': ' + e.msg; }).join('; ');
+                            }
+                            throw new Error(msg);
+                        });
+                    }
+                    return res.json();
+                })
+                .then(function(data) {
+                    statusSpan.textContent = 'Uploaded successfully!';
+                    statusSpan.style.color = 'green';
+                    if (fileInput.files && fileInput.files[0] && img) {
+                        img.src = URL.createObjectURL(fileInput.files[0]);
+                    } else if (data.avatar_url && img) {
+                        img.src = data.avatar_url;
+                    }
+                })
+                .catch(function(err) {
+                    statusSpan.textContent = err.message || 'Failed to upload photo.';
+                    statusSpan.style.color = 'red';
+                });
+            });
+        }
+
+        var removeBtn = document.getElementById('avatar-remove-btn');
+        if (removeBtn) {
+            removeBtn.addEventListener('click', function() {
+                statusSpan.textContent = 'Removing...';
+                statusSpan.style.color = '#333';
+
+                fetch('/account/avatar', {
+                    method: 'DELETE'
+                })
+                .then(function(res) {
+                    if (!res.ok) {
+                        return res.json().then(function(data) {
+                            var msg = (data && data.detail) ? data.detail : 'Failed to remove photo.';
+                            throw new Error(msg);
+                        });
+                    }
+                    return res.json();
+                })
+                .then(function(data) {
+                    statusSpan.textContent = 'Photo removed successfully!';
+                    statusSpan.style.color = 'green';
+                    if (fileInput) fileInput.value = '';
+                    if (img) {
+                        img.src = '$(page.key)/avatar?t=' + Date.now();
+                    }
+                })
+                .catch(function(err) {
+                    statusSpan.textContent = err.message || 'Failed to remove photo.';
+                    statusSpan.style.color = 'red';
+                });
+            });
+        }
+    });
+</script>

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -3,6 +3,7 @@ from unittest import mock
 from requests.models import Response
 
 from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, model
+from openlibrary.utils.request_context import site
 
 
 def get_username(account):
@@ -30,6 +31,24 @@ def test_parse_s3_cookie_returns_none_when_absent():
 @mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
 def test_parse_s3_cookie_returns_none_for_tampered_token(mock_secret_key):
     assert model.parse_s3_cookie("not-a-real-token") is None
+
+
+def test_get_s3_keys_reads_store_via_site_contextvar(monkeypatch):
+    """The store fallback must work without web.ctx (the FastAPI request path)."""
+    account = mock.MagicMock()
+    account._key = "account/testuser"
+    mock_site = mock.MagicMock()
+    mock_site.store.get.return_value = {"s3_keys": {"access": "AKIA", "secret": "sec"}}
+    site.set(mock_site)
+
+    assert model.get_s3_keys(account) == {"access": "AKIA", "secret": "sec"}
+    mock_site.store.get.assert_called_once_with("account/testuser", {})
+
+
+@mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
+def test_get_s3_keys_prefers_the_s3_cookie(mock_secret_key):
+    keys = {"access": "AKIA-cookie", "secret": "cookie-secret"}
+    assert model.get_s3_keys({}, s3_cookie=model.encrypt_s3_keys(keys["access"], keys["secret"])) == keys
 
 
 def test_xauth_http_error_without_json(monkeypatch):

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import io
 from unittest.mock import MagicMock, patch
 from urllib.parse import unquote
 
+from PIL import Image
+
 from infogami import config
 from openlibrary.core.auth import ExpiredTokenError, MissingKeyError
+from openlibrary.fastapi.account import sanitize_image
 from openlibrary.utils.request_context import RequestContextVars, req_context, site
 
 _DEFAULT_HEADER = "LOW ak:sk"
@@ -612,3 +616,123 @@ class TestAnonymizeAccount:
 
         assert resp.status_code == 500
         assert resp.json()["detail"] == "Internal Server Error"
+
+
+class TestAvatarUpload:
+    def test_upload_avatar_unauthenticated(self, fastapi_client):
+        response = fastapi_client.post("/account/avatar")
+        assert response.status_code == 401
+
+    def test_upload_avatar_success(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        # Create a small valid test JPEG image using Pillow
+        img = Image.new("RGB", (100, 100), color="blue")
+        img_byte_arr = io.BytesIO()
+        img.save(img_byte_arr, format="JPEG")
+        img_bytes = img_byte_arr.getvalue()
+
+        # Mock OpenLibraryAccount.get_by_username
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+            "s3_keys": {"access": "mock_access", "secret": "mock_secret"},
+        }
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+
+        # Mock site store and models.User.get_avatar_url
+        mock_site = MagicMock()
+        mock_site.store = {"account/testuser": mock_account}
+        site.set(mock_site)
+
+        mock_get_avatar = MagicMock(return_value="https://archive.org/services/img/@testuser-archive?v=1234567")
+        mock_get_avatar.invalidate = MagicMock()
+        monkeypatch.setattr("openlibrary.plugins.upstream.models.User.get_avatar_url", mock_get_avatar)
+
+        response = fastapi_client.post(
+            "/account/avatar",
+            files={"file": ("test_avatar.jpg", img_bytes, "image/jpeg")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "https://archive.org/services/img/@testuser-archive" in data["avatar_url"]
+
+    def test_upload_avatar_invalid_file_type(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+        }
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+
+        response = fastapi_client.post(
+            "/account/avatar",
+            files={"file": ("test.txt", b"not an image file content", "text/plain")},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid or corrupt image file" in response.json()["detail"]
+
+    def test_upload_avatar_file_too_large(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+        }
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+
+        large_bytes = b"x" * (6 * 1024 * 1024)  # 6 MB
+
+        response = fastapi_client.post(
+            "/account/avatar",
+            files={"file": ("large.jpg", large_bytes, "image/jpeg")},
+        )
+
+        assert response.status_code == 400
+        assert "File size exceeds 5MB limit" in response.json()["detail"]
+
+    def test_delete_avatar_unauthenticated(self, fastapi_client):
+        response = fastapi_client.delete("/account/avatar")
+        assert response.status_code == 401
+
+    def test_delete_avatar_success(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+            "avatar_updated": 1234567,
+        }
+        mock_site = MagicMock()
+        mock_site.store = {"account/testuser": mock_account}
+        site.set(mock_site)
+
+        mock_get_avatar = MagicMock(return_value="https://archive.org/services/img/@testuser-archive")
+        monkeypatch.setattr("openlibrary.plugins.upstream.models.User.get_avatar_url", mock_get_avatar)
+
+        response = fastapi_client.delete("/account/avatar")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["message"] == "Profile picture removed successfully"
+        assert "avatar_updated" not in mock_account
+
+    def test_delete_avatar_no_avatar_exists(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+        }
+        mock_site = MagicMock()
+        mock_site.store = {"account/testuser": mock_account}
+        site.set(mock_site)
+
+        response = fastapi_client.delete("/account/avatar")
+
+        assert response.status_code == 400
+        assert "No custom profile picture exists to remove" in response.json()["detail"]

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -641,24 +641,62 @@ class TestAvatarUpload:
             lambda username: mock_account,
         )
 
-        # Mock site store and models.User.get_avatar_url
+        # Mock site store; get_avatar_url will find no user doc and fall back
+        # to the "@{username}" itemname convention.
         mock_site = MagicMock()
         mock_site.store = {"account/testuser": mock_account}
+        mock_site.get.return_value = None
         site.set(mock_site)
 
-        mock_get_avatar = MagicMock(return_value="https://archive.org/services/img/@testuser-archive?v=1234567")
-        mock_get_avatar.invalidate = MagicMock()
-        monkeypatch.setattr("openlibrary.plugins.upstream.models.User.get_avatar_url", mock_get_avatar)
+        # get_avatar_url is memoized with a computed memcache key; patch the
+        # underlying client so the invalidation delete can be observed.
+        mock_memcache = MagicMock()
+        mock_memcache.get.return_value = None
+        monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
 
         response = fastapi_client.post(
             "/account/avatar",
             files={"file": ("test_avatar.jpg", img_bytes, "image/jpeg")},
         )
 
-        assert response.status_code == 200
+        print("DEBUG BODY:", response.text)
         data = response.json()
         assert data["status"] == "success"
-        assert "https://archive.org/services/img/@testuser-archive" in data["avatar_url"]
+        assert data["avatar_url"] == "https://archive.org/services/img/@testuser"
+        assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
+        assert mock_account["avatar_updated"]
+
+    def test_upload_avatar_exif_orientation_is_baked_in(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        """A photo flagged as rotated by EXIF is re-encoded upright."""
+        mock_account = {
+            "internetarchive_itemname": "@testuser-archive",
+            "username": "testuser",
+            "s3_keys": {"access": "mock_access", "secret": "mock_secret"},
+        }
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+
+        mock_site = MagicMock()
+        mock_site.store = {"account/testuser": mock_account}
+        mock_site.get.return_value = None
+        site.set(mock_site)
+
+        mock_memcache = MagicMock()
+        mock_memcache.get.return_value = None
+        monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
+
+        # A wide image with EXIF orientation 6 (rotate 90 CW) should decode as
+        # tall after sanitize_image bakes the orientation into the pixels.
+        img = Image.new("RGB", (200, 100), color="red")
+        buf = io.BytesIO()
+        exif = Image.Exif()
+        exif[0x0112] = 6  # Orientation: rotate 90 CW
+        img.save(buf, format="JPEG", exif=exif)
+
+        out = Image.open(sanitize_image(buf.getvalue(), "testuser"))
+        assert out.size == (100, 200)
 
     def test_upload_avatar_invalid_file_type(self, fastapi_client, mock_authenticated_user, monkeypatch):
         mock_account = {
@@ -710,10 +748,12 @@ class TestAvatarUpload:
         }
         mock_site = MagicMock()
         mock_site.store = {"account/testuser": mock_account}
+        mock_site.get.return_value = None
         site.set(mock_site)
 
-        mock_get_avatar = MagicMock(return_value="https://archive.org/services/img/@testuser-archive")
-        monkeypatch.setattr("openlibrary.plugins.upstream.models.User.get_avatar_url", mock_get_avatar)
+        mock_memcache = MagicMock()
+        mock_memcache.get.return_value = None
+        monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
 
         response = fastapi_client.delete("/account/avatar")
 
@@ -722,6 +762,7 @@ class TestAvatarUpload:
         assert data["status"] == "success"
         assert data["message"] == "Profile picture removed successfully"
         assert "avatar_updated" not in mock_account
+        assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
 
     def test_delete_avatar_no_avatar_exists(self, fastapi_client, mock_authenticated_user, monkeypatch):
         mock_account = {

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -665,8 +665,8 @@ class TestAvatarUpload:
         response = fastapi_client.post("/account/avatar")
         assert response.status_code == 401
 
-    def test_upload_avatar_mock_skips_ia_and_writes_no_state(self, fastapi_client, mock_authenticated_user, monkeypatch):
-        """Mock uploads (local dev / fake keys) must not fake state or hit IA."""
+    def test_upload_avatar_mock_stores_locally_and_skips_ia(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        """Mock uploads (local dev / fake keys) store a local file and never hit IA."""
         mock_account = self._make_account(s3_keys={"access": "mock_access", "secret": "mock_secret"})
         monkeypatch.setattr(
             "openlibrary.accounts.OpenLibraryAccount.get_by_username",
@@ -674,6 +674,8 @@ class TestAvatarUpload:
         )
         self._set_up_site_and_memcache(monkeypatch, mock_account)
 
+        mock_write = MagicMock()
+        monkeypatch.setattr("openlibrary.fastapi.account.write_local_avatar", mock_write)
         mock_get_item = MagicMock()
         monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", mock_get_item)
 
@@ -685,7 +687,9 @@ class TestAvatarUpload:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
-        assert data["avatar_url"] is None
+        assert data["avatar_url"].startswith("/people/testuser/avatar?v=")
+        assert mock_write.call_args.args[0] == "testuser"
+        assert len(mock_write.call_args.args[1]) > 0  # sanitized JPEG bytes
         assert "avatar_updated" not in mock_account
         mock_get_item.assert_not_called()
 
@@ -782,6 +786,8 @@ class TestAvatarUpload:
         )
         _, mock_memcache = self._set_up_site_and_memcache(monkeypatch, mock_account)
 
+        mock_delete = MagicMock()
+        monkeypatch.setattr("openlibrary.fastapi.account.delete_local_avatar", mock_delete)
         mock_get_item = MagicMock()
         monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", mock_get_item)
 
@@ -792,6 +798,7 @@ class TestAvatarUpload:
         assert data["status"] == "success"
         assert data["message"] == "Profile picture removed successfully"
         assert "avatar_updated" not in mock_account
+        mock_delete.assert_called_once_with("testuser")
         mock_get_item.assert_not_called()
         assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
 
@@ -827,6 +834,7 @@ class TestAvatarUpload:
             "internetarchive_itemname": "@testuser-archive",
             "username": "testuser",
         }
+        monkeypatch.setattr("openlibrary.fastapi.account.read_local_avatar", lambda username: None)
         mock_site = MagicMock()
         mock_site.store = {"account/testuser": mock_account}
         site.set(mock_site)

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -17,6 +17,13 @@ _DEFAULT_HEADER = "LOW ak:sk"
 _SENTINEL = object()
 
 
+def _make_jpeg_bytes(color: str = "blue", size: tuple[int, int] = (100, 100)) -> bytes:
+    """Render a small valid JPEG to bytes with Pillow."""
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
 def _anonymize_post(
     client,
     *,
@@ -619,33 +626,32 @@ class TestAnonymizeAccount:
 
 
 class TestAvatarUpload:
-    def test_upload_avatar_unauthenticated(self, fastapi_client):
-        response = fastapi_client.post("/account/avatar")
-        assert response.status_code == 401
-
-    def test_upload_avatar_success(self, fastapi_client, mock_authenticated_user, monkeypatch):
-        # Create a small valid test JPEG image using Pillow
-        img = Image.new("RGB", (100, 100), color="blue")
-        img_byte_arr = io.BytesIO()
-        img.save(img_byte_arr, format="JPEG")
-        img_bytes = img_byte_arr.getvalue()
-
-        # Mock OpenLibraryAccount.get_by_username
-        mock_account = {
+    def _make_account(self, *, avatar_updated=None, s3_keys=None):
+        account = {
             "internetarchive_itemname": "@testuser-archive",
             "username": "testuser",
-            "s3_keys": {"access": "mock_access", "secret": "mock_secret"},
         }
-        monkeypatch.setattr(
-            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
-            lambda username: mock_account,
-        )
+        if avatar_updated is not None:
+            account["avatar_updated"] = avatar_updated
+        if s3_keys is not None:
+            account["s3_keys"] = s3_keys
+        return account
 
-        # Mock site store; get_avatar_url will find no user doc and fall back
-        # to the "@{username}" itemname convention.
+    def _set_up_site_and_memcache(self, monkeypatch, mock_account, *, with_account_doc=None):
+        """Point the site ContextVar at a mock store and stub memcache.
+
+        with_account_doc: when given, site.get("/people/...") returns a mock
+        user whose get_account() returns this dict, so get_avatar_url can
+        observe avatar_updated.
+        """
         mock_site = MagicMock()
         mock_site.store = {"account/testuser": mock_account}
-        mock_site.get.return_value = None
+        if with_account_doc is None:
+            mock_site.get.return_value = None
+        else:
+            mock_user = MagicMock()
+            mock_user.get_account.return_value = with_account_doc
+            mock_site.get.return_value = mock_user
         site.set(mock_site)
 
         # get_avatar_url is memoized with a computed memcache key; patch the
@@ -653,40 +659,64 @@ class TestAvatarUpload:
         mock_memcache = MagicMock()
         mock_memcache.get.return_value = None
         monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
+        return mock_site, mock_memcache
 
-        response = fastapi_client.post(
-            "/account/avatar",
-            files={"file": ("test_avatar.jpg", img_bytes, "image/jpeg")},
-        )
+    def test_upload_avatar_unauthenticated(self, fastapi_client):
+        response = fastapi_client.post("/account/avatar")
+        assert response.status_code == 401
 
-        print("DEBUG BODY:", response.text)
-        data = response.json()
-        assert data["status"] == "success"
-        assert data["avatar_url"] == "https://archive.org/services/img/@testuser"
-        assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
-        assert mock_account["avatar_updated"]
-
-    def test_upload_avatar_exif_orientation_is_baked_in(self, fastapi_client, mock_authenticated_user, monkeypatch):
-        """A photo flagged as rotated by EXIF is re-encoded upright."""
-        mock_account = {
-            "internetarchive_itemname": "@testuser-archive",
-            "username": "testuser",
-            "s3_keys": {"access": "mock_access", "secret": "mock_secret"},
-        }
+    def test_upload_avatar_mock_skips_ia_and_writes_no_state(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        """Mock uploads (local dev / fake keys) must not fake state or hit IA."""
+        mock_account = self._make_account(s3_keys={"access": "mock_access", "secret": "mock_secret"})
         monkeypatch.setattr(
             "openlibrary.accounts.OpenLibraryAccount.get_by_username",
             lambda username: mock_account,
         )
+        self._set_up_site_and_memcache(monkeypatch, mock_account)
 
-        mock_site = MagicMock()
-        mock_site.store = {"account/testuser": mock_account}
-        mock_site.get.return_value = None
-        site.set(mock_site)
+        mock_get_item = MagicMock()
+        monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", mock_get_item)
 
-        mock_memcache = MagicMock()
-        mock_memcache.get.return_value = None
-        monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
+        response = fastapi_client.post(
+            "/account/avatar",
+            files={"file": ("test_avatar.jpg", _make_jpeg_bytes(), "image/jpeg")},
+        )
 
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["avatar_url"] is None
+        assert "avatar_updated" not in mock_account
+        mock_get_item.assert_not_called()
+
+    def test_upload_avatar_real_path_uploads_to_ia_and_bumps_timestamp(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        """A real upload writes the file to IA and bumps the avatar timestamp."""
+        mock_account = self._make_account(s3_keys={"access": "AKIA-test", "secret": "test-secret"})
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+        _, mock_memcache = self._set_up_site_and_memcache(monkeypatch, mock_account, with_account_doc=mock_account)
+
+        mock_item = MagicMock()
+        monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", lambda itemname: mock_item)
+
+        response = fastapi_client.post(
+            "/account/avatar",
+            files={"file": ("test_avatar.jpg", _make_jpeg_bytes(), "image/jpeg")},
+        )
+
+        assert response.status_code == 200
+        mock_item.upload.assert_called_once()
+        assert "avatar.jpg" in mock_item.upload.call_args.args[0]
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["avatar_url"] == f"https://archive.org/services/img/@testuser-archive?v={mock_account['avatar_updated']}"
+        assert mock_account["avatar_updated"]
+        assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
+
+    def test_upload_avatar_exif_orientation_is_baked_in(self):
+        """A photo flagged as rotated by EXIF is re-encoded upright."""
         # A wide image with EXIF orientation 6 (rotate 90 CW) should decode as
         # tall after sanitize_image bakes the orientation into the pixels.
         img = Image.new("RGB", (200, 100), color="red")
@@ -741,19 +771,19 @@ class TestAvatarUpload:
         assert response.status_code == 401
 
     def test_delete_avatar_success(self, fastapi_client, mock_authenticated_user, monkeypatch):
-        mock_account = {
-            "internetarchive_itemname": "@testuser-archive",
-            "username": "testuser",
-            "avatar_updated": 1234567,
-        }
-        mock_site = MagicMock()
-        mock_site.store = {"account/testuser": mock_account}
-        mock_site.get.return_value = None
-        site.set(mock_site)
+        """Mock removal (fake keys) clears OL state without touching IA."""
+        mock_account = self._make_account(
+            avatar_updated=1234567,
+            s3_keys={"access": "mock_access", "secret": "mock_secret"},
+        )
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+        _, mock_memcache = self._set_up_site_and_memcache(monkeypatch, mock_account)
 
-        mock_memcache = MagicMock()
-        mock_memcache.get.return_value = None
-        monkeypatch.setattr("openlibrary.core.cache.memcache_cache.memcache", mock_memcache)
+        mock_get_item = MagicMock()
+        monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", mock_get_item)
 
         response = fastapi_client.delete("/account/avatar")
 
@@ -762,7 +792,35 @@ class TestAvatarUpload:
         assert data["status"] == "success"
         assert data["message"] == "Profile picture removed successfully"
         assert "avatar_updated" not in mock_account
+        mock_get_item.assert_not_called()
         assert any(call.args and call.args[0] == "user-avatar-testuser" for call in mock_memcache.delete.call_args_list)
+
+    def test_delete_avatar_real_path_removes_file_and_metadata(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        """A real removal deletes the IA file and clears the item image metadata."""
+        mock_account = self._make_account(
+            avatar_updated=1234567,
+            s3_keys={"access": "AKIA-test", "secret": "test-secret"},
+        )
+        monkeypatch.setattr(
+            "openlibrary.accounts.OpenLibraryAccount.get_by_username",
+            lambda username: mock_account,
+        )
+        self._set_up_site_and_memcache(monkeypatch, mock_account)
+
+        mock_file = MagicMock()
+        mock_file.delete.return_value = MagicMock(status_code=204)
+        mock_item = MagicMock()
+        mock_item.item_metadata = {"metadata": {"image": "avatar.jpg"}}
+        mock_item.get_file.return_value = mock_file
+        monkeypatch.setattr("openlibrary.fastapi.account.ia.get_item", lambda itemname: mock_item)
+
+        response = fastapi_client.delete("/account/avatar")
+
+        assert response.status_code == 200
+        mock_item.modify_metadata.assert_called_once()
+        assert mock_item.modify_metadata.call_args.args[0] == {"image": None}
+        mock_file.delete.assert_called_once()
+        assert "avatar_updated" not in mock_account
 
     def test_delete_avatar_no_avatar_exists(self, fastapi_client, mock_authenticated_user, monkeypatch):
         mock_account = {

--- a/openlibrary/utils/avatar.py
+++ b/openlibrary/utils/avatar.py
@@ -1,0 +1,40 @@
+"""Local-dev avatar file helpers.
+
+In LOCAL_DEV the avatar upload endpoint cannot write to archive.org (there
+are no real S3 credentials), so instead of pretending the upload landed on
+the Internet Archive the sanitized bytes are stored under ``var/avatars/``
+(gitignored) and the ``/people/{username}/avatar`` route serves them directly
+instead of redirecting to archive.org. This keeps the whole avatar flow —
+upload, preview, refresh, remove — working in local development.
+
+These helpers are only ever called when ``get_ol_env().LOCAL_DEV`` (or fake
+``mock_`` test keys) is in play; production never touches these files.
+"""
+
+import contextlib
+from pathlib import Path
+
+_AVATAR_DIR = Path("var/avatars")
+
+
+def local_avatar_path(username: str) -> Path:
+    return _AVATAR_DIR / f"{username}.jpg"
+
+
+def read_local_avatar(username: str) -> bytes | None:
+    """Return the locally stored avatar bytes, or None when absent."""
+    try:
+        return local_avatar_path(username).read_bytes()
+    except OSError:
+        return None
+
+
+def write_local_avatar(username: str, contents: bytes) -> None:
+    path = local_avatar_path(username)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+
+
+def delete_local_avatar(username: str) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        local_avatar_path(username).unlink()

--- a/static/css/components/avatar--js.css
+++ b/static/css/components/avatar--js.css
@@ -1,0 +1,86 @@
+/**
+ * Avatar (Profile Picture) component styles.
+ * Loaded dynamically via avatar.js off the critical CSS rendering path.
+ */
+
+.avatar-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-stack-md);
+}
+
+.avatar-preview-container {
+  width: 80px;
+  height: 80px;
+  border-radius: var(--border-radius-avatar);
+  overflow: hidden;
+  border: 2px solid var(--color-border-subtle);
+  background-color: var(--color-surface);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar-preview-container img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.avatar-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-stack-xs);
+}
+
+.avatar-controls input[type="file"] {
+  font-size: 0.9em;
+}
+
+.avatar-button-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-stack-xs);
+  flex-wrap: wrap;
+}
+
+.avatar-btn {
+  display: inline-block;
+  width: auto;
+  padding: 5px 12px;
+  font-size: var(--font-size-label-small, 13px);
+  font-weight: 600;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+}
+
+.avatar-btn--upload {
+  color: var(--color-text);
+  background-color: var(--neutral-100);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.avatar-btn--remove {
+  color: var(--color-danger-fg);
+  background-color: var(--white);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.avatar-upload-status {
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.avatar-upload-status--success {
+  color: var(--color-success-fg);
+}
+
+.avatar-upload-status--error {
+  color: var(--color-danger-fg);
+}
+
+.avatar-upload-status--info {
+  color: var(--color-text);
+}

--- a/tests/unit/js/avatar.test.js
+++ b/tests/unit/js/avatar.test.js
@@ -104,6 +104,35 @@ describe('avatar module', () => {
             expect(global.fetch).not.toHaveBeenCalled();
         });
 
+        test('keeps the local file preview when the response has no avatar_url (dev mock)', async() => {
+            initAvatarUpload(container);
+
+            const uploadBtn = document.getElementById('avatar-upload-btn');
+            const fileInput = document.getElementById('avatar-file-input');
+            const statusSpan = document.getElementById('avatar-upload-status');
+            const img = document.getElementById('avatar-preview-img');
+            const file = new File(['test-image-data'], 'test.png', { type: 'image/png' });
+
+            Object.defineProperty(fileInput, 'files', {
+                value: [file],
+                writable: true,
+            });
+
+            fileInput.dispatchEvent(new Event('change'));
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async() => ({}),
+            });
+
+            uploadBtn.dispatchEvent(new Event('click'));
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(statusSpan.textContent).toBe('Uploaded successfully!');
+            expect(global.URL.createObjectURL).toHaveBeenCalledWith(file);
+            expect(img.src).toBe('blob:http://localhost/mock-blob-url');
+        });
+
         test('successfully uploads avatar and updates status', async() => {
             initAvatarUpload(container);
 

--- a/tests/unit/js/avatar.test.js
+++ b/tests/unit/js/avatar.test.js
@@ -1,0 +1,213 @@
+import {
+    DEFAULT_AVATAR_STRINGS,
+    avatarStringsFromElement,
+    setStatus,
+    initAvatarUpload
+} from '../../../openlibrary/plugins/openlibrary/js/avatar';
+
+describe('avatar module', () => {
+    let container;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div class="formElement avatar" data-i18n='{"chooseImagePrompt": "Custom choose prompt"}'>
+                <div class="input avatar-container">
+                    <div class="avatar-preview-container">
+                        <img id="avatar-preview-img"
+                             src="/people/testuser/avatar"
+                             data-base-src="/people/testuser/avatar"
+                             alt="" />
+                    </div>
+                    <div class="avatar-controls">
+                        <input type="file" id="avatar-file-input" accept="image/jpeg,image/png,image/webp,image/gif" />
+                        <div class="avatar-button-group">
+                            <button type="button" id="avatar-upload-btn" class="avatar-btn avatar-btn--upload">Upload</button>
+                            <button type="button" id="avatar-remove-btn" class="avatar-btn avatar-btn--remove">Remove</button>
+                        </div>
+                        <span id="avatar-upload-status" class="avatar-upload-status"></span>
+                    </div>
+                </div>
+            </div>
+        `;
+        container = document.querySelector('.formElement.avatar');
+
+        // Mock URL.createObjectURL
+        global.URL.createObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
+        // Mock fetch
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('avatarStringsFromElement', () => {
+        test('merges dataset.i18n overrides with default strings', () => {
+            const strings = avatarStringsFromElement(container);
+            expect(strings.chooseImagePrompt).toBe('Custom choose prompt');
+            expect(strings.uploadSuccess).toBe(DEFAULT_AVATAR_STRINGS.uploadSuccess);
+        });
+
+        test('returns default strings when element has no dataset or malformed JSON', () => {
+            expect(avatarStringsFromElement(null)).toEqual(DEFAULT_AVATAR_STRINGS);
+
+            const badEl = document.createElement('div');
+            badEl.dataset.i18n = 'invalid json';
+            expect(avatarStringsFromElement(badEl)).toEqual(DEFAULT_AVATAR_STRINGS);
+        });
+    });
+
+    describe('setStatus', () => {
+        test('updates text and applies state classes', () => {
+            const statusSpan = document.getElementById('avatar-upload-status');
+            setStatus(statusSpan, 'Success text', 'success');
+            expect(statusSpan.textContent).toBe('Success text');
+            expect(statusSpan.classList.contains('avatar-upload-status--success')).toBe(true);
+
+            setStatus(statusSpan, 'Error text', 'error');
+            expect(statusSpan.textContent).toBe('Error text');
+            expect(statusSpan.classList.contains('avatar-upload-status--error')).toBe(true);
+            expect(statusSpan.classList.contains('avatar-upload-status--success')).toBe(false);
+
+            setStatus(null, 'Nothing', 'info'); // should not throw
+        });
+    });
+
+    describe('initAvatarUpload', () => {
+        test('updates preview image when file is selected', () => {
+            initAvatarUpload(container);
+
+            const fileInput = document.getElementById('avatar-file-input');
+            const img = document.getElementById('avatar-preview-img');
+            const file = new File(['test'], 'avatar.jpg', { type: 'image/jpeg' });
+
+            Object.defineProperty(fileInput, 'files', {
+                value: [file],
+                writable: true,
+            });
+
+            fileInput.dispatchEvent(new Event('change'));
+            expect(global.URL.createObjectURL).toHaveBeenCalledWith(file);
+            expect(img.src).toBe('blob:http://localhost/mock-blob-url');
+        });
+
+        test('shows error when upload is clicked without selecting a file', async() => {
+            initAvatarUpload(container);
+
+            const uploadBtn = document.getElementById('avatar-upload-btn');
+            const statusSpan = document.getElementById('avatar-upload-status');
+
+            uploadBtn.dispatchEvent(new Event('click'));
+
+            expect(statusSpan.textContent).toBe('Custom choose prompt');
+            expect(statusSpan.classList.contains('avatar-upload-status--error')).toBe(true);
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        test('successfully uploads avatar and updates status', async() => {
+            initAvatarUpload(container);
+
+            const uploadBtn = document.getElementById('avatar-upload-btn');
+            const fileInput = document.getElementById('avatar-file-input');
+            const statusSpan = document.getElementById('avatar-upload-status');
+            const file = new File(['test-image-data'], 'test.png', { type: 'image/png' });
+
+            Object.defineProperty(fileInput, 'files', {
+                value: [file],
+                writable: true,
+            });
+
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async() => ({
+                    avatar_url: 'https://archive.org/services/img/@testuser/avatar.jpg?v=12345',
+                }),
+            });
+
+            uploadBtn.dispatchEvent(new Event('click'));
+
+            expect(statusSpan.textContent).toBe('Uploading...');
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(global.fetch).toHaveBeenCalledWith('/account/avatar', expect.objectContaining({
+                method: 'POST',
+            }));
+            expect(statusSpan.textContent).toBe('Uploaded successfully!');
+            expect(statusSpan.classList.contains('avatar-upload-status--success')).toBe(true);
+        });
+
+        test('handles upload error response gracefully', async() => {
+            initAvatarUpload(container);
+
+            const uploadBtn = document.getElementById('avatar-upload-btn');
+            const fileInput = document.getElementById('avatar-file-input');
+            const statusSpan = document.getElementById('avatar-upload-status');
+            const file = new File(['test-bad'], 'bad.txt', { type: 'text/plain' });
+
+            Object.defineProperty(fileInput, 'files', {
+                value: [file],
+                writable: true,
+            });
+
+            global.fetch.mockResolvedValueOnce({
+                ok: false,
+                json: async() => ({ detail: 'Only JPEG, PNG, WEBP, and GIF images are allowed' }),
+            });
+
+            uploadBtn.dispatchEvent(new Event('click'));
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(statusSpan.textContent).toBe('Only JPEG, PNG, WEBP, and GIF images are allowed');
+            expect(statusSpan.classList.contains('avatar-upload-status--error')).toBe(true);
+        });
+
+        test('successfully removes avatar and updates preview and status', async() => {
+            initAvatarUpload(container);
+
+            const removeBtn = document.getElementById('avatar-remove-btn');
+            const fileInput = document.getElementById('avatar-file-input');
+            const statusSpan = document.getElementById('avatar-upload-status');
+            const img = document.getElementById('avatar-preview-img');
+
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async() => ({ status: 'success' }),
+            });
+
+            removeBtn.dispatchEvent(new Event('click'));
+            expect(statusSpan.textContent).toBe('Removing...');
+
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(global.fetch).toHaveBeenCalledWith('/account/avatar', {
+                method: 'DELETE',
+            });
+            expect(statusSpan.textContent).toBe('Photo removed successfully!');
+            expect(statusSpan.classList.contains('avatar-upload-status--success')).toBe(true);
+            expect(fileInput.value).toBe('');
+            expect(img.src).toContain('/people/testuser/avatar?t=');
+        });
+
+        test('handles remove error response gracefully', async() => {
+            initAvatarUpload(container);
+
+            const removeBtn = document.getElementById('avatar-remove-btn');
+            const statusSpan = document.getElementById('avatar-upload-status');
+
+            global.fetch.mockResolvedValueOnce({
+                ok: false,
+                json: async() => ({ detail: 'No custom profile picture exists to remove' }),
+            });
+
+            removeBtn.dispatchEvent(new Event('click'));
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(statusSpan.textContent).toBe('No custom profile picture exists to remove');
+            expect(statusSpan.classList.contains('avatar-upload-status--error')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13263

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feat: Add direct profile picture upload and removal via FastAPI endpoints

### Technical
<!-- What should be noted about the implementation? -->
1. **FastAPI Avatar Endpoints (`openlibrary/fastapi/account.py`)**:
   - Added `POST /account/avatar` endpoint with Pillow image validation, EXIF metadata stripping, RGB normalization, and max 500x500 JPEG re-encoding.
   - Integrated Internet Archive S3 upload (`ia.get_item().upload`) with `queue_derive=True` signal for automatic thumbnail derivative processing.
   - Added `DELETE /account/avatar` endpoint to remove custom profile picture timestamp and reset avatar URL.
   - Updates user account `avatar_updated` timestamp and invalidates `user-avatar-{username}` Memcached key.

2. **Reverse Proxy Stream Fix (`openlibrary/plugins/openlibrary/deprecated_handler.py`)**:
   - Extracted binary file streams directly from `v.file.read()` to prevent `UnicodeDecodeError` when proxying multipart form data from legacy `web.py` to `FastAPI`.

3. **UI Enhancements (`openlibrary/templates/type/user/edit.html`)**:
   - Updated avatar `src` to route via `$(page.key)/avatar` with circular container overflow and `onerror` fallback safety.
   - Added instant client-side preview (`URL.createObjectURL`) on file selection.
   - Added inline **Upload Photo** and **Remove Photo** buttons with async status updates and error details.

4. **Model Formatting (`openlibrary/core/models.py`)**:
   - Ensured `itemname` formatting with `@` prefix in `User.get_avatar_url()` and appended `?v={avatar_updated}` query parameter for CDN/browser cache invalidation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. **Automated Unit Tests**:
   ```bash
   uv run --with-requirements requirements_test.txt pytest openlibrary/tests/fastapi/test_account.py
   ```
   *(19/19 pytest unit tests passing in 1.04s)*

2. **Pre-commit Quality Hooks**:
   ```bash
   pre-commit run --files openlibrary/core/models.py openlibrary/fastapi/account.py openlibrary/plugins/openlibrary/deprecated_handler.py openlibrary/templates/type/user/edit.html openlibrary/tests/fastapi/test_account.py
   ```
   *(All linter, formatter, walrus, and i18n hooks passed cleanly)*

3. **Manual Verification**:
   - Log in and navigate to `http://localhost:8080/people/<username>?m=edit`.
   - Click **Choose File** and select an image — observe instant DOM circular preview.
   - Click **Upload Photo** — status displays green "Uploaded successfully!".
   - Click **Remove Photo** — status displays green "Photo removed successfully!". If no photo exists, displays "No custom profile picture exists to remove".

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="231" height="73" alt="image" src="https://github.com/user-attachments/assets/d66dfc55-0df7-4ddf-860c-1400397d81c5" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
- @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->