### PR TITLE
feat(vendors): make Amazon affiliate metadata fetch async

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -23,6 +23,7 @@ from openlibrary.catalog.add_book import load
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
 from openlibrary.utils import dateutil, uniq
+from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.isbn import (
     isbn_10_to_isbn_13,
     isbn_13_to_isbn_10,
@@ -31,6 +32,10 @@ from openlibrary.utils.isbn import (
 
 logger = logging.getLogger("openlibrary.vendors")
 session = requests.Session()
+# Shared by the FastAPI event loop (get_betterworldbooks_metadata,
+# get_amazon_metadata_async) and the async_bridge background loop (the sync
+# get_amazon_metadata wrapper). Fine in production: web.py and FastAPI run in
+# separate processes, so each process uses it on a single event loop.
 async_session = httpx.AsyncClient()
 
 BETTERWORLDBOOKS_API_URL = "https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId="
@@ -585,31 +590,6 @@ class AmazonCreatorsAPI:
         return book
 
 
-def get_amazon_metadata(
-    id_: str,
-    id_type: Literal["asin", "isbn"] = "isbn",
-    resources: Any = None,
-    high_priority: bool = False,
-    stage_import: bool = True,
-) -> dict | None:
-    """Main interface to Amazon LookupItem API. Will cache results.
-
-    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
-    :param str id_type: 'isbn' or 'asin'.
-    :param bool high_priority: Priority in the import queue. High priority
-           goes to the front of the queue.
-    param bool stage_import: stage the id_ for import if not in the cache.
-    :return: A single book item's metadata, or None.
-    """
-    return cached_get_amazon_metadata(
-        id_,
-        id_type=id_type,
-        resources=resources,
-        high_priority=high_priority,
-        stage_import=stage_import,
-    )
-
-
 @cache.memoize(
     engine="memcache",
     key="get_amazon_metadata_async",
@@ -623,96 +603,16 @@ async def get_amazon_metadata_async(
     high_priority: bool = False,
     stage_import: bool = True,
 ) -> dict | None:
-    """Async interface to the Amazon LookupItem API (non-blocking).
-
-    Same semantics as :func:`get_amazon_metadata`, but uses httpx so it never
-    blocks the event loop. Results are cached in memcache for a week.
-    Bare ``None`` results (e.g. a 503 throttle from the affiliate server) are
-    not cached, so the next call retries — matching the sync path's
-    "only the value None will cause re-cache" behaviour.
-
-    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
-    :param str id_type: 'isbn' or 'asin'.
-    :param bool high_priority: Priority in the import queue. High priority
-           goes to the front of the queue.
-    param bool stage_import: stage the id_ for import if not in the cache.
-    :return: A single book item's metadata, or None.
-    """
-    return await _get_amazon_metadata_async(
-        id_,
-        id_type=id_type,
-        resources=resources,
-        high_priority=high_priority,
-        stage_import=stage_import,
-    )
-
-
-def _get_amazon_metadata(
-    id_: str,
-    id_type: Literal["asin", "isbn"] = "isbn",
-    resources: Any = None,
-    high_priority: bool = False,
-    stage_import: bool = True,
-    timeout: float = 10.0,
-) -> dict | None:
     """Uses the Amazon Product Advertising API ItemLookup operation to locate a
     specific book by identifier; either 'isbn' or 'asin'.
     https://webservices.amazon.com/paapi5/documentation/get-items.html
 
-    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
-    :param str id_type: 'isbn' or 'asin'.
-    :param Any resources: Used for AWSE Commerce Service lookup
-           See https://webservices.amazon.com/paapi5/documentation/get-items.html
-    :param bool high_priority: Priority in the import queue. High priority
-           goes to the front of the queue.
-    param bool stage_import: stage the id_ for import if not in the cache.
-    :return: A single book item's metadata, or None.
-    """
-    if not affiliate_server_url:
-        return None
-
-    if id_type == "isbn":
-        isbn = normalize_isbn(id_)
-        if isbn is None:
-            return None
-        id_ = isbn
-        if len(id_) == 13 and id_.startswith("978"):
-            isbn = isbn_13_to_isbn_10(id_)
-            if isbn is None:
-                return None
-            id_ = isbn
-
-    try:
-        priority = "true" if high_priority else "false"
-        stage = "true" if stage_import else "false"
-        r = session.get(
-            f"http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}",
-            timeout=timeout,
-        )
-        r.raise_for_status()
-        if data := r.json().get("hit"):
-            return data
-        else:
-            return None
-    except requests.exceptions.ConnectionError:
-        logger.exception("Affiliate Server unreachable")
-    except requests.exceptions.HTTPError:
-        logger.exception(f"Affiliate Server: id {id_} not found")
-    return None
-
-
-async def _get_amazon_metadata_async(
-    id_: str,
-    id_type: Literal["asin", "isbn"] = "isbn",
-    resources: Any = None,
-    high_priority: bool = False,
-    stage_import: bool = True,
-) -> dict | None:
-    """Async mirror of :func:`_get_amazon_metadata` using httpx (non-blocking).
-
-    Uses the same /isbn/ endpoint on the affiliate server and the same ISBN
-    normalization, but makes the HTTP round-trip with the shared
-    ``async_session`` httpx client so it never blocks the event loop.
+    Canonical async implementation: makes the HTTP round-trip to the affiliate
+    server with the shared httpx ``async_session`` so it never blocks the event
+    loop. Results are cached in memcache for a week; bare ``None`` results
+    (e.g. a 503 throttle from the affiliate server) are not cached, so the next
+    call retries — matching the historical "only the value None will cause
+    re-cache" behaviour.
 
     :param str id_: The item id: isbn (10/13), or Amazon ASIN.
     :param str id_type: 'isbn' or 'asin'.
@@ -754,6 +654,15 @@ async def _get_amazon_metadata_async(
     except httpx.TransportError:
         logger.exception("Affiliate Server unreachable")
     return None
+
+
+# Sync wrapper for backward compatibility (async_bridge pattern — see
+# openlibrary/core/lending.py). Sync and async callers share the same memcache
+# entries and the same underlying implementation. Note: unlike the old
+# memcache_memoize path (stale value served while a background thread refreshes
+# after expiry), cache.memoize hard-expires the entry, so the first call after a
+# week blocks on the affiliate-server round trip.
+get_amazon_metadata = async_bridge.wrap(get_amazon_metadata_async)
 
 
 def stage_bookworm_metadata(identifier: str | None) -> dict | None:
@@ -857,29 +766,6 @@ def create_edition_from_amazon_metadata(id_: str, id_type: Literal["asin", "isbn
             if reply and reply.get("success"):
                 return reply["edition"].get("key")
     return None
-
-
-def cached_get_amazon_metadata(*args, **kwargs):
-    """If the cached data is `None`, it's likely a 503 throttling occurred on
-    Amazon's side. Try again to fetch the value instead of using the
-    cached value. It may 503 again, in which case the next access of
-    this page will trigger another re-cache. If the Amazon API call
-    succeeds but the book has no price data, then {"price": None} will
-    be cached as to not trigger a re-cache (only the value `None`
-    will cause re-cache)
-    """
-
-    # fetch/compose a cache controller obj for
-    # "upstream.code._get_amazon_metadata"
-    memoized_get_amazon_metadata = cache.memcache_memoize(
-        _get_amazon_metadata,
-        "upstream.code._get_amazon_metadata",
-        timeout=dateutil.WEEK_SECS,
-    )
-    # fetch cached value from this controller
-    result = memoized_get_amazon_metadata(*args, **kwargs)
-    # if no result, then recache / update this controller's cached value
-    return result or memoized_get_amazon_metadata.update(*args, **kwargs)[0]
 
 
 class BetterWorldBooksMetadata(TypedDict):

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -32,10 +32,6 @@ from openlibrary.utils.isbn import (
 
 logger = logging.getLogger("openlibrary.vendors")
 session = requests.Session()
-# Shared by the FastAPI event loop (get_betterworldbooks_metadata,
-# get_amazon_metadata_async) and the async_bridge background loop (the sync
-# get_amazon_metadata wrapper). Fine in production: web.py and FastAPI run in
-# separate processes, so each process uses it on a single event loop.
 async_session = httpx.AsyncClient()
 
 BETTERWORLDBOOKS_API_URL = "https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId="
@@ -602,6 +598,7 @@ async def get_amazon_metadata_async(
     resources: Any = None,
     high_priority: bool = False,
     stage_import: bool = True,
+    timeout: float = 10.0,  # noqa: ASYNC109
 ) -> dict | None:
     """Uses the Amazon Product Advertising API ItemLookup operation to locate a
     specific book by identifier; either 'isbn' or 'asin'.
@@ -620,7 +617,9 @@ async def get_amazon_metadata_async(
            See https://webservices.amazon.com/paapi5/documentation/get-items.html
     :param bool high_priority: Priority in the import queue. High priority
            goes to the front of the queue.
-    param bool stage_import: stage the id_ for import if not in the cache.
+    :param bool stage_import: stage the id_ for import if not in the cache.
+    :param float timeout: Per-request timeout in seconds for the affiliate
+           server call.
     :return: A single book item's metadata, or None.
     """
     if not affiliate_server_url:
@@ -642,7 +641,7 @@ async def get_amazon_metadata_async(
         stage = "true" if stage_import else "false"
         r = await async_session.get(
             f"http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}",
-            timeout=10.0,
+            timeout=timeout,
         )
         r.raise_for_status()
         if data := r.json().get("hit"):
@@ -656,12 +655,8 @@ async def get_amazon_metadata_async(
     return None
 
 
-# Sync wrapper for backward compatibility (async_bridge pattern — see
-# openlibrary/core/lending.py). Sync and async callers share the same memcache
-# entries and the same underlying implementation. Note: unlike the old
-# memcache_memoize path (stale value served while a background thread refreshes
-# after expiry), cache.memoize hard-expires the entry, so the first call after a
-# week blocks on the affiliate-server round trip.
+# Sync wrapper for backward compatibility (async_bridge pattern, see
+# openlibrary/core/lending.py); sync callers share the same cache and code path.
 get_amazon_metadata = async_bridge.wrap(get_amazon_metadata_async)
 
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -610,6 +610,43 @@ def get_amazon_metadata(
     )
 
 
+@cache.memoize(
+    engine="memcache",
+    key="get_amazon_metadata_async",
+    expires=dateutil.WEEK_SECS,
+    cacheable=lambda key, value: value is not None,
+)
+async def get_amazon_metadata_async(
+    id_: str,
+    id_type: Literal["asin", "isbn"] = "isbn",
+    resources: Any = None,
+    high_priority: bool = False,
+    stage_import: bool = True,
+) -> dict | None:
+    """Async interface to the Amazon LookupItem API (non-blocking).
+
+    Same semantics as :func:`get_amazon_metadata`, but uses httpx so it never
+    blocks the event loop. Results are cached in memcache for a week.
+    Bare ``None`` results (e.g. a 503 throttle from the affiliate server) are
+    not cached, so the next call retries — matching the sync path's
+    "only the value None will cause re-cache" behaviour.
+
+    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
+    :param str id_type: 'isbn' or 'asin'.
+    :param bool high_priority: Priority in the import queue. High priority
+           goes to the front of the queue.
+    param bool stage_import: stage the id_ for import if not in the cache.
+    :return: A single book item's metadata, or None.
+    """
+    return await _get_amazon_metadata_async(
+        id_,
+        id_type=id_type,
+        resources=resources,
+        high_priority=high_priority,
+        stage_import=stage_import,
+    )
+
+
 def _get_amazon_metadata(
     id_: str,
     id_type: Literal["asin", "isbn"] = "isbn",
@@ -661,6 +698,61 @@ def _get_amazon_metadata(
         logger.exception("Affiliate Server unreachable")
     except requests.exceptions.HTTPError:
         logger.exception(f"Affiliate Server: id {id_} not found")
+    return None
+
+
+async def _get_amazon_metadata_async(
+    id_: str,
+    id_type: Literal["asin", "isbn"] = "isbn",
+    resources: Any = None,
+    high_priority: bool = False,
+    stage_import: bool = True,
+) -> dict | None:
+    """Async mirror of :func:`_get_amazon_metadata` using httpx (non-blocking).
+
+    Uses the same /isbn/ endpoint on the affiliate server and the same ISBN
+    normalization, but makes the HTTP round-trip with the shared
+    ``async_session`` httpx client so it never blocks the event loop.
+
+    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
+    :param str id_type: 'isbn' or 'asin'.
+    :param Any resources: Used for AWSE Commerce Service lookup
+           See https://webservices.amazon.com/paapi5/documentation/get-items.html
+    :param bool high_priority: Priority in the import queue. High priority
+           goes to the front of the queue.
+    param bool stage_import: stage the id_ for import if not in the cache.
+    :return: A single book item's metadata, or None.
+    """
+    if not affiliate_server_url:
+        return None
+
+    if id_type == "isbn":
+        isbn = normalize_isbn(id_)
+        if isbn is None:
+            return None
+        id_ = isbn
+        if len(id_) == 13 and id_.startswith("978"):
+            isbn = isbn_13_to_isbn_10(id_)
+            if isbn is None:
+                return None
+            id_ = isbn
+
+    try:
+        priority = "true" if high_priority else "false"
+        stage = "true" if stage_import else "false"
+        r = await async_session.get(
+            f"http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}",
+            timeout=10.0,
+        )
+        r.raise_for_status()
+        if data := r.json().get("hit"):
+            return data
+        else:
+            return None
+    except httpx.HTTPStatusError:
+        logger.exception(f"Affiliate Server: id {id_} not found")
+    except httpx.TransportError:
+        logger.exception("Affiliate Server unreachable")
     return None
 
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -655,8 +655,7 @@ async def get_amazon_metadata_async(
     return None
 
 
-# Sync wrapper for backward compatibility (async_bridge pattern, see
-# openlibrary/core/lending.py); sync callers share the same cache and code path.
+# Sync wrapper for backward compatibility.
 get_amazon_metadata = async_bridge.wrap(get_amazon_metadata_async)
 
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -40,7 +40,7 @@ from openlibrary.core.models import (
 from openlibrary.core.observations import Observations
 from openlibrary.core.vendors import (
     create_edition_from_amazon_metadata,
-    get_amazon_metadata,
+    get_amazon_metadata_async,
     get_betterworldbooks_metadata,
 )
 from openlibrary.i18n import gettext as _
@@ -335,7 +335,7 @@ async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:
     id_ = asin or (normalize_isbn(isbn) or isbn)
 
     metadata: dict = {
-        "amazon": get_amazon_metadata(id_, id_type=id_type_short) or {},
+        "amazon": await get_amazon_metadata_async(id_, id_type=id_type_short) or {},
         "betterworldbooks": {},
     }
     if id_type_short == "isbn":

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -16,7 +16,7 @@ from openlibrary.core.lending import compose_ia_url, get_available_async
 from openlibrary.core.vendors import (
     BetterWorldBooksMetadata,
     amazon_affiliate_url,
-    get_amazon_metadata,
+    get_amazon_metadata_async,
     get_betterworldbooks_metadata,
 )
 from openlibrary.i18n import gettext as _
@@ -309,7 +309,7 @@ class AffiliateLinksPartial:
         if should_fetch_prices and isbn:
             bwb_metadata = await get_betterworldbooks_metadata(isbn)
             if not bwb_metadata or not bwb_metadata.get("market_price"):
-                amz_metadata = get_amazon_metadata(isbn, resources="prices")
+                amz_metadata = await get_amazon_metadata_async(isbn, resources="prices")
 
         if bwb_metadata and "error" in bwb_metadata:
             bwb_metadata = None

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -331,7 +331,10 @@ async def test_get_amazon_metadata_async() -> None:
         def json(self):
             return mock_response
 
+    captured_kwargs = {}
+
     async def mock_async_get(*args, **kwargs):
+        captured_kwargs.update(kwargs)
         return MockResponse()
 
     mock_response = {
@@ -355,16 +358,15 @@ async def test_get_amazon_metadata_async() -> None:
         },
     }
     expected = mock_response["hit"]
-    # Use the ISBN-13 form of the same book: the memoized cache key is built
-    # from the raw input, so this keeps this test's cache entry distinct from
-    # the sync test's ISBN-10 one (both entry points share one key scheme).
+    # Use the ISBN-13 form of the same book for a distinct cache key.
     isbn = "9780590353427"
     with (
         patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),
     ):
-        got = await get_amazon_metadata_async(id_=isbn, id_type="isbn")
+        got = await get_amazon_metadata_async(id_=isbn, id_type="isbn", timeout=5.0)
         assert got == expected
+        assert captured_kwargs["timeout"] == 5.0
 
 
 @dataclass

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -10,6 +10,7 @@ from openlibrary.core.vendors import (
     betterworldbooks_fmt,
     clean_amazon_metadata_for_load,
     get_amazon_metadata,
+    get_amazon_metadata_async,
     is_dvd,
     split_amazon_title,
 )
@@ -307,6 +308,54 @@ def test_get_amazon_metadata() -> None:
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),
     ):
         got = get_amazon_metadata(id_=isbn, id_type="isbn")
+        assert got == expected
+
+
+@pytest.mark.asyncio
+async def test_get_amazon_metadata_async() -> None:
+    """
+    Async version of get_amazon_metadata: mock a reply from the affiliate
+    server via the shared httpx async session and verify the metadata is
+    returned without blocking.
+    """
+
+    class MockResponse:
+        def raise_for_status(self):
+            return True
+
+        def json(self):
+            return mock_response
+
+    async def mock_async_get(*args, **kwargs):
+        return MockResponse()
+
+    mock_response = {
+        "status": "success",
+        "hit": {
+            "url": "https://www.amazon.com/dp/059035342X/?tag=internetarchi-20",
+            "source_records": ["amazon:059035342X"],
+            "isbn_10": ["059035342X"],
+            "isbn_13": ["9780590353427"],
+            "price": "$5.10",
+            "price_amt": 509,
+            "title": "Harry Potter and the Sorcerer's Stone",
+            "cover": "https://m.media-amazon.com/images/I/51Wbz5GypgL._SL500_.jpg",
+            "authors": [{"name": "Rowling, J.K."}, {"name": "GrandPr_, Mary"}],
+            "publishers": ["Scholastic"],
+            "number_of_pages": 309,
+            "edition_num": "1",
+            "publish_date": "Sep 02, 1998",
+            "product_group": "Book",
+            "physical_format": "paperback",
+        },
+    }
+    expected = mock_response["hit"]
+    isbn = "059035342X"
+    with (
+        patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
+        patch("openlibrary.core.vendors.affiliate_server_url", new=True),
+    ):
+        got = await get_amazon_metadata_async(id_=isbn, id_type="isbn")
         assert got == expected
 
 

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -254,8 +254,9 @@ def test_betterworldbooks_fmt():
 
 def test_get_amazon_metadata() -> None:
     """
-    Mock a reply from the Amazon Products API so we can do a basic test for
-    get_amazon_metadata() and cached_get_amazon_metadata().
+    Mock a reply from the Amazon affiliate server so we can do a basic test for
+    get_amazon_metadata(), the sync async_bridge wrapper around the canonical
+    get_amazon_metadata_async().
     """
 
     class MockResponse:
@@ -303,8 +304,12 @@ def test_get_amazon_metadata() -> None:
         "physical_format": "paperback",
     }
     isbn = "059035342X"
+
+    async def mock_async_get(*args, **kwargs):
+        return MockResponse()
+
     with (
-        patch("openlibrary.core.vendors.session.get", return_value=MockResponse()),
+        patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),
     ):
         got = get_amazon_metadata(id_=isbn, id_type="isbn")
@@ -350,7 +355,10 @@ async def test_get_amazon_metadata_async() -> None:
         },
     }
     expected = mock_response["hit"]
-    isbn = "059035342X"
+    # Use the ISBN-13 form of the same book: the memoized cache key is built
+    # from the raw input, so this keeps this test's cache entry distinct from
+    # the sync test's ISBN-10 one (both entry points share one key scheme).
+    isbn = "9780590353427"
     with (
         patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),


### PR DESCRIPTION
Part of https://github.com/internetarchive/openlibrary/issues/13277

## Summary

Makes the Amazon affiliate metadata fetch non-blocking in the FastAPI/async paths, so the event loop isn't tied up on a synchronous HTTP round-trip to the affiliate server.

## What changed

- **`openlibrary/core/vendors.py`** — makes `get_amazon_metadata_async()` the single canonical implementation of the affiliate-server lookup: an `httpx`-based, non-blocking fetch (using the shared `async_session` client) with the same ISBN normalization, `/isbn/` endpoint, 10s timeout, and error handling as before. It is memoized for a week via `@cache.memoize` (which supports async functions — see `test_cache.py`), and bare `None` results (e.g. 503 throttling) are not cached (`cacheable=lambda key, value: value is not None`) so the next call retries.
  - The old sync implementation (`_get_amazon_metadata` + `cached_get_amazon_metadata`) is replaced by a sync wrapper: `get_amazon_metadata = async_bridge.wrap(get_amazon_metadata_async)` — the same pattern used in `openlibrary/core/lending.py` (`get_available`), `fulltext.py`, and `solr.py`. Sync callers keep the same interface, and both entry points share one memcache key scheme, so a warm ISBN is warm for both paths.
- **`openlibrary/plugins/openlibrary/partials.py`** — `AffiliateLinksPartial.generate_async` now `await`s `get_amazon_metadata_async()`.
- **`openlibrary/plugins/openlibrary/api.py`** — `get_price_data_async` (backs `/internal/prices.json`) now `await`s `get_amazon_metadata_async()`.
- **`openlibrary/tests/core/test_vendors.py`** — tests the sync wrapper and the async function against a mocked `async_session.get`, and asserts the `timeout` parameter threads through to the httpx call.

## Why

The two FastAPI handlers (`/partials/AffiliateLinks.json` and `/internal/prices.json`) previously made a **synchronous** `requests` call to the affiliate server from inside an async handler, blocking the event loop for up to the 10s timeout. This makes those paths truly non-blocking, matching how BetterWorldBooks metadata is already fetched.

Sync callers (`models.py`, `import_ui.py`, `create_edition_from_amazon_metadata`) are unchanged — they keep calling `get_amazon_metadata()` (now via the bridge), which runs in web.py's threaded context, not the FastAPI event loop.

## Known tradeoff

On cache expiry (1-week TTL), the value recomputes on the next call rather than serving stale data while a background thread refreshes (the old sync `memcache_memoize` path). This now applies uniformly to sync and async callers; in practice it means at most one blocking fetch per ISBN per week.
