### PR TITLE
Manually send data-ol-link-track to matomo

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.analytics.js
+++ b/openlibrary/plugins/openlibrary/js/ol.analytics.js
@@ -65,6 +65,7 @@ export default function initAnalytics() {
             var category_action = $(this).attr('data-ol-link-track').split('|');
             // for testing,
             // console.log(category_action[0], category_action[1]);
+            trackEvent(category_action[0], category_action[1], category_action[2]);
             window.archive_analytics.ol_send_event_ping({
                 category: category_action[0],
                 action: category_action[1],


### PR DESCRIPTION
Instead of using Matomo's tag manager triggers to read the attribute, try using our existing JS to send it to matomo directly. This to try to resolve an issue we're observing where the attribute isn't working when attached to lit components.

Closes #13291


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

I am seeing matomo appear twice here now on testing, but I think once we block the matomo code from the matomo UI there should be no more duplicates.

<img width="1917" height="732" alt="image" src="https://github.com/user-attachments/assets/d589b8f3-fde6-4f75-a6ee-d54d25dbe9e1" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
