### PR TITLE
`purge_s3_keys.py` script updates

### DIFF
--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -87,6 +87,7 @@ def main():
 
     setup()
 
+    updated_count = 0
     if args.dry_run:
         it = get_affected_keys(limit=None)
         for record in it:
@@ -100,9 +101,15 @@ def main():
                 success = update_record(key)
                 if not success:
                     print(f"Failed to update {key}")
+                    continue
+                updated_count += 1
                 if was_shutdown_requested():
+                    print(f"Records updated this session: {updated_count}")
                     return 130
+            # After each batch:
+            print(f"{updated_count:>11} records updated")
 
+    print(f"Records updated this session: {updated_count}")
     return 0
 
 

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -109,7 +109,7 @@ def main():
                     print(f"Records updated this session: {updated_count}")
                     return 130
             # After each batch:
-            print(f"{updated_count:>11} records updated")
+            print(f"{updated_count:>11} records updated", flush=True)
 
     print(f"Records updated this session: {updated_count}")
     return 0

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -40,7 +40,9 @@ def get_affected_keys(limit: int | None = 100_000):
         )
     """
     oldb = db.get_db()
-    rs = oldb.query(query, vars={"limit": limit})
+    with oldb.transaction():
+        oldb.query("SET LOCAL statement_timeout = '450s'")  # 7.5 minutes
+        rs = oldb.query(query, vars={"limit": limit})
     return iter(rs)
 
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates `purge_s3_keys.py` in the following ways:

- Prints the number of updated records after processing a batch of records
- Sets a 7.5 minute timeout for affected key query transactions

The query to find all affected accounts takes over an hour to run, so the printing the number of updated records will help us determine the number of remaining records w/o the need to wait so long for results.

The default query timeout is too short for the affected keys query, which takes less than 3 minutes currently.  I wouldn't be surprised if this query takes longer as more records are updated, so I've set the timeout to 7.5 minutes.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
