### PR TITLE
Make debug feature flag optional with LOCAL_DEV

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -40,7 +40,7 @@ if not hasattr(infogami.config, "features"):
 import openlibrary.core.stats
 from infogami.core.db import ValidationException
 from infogami.infobase import client
-from infogami.utils import delegate, i18n, macro, template
+from infogami.utils import delegate, features, i18n, macro, template
 from infogami.utils.app import metapage
 from infogami.utils.view import (
     add_flash_message,
@@ -1030,10 +1030,7 @@ def internalerror():
     if sentry.enabled:
         sentry_event_id = sentry.capture_exception_webpy()
 
-    debug_spec = (infogami.config.get("features") or {}).get("debug")
-    debug_value = debug_spec.get("value") if isinstance(debug_spec, dict) else None
-
-    if get_ol_env().LOCAL_DEV or (debug_value and web.input(_method="GET").get("debug") == debug_value):
+    if get_ol_env().LOCAL_DEV or features.is_enabled("debug"):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -40,7 +40,7 @@ if not hasattr(infogami.config, "features"):
 import openlibrary.core.stats
 from infogami.core.db import ValidationException
 from infogami.infobase import client
-from infogami.utils import delegate, features, i18n, macro, template
+from infogami.utils import delegate, i18n, macro, template
 from infogami.utils.app import metapage
 from infogami.utils.view import (
     add_flash_message,
@@ -1030,7 +1030,10 @@ def internalerror():
     if sentry.enabled:
         sentry_event_id = sentry.capture_exception_webpy()
 
-    if features.is_enabled("debug"):
+    debug_spec = (infogami.config.get("features") or {}).get("debug")
+    debug_value = debug_spec.get("value") if isinstance(debug_spec, dict) else None
+
+    if get_ol_env().LOCAL_DEV or (debug_value and web.input(_method="GET").get("debug") == debug_value):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -39,7 +39,7 @@ from infogami import config
 from infogami.infobase import client
 from infogami.infobase.client import Changeset, Nothing, Thing, storify
 from infogami.infobase.common import parse_query
-from infogami.utils import delegate, features, stats, view
+from infogami.utils import delegate, stats, view
 from infogami.utils.context import InfogamiContext, context
 from infogami.utils.macro import macro
 from infogami.utils.view import (
@@ -299,11 +299,6 @@ def json_encode(d, indent: int | str | None = None, sort_keys: bool = False) -> 
     # Escape < and > so the output is safe inside <script> tags with unescaped $: output.
     # </> are valid JSON unicode escapes; all parsers decode them correctly.
     return json.dumps(d, indent=indent, sort_keys=sort_keys).replace("<", "\\u003c").replace(">", "\\u003e")
-
-
-@public
-def is_feature_enabled(feature_name: str) -> bool:
-    return features.is_enabled(feature_name)
 
 
 def unflatten(d: dict, separator: str = "--") -> Storage | list[Any]:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

This PR now accomplishes two things, makes sure debug is always enabled in local dev and removed an unused `is_feature_enabled` function. Also confirmed there is no usage of this in the dump of pages from prod.

As such, closing up the final code changes for our migration of feature flags.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
