### PR TITLE
Fix stopword position gap loss in text_en_splitting index analyzer

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -643,33 +643,41 @@
         <!-- in this example, we will only use synonyms at query time
         <filter name="synonymGraph" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
-        <!-- Case insensitive stop word removal.
-        -->
-        <!-- Disabling because it's causing a few issues with our queries. See https://github.com/internetarchive/openlibrary/issues/3317#issuecomment-837506502 -->
-        <!-- <filter name="stop"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        /> -->
         <filter name="icuFolding"/>
         <filter name="wordDelimiterGraph" types="wordtypes.txt" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter name="lowercase"/>
         <filter name="keywordMarker" protected="protwords.txt"/>
         <filter name="porterStem"/>
         <filter name="flattenGraph" />
+        <!-- Case insensitive stop word removal. Must run after flattenGraph: StopFilter
+             leaves a position gap for each removed stopword (e.g. two consecutive
+             stopwords leave a gap of 2), but flattenGraph mis-flattens gaps larger
+             than 1 when they occur upstream of it, silently shrinking them to 1 and
+             breaking phrase queries that span the removed words. Running stop last
+             means flattenGraph never sees a gap, only the graph wordDelimiterGraph
+             actually produced. See https://github.com/internetarchive/openlibrary/issues/5393
+        -->
+        <filter name="stop"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
       </analyzer>
       <analyzer type="query">
         <tokenizer name="whitespace"/>
         <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <!-- Disabling because it's causing a few issues with our queries. See https://github.com/internetarchive/openlibrary/issues/3317#issuecomment-837506502 -->
-        <!-- <filter name="stop"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        /> -->
         <filter name="icuFolding"/>
         <filter name="wordDelimiterGraph" types="wordtypes.txt" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter name="lowercase"/>
         <filter name="keywordMarker" protected="protwords.txt"/>
         <filter name="porterStem"/>
+        <!-- Kept in the same relative position as the index analyzer (last) for
+             symmetry, even though there's no flattenGraph here to interact with.
+             See https://github.com/internetarchive/openlibrary/issues/5393
+        -->
+        <filter name="stop"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
Closes #5393 .

StopFilter correctly leaves a position gap for each removed stopword (e.g. two consecutive stopwords like "of the" leave a gap of 2), but flattenGraph silently collapses gaps larger than 1 when they occur upstream of it in the chain, shrinking them down to 1. This desyncs the index-time and query-time token positions for any phrase spanning consecutive stopwords, breaking exact-phrase search.

Move the stop filter to run after flattenGraph (and word splitting/ stemming) on the index side, so flattenGraph only ever sees the graph wordDelimiterGraph actually produced, never a stopword-created hole. Mirrored the same ordering on the query side for symmetry, since the prior asymmetric ordering is what let this drift unnoticed.

Verified via Solr's field analysis API: index and query token positions now match exactly for phrases with consecutive stopwords (e.g. "The Mark of the Crown"), and word-delimiter splitting behavior (e.g. "Wi-Fi") is unaffected.

See https://github.com/internetarchive/openlibrary/issues/5393 and https://github.com/internetarchive/openlibrary/issues/3317#issuecomment-837506502

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@SomeInternet

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
