### PR TITLE
Document local-dev API and copydocs gotchas

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -75,6 +75,68 @@ docker compose up -d solr
 docker compose run --rm home make reindex-solr
 ```
 
+### API writes silently drop `action`/`comment`/`data` or 500
+
+The infogami write API (`/api/save_many`, `/api/write`) only applies custom
+`action`, `comment`, and `data` headers when the request's `Opt` header
+matches the app's configured `http_ext_header_uri`. The dev app sets this to
+`http://openlibrary.org/dev/docs/api` (`openlibrary/plugins/openlibrary/code.py`),
+**not** the infogami default (`http://infogami.org/api`).
+
+- **Mismatch symptom:** saves succeed but are recorded as `default-bulk-update`
+  with no comment or data (silent — action-tagged saves like merges lose their
+  metadata), or `api/save_many` 500s when the custom headers come back `None`.
+- **Fix:** send the matching declaration, e.g.
+  `Opt: "http://openlibrary.org/dev/docs/api"; ns=12` plus
+  `X-12-action: merge-authors`, `X-12-comment: ...`, `X-12-data: {...}`.
+- **Prefer FastAPI endpoints instead:** they share the session auth and need
+  no custom headers — e.g. author merges via
+  `POST http://localhost:18080/authors/merge.json`.
+
+### Scripts must log in via the JSON endpoint
+
+`POST /account/login` with a form body returns **200 but does not set a
+session cookie** — scripts that use it appear logged in but their writes are
+unauthenticated. Always POST JSON to `/account/login.json`:
+
+```bash
+curl -s -c /tmp/ck.txt -X POST http://localhost:8080/account/login.json \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"openlibrary","password":"openlibrary"}'
+```
+
+The dev user `openlibrary` / `openlibrary` is a member of `/usergroup/admin`
+(see `scripts/dev-instance/dev_db.pg_dump`), i.e. a super-librarian.
+`scripts/copydocs.py`'s `~/.olrc` autologin hits the form-POST trap — see its
+docstring.
+
+### copydocs copies current revisions only
+
+`scripts/copydocs.py` copies the *current* revision of each document and
+follows *current* references. It does **not** copy changesets/transactions,
+version history (`?v=`), or references that only exist in older revisions,
+and it deliberately strips `authors` from editions.
+
+If you need older revisions:
+
+- **Fetch one revision directly:** `GET /api/get?key=<key>&v=<revision>`
+  (e.g. `curl 'http://localhost:8080/api/get?key=/books/OL1M&v=2'`). On
+  openlibrary.org the same works via `<key>.json?v=<revision>`.
+- **List a doc's revisions:** `GET /api/versions?query=<url-encoded JSON>` —
+  each entry includes the revision number, changeset id, action, and comment.
+  The `query` JSON must be URL-encoded, e.g.
+  `curl -G 'http://localhost:8080/api/versions' --data-urlencode 'query={"key": "/books/OL1M", "limit": 5}'`.
+- **copydocs `?v=N` keys** (`./scripts/copydocs.py /works/OL1W?v=2`) copy an
+  old revision's *content*, but it is saved as a fresh local revision — local
+  revision numbering and changeset history are still not preserved.
+- **Reproductions that depend on history** (e.g. undo, which fetches
+  `revision − 1`) need the local infobase rows
+  (`transaction`/`thing`/`data`/`version`) to match production — either
+  reconstruct them via `psql` in the `db` container (fetch R and R−1 from
+  production), or — usually simpler — build a synthetic scenario through the
+  API instead of copying history at all (the #5664 reproduction work is a
+  worked example of the API approach).
+
 ## Linting
 
 ```bash

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+"""Copy docs from one Open Library instance to another (usually openlibrary.org
+into a local dev instance).
+
+Known dev-instance quirks (login is JSON-only, custom save headers require the
+right Opt decl_uri, and only *current* revisions are copied — no
+changeset/transaction history) are documented in docs/ai/README.md →
+Troubleshooting.
+"""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
Documents hard-won local dev gotchas in the AI guide and the copydocs docstring, so future agents and humans hit fewer silent failures:

- Scripts must log in via the JSON endpoint (`/account/login.json`)
- Custom save headers (`Opt` / `http_ext_header_uri`) can be silently dropped
- copydocs copies only current revisions, with guidance for fetching older ones

All facts verified live against the dev instance and openlibrary.org.