### PR TITLE
chore: remove lokesh from weekly status report leads

### DIFF
--- a/.github/workflows/config/weekly_status_report_openlibrary_leads_g.json
+++ b/.github/workflows/config/weekly_status_report_openlibrary_leads_g.json
@@ -16,11 +16,6 @@
       "githubUsername": "rebecca-shoptaw",
       "leadLabel": "Lead: @rebecca-shoptaw",
       "slackId": "<@U06D09YC69L>"
-    },
-    {
-      "githubUsername": "lokesh",
-      "leadLabel": "Lead: @lokesh",
-      "slackId": "<@U09NTCSNVNG>"
     }
   ]
 }


### PR DESCRIPTION
Removes me from the `#openlibrary-leads-g` weekly Slack digest. I'm using my own weekly report generation tooling, so this is just notification noise for me.

### Technical
Drops the `lokesh` entry from the `leads` array.

### Testing
N/A — config only.

### Stakeholders
@RayBB
