### PR TITLE
Fix: Render Search Inside above Read button for open-access books (#13308)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
 msgstr ""
 
-#: login.html openlibrary/plugins/upstream/forms.py
+#: login.html
 msgid "Email"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "Forgot your Internet Archive email?"
 msgstr ""
 
-#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+#: account/email/forgot-ia.html login.html
 msgid "Password"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: SearchAuthorSuggestion.html books/add.html books/edit.html books/edit/edition.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
+#: SearchAuthorSuggestion.html books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "All Time"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+#: home/index.html trending.html
 msgid "Trending Books"
 msgstr ""
 
@@ -966,7 +966,7 @@ msgstr ""
 msgid "Solr Editions"
 msgstr ""
 
-#: account/reading_log.html openlibrary/plugins/worksearch/code.py search/availability_i18n.html type/author/view.html work_search.html
+#: account/reading_log.html search/availability_i18n.html type/author/view.html work_search.html
 msgid "Readable Only"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Filter by availability"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
+#: search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
 msgstr ""
 
@@ -1033,7 +1033,7 @@ msgstr ""
 msgid "Authors"
 msgstr ""
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py work_search.html
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html work_search.html
 msgid "Books"
 msgstr ""
 
@@ -1098,11 +1098,11 @@ msgstr ""
 msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
 msgstr ""
 
-#: account/create.html openlibrary/plugins/upstream/forms.py
+#: account/create.html
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account/create.html openlibrary/plugins/upstream/forms.py
+#: account/create.html
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 
 #. Display name for the "already-read" reading log shelf used in page headings and breadcrumbs.
 #. Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1427,7 +1427,7 @@ msgstr ""
 msgid "My Reading Stats"
 msgstr ""
 
-#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html
 msgid "Loan History"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html
 msgid "Reviews"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "Click on a bar to see matching works"
 msgstr ""
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
 msgid "My Feed"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: admin/imports_by_date.html openlibrary/core/edits.py
+#: admin/imports_by_date.html
 msgid "Pending"
 msgstr ""
 
@@ -2362,7 +2362,7 @@ msgstr ""
 msgid "Admin Center"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html type/author/view.html type/list/view_body.html
 msgid "People"
 msgstr ""
 
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Anonymize Account"
 msgstr ""
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -3498,44 +3498,36 @@ msgstr ""
 msgid "in %(languagelist)s"
 msgstr ""
 
-#. Page title for the "Want to Read" shelf page.
-#. Example: "Want to Read (17)". %(count)d is the number of books on this shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#. Page title for the "Currently Reading" shelf page.
-#. Example: "Currently Reading (42)". %(count)d is the number of books on this shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#. Page title for the "Already Read" shelf page.
-#. Example: "Already Read (203)". %(count)d is the number of books on this shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
-#. Page title for the "Stopped Reading" shelf page.
-#. Example: "Stopped Reading (8)". %(count)d is the number of books on this shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Stopped Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: books/mybooks_breadcrumb_select.html
 msgid "Imports and Exports"
 msgstr ""
 
@@ -4348,7 +4340,7 @@ msgstr[1] ""
 msgid "Welcome to Open Library"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Classic Books"
 msgstr ""
 
@@ -4356,19 +4348,19 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#: home/index.html
 msgid "Romance"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Kids"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#: home/index.html
 msgid "Textbooks"
 msgstr ""
 
@@ -4571,7 +4563,7 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/browse_popover.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/browse_popover.html lib/nav_foot.html lib/nav_head.html subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
@@ -4656,7 +4648,7 @@ msgstr ""
 msgid "New!"
 msgstr ""
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html
 msgid "History"
 msgstr ""
 
@@ -4730,7 +4722,7 @@ msgstr ""
 msgid "Just a sentence or two is good."
 msgstr ""
 
-#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+#: lib/nav_foot.html site/head.html
 msgid "Open Library"
 msgstr ""
 
@@ -5345,11 +5337,11 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html openlibrary/core/edits.py
+#: merge_request_table/table_header.html
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html openlibrary/core/edits.py
+#: merge_request_table/table_header.html
 msgid "Declined"
 msgstr ""
 
@@ -5642,7 +5634,7 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
+#: publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr ""
 
@@ -5914,15 +5906,15 @@ msgstr ""
 msgid "No <strong>authors</strong> directly matched your search"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+#: search/availability_i18n.html
 msgid "All books"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+#: search/availability_i18n.html
 msgid "Free to read now"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+#: search/availability_i18n.html
 msgid "Borrow online"
 msgstr ""
 
@@ -6465,7 +6457,7 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -6921,7 +6913,7 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -7361,6 +7353,10 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
+#: LoanStatus.html
+msgid "Only a preview is available."
+msgstr ""
+
 #: LocateButton.html
 msgid "Locate"
 msgstr ""
@@ -7792,708 +7788,5 @@ msgstr ""
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
-msgstr ""
-
-#: openlibrary/core/bookshelves.py
-msgid "[Record deleted]"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Can be accessed in full online (read / borrowed)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Borrowable and readable books can be accessed by readers, researchers, and all patrons alike."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Can view snippets via search inside"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Books that allow search inside enable patrons to quickly find relevant content within the book."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Open access (can analyze in full)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Fully public books can be read online or downloaded without any restrictions, providing excellent access for patrons."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has purchase options"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "An ISBN, Amazon ASIN identifier, or BWB identifier enables patrons to purchase the book from retailers."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has library options (ISBN or OCLC)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "ISBN or OCLC numbers enable patrons to find the book through library catalogs."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has fan fiction link (Archive of Our Own)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A link to Archive of Our Own helps readers discover related fan-created works."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has Wikipedia link"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A Wikipedia link provides additional context and encyclopedic information about the work."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has first sentence"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "The first sentence gives patrons an immediate taste of the writing style."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has title field"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A title is essential for discovery and helps patrons identify the book in search results and catalogs."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has author information"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Author information is crucial for discovery and helps patrons find other works by the same author."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has genre/category tags"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Genre tags help patrons search by genre or category to discover relevant books."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has series information"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Series information helps patrons search by series and discover related books."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has table of contents"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Table of contents entries are indexed and searchable, improving discoverability."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has DDC or LCC classification"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Dewey Decimal or Library of Congress classifications help with organization and shelf browsing."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has language information"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Language information helps patrons filter and find books in their preferred language."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has ISBN"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "ISBNs allow searching by barcode scanner and help with identification."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has Lexile measure"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Lexile measures help educators and parents find books at the appropriate reading level."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has star ratings (ranking signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Star ratings contribute to search ranking so better-rated books surface higher."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Appears on reading logs (ranking signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Presence on reading logs is a popularity signal that helps with search ranking."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Appears on lists (ranking signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Presence on user lists is a popularity signal that helps with search ranking."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has contributor names"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Contributor names (editors, illustrators, translators) enable searching by contributor."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has a description"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A description helps patrons understand what the book is about before accessing it."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has cover image"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A cover image helps patrons visually identify the book and makes it more appealing in search results."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A table of contents helps patrons evaluate the structure and scope of the book."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Genre tags help patrons quickly assess whether a book matches their interests."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has star ratings (popularity signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Star ratings from other readers help patrons gauge the quality and reception of the book."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has a rich description (50+ characters)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "A detailed description (50+ characters) provides more context to help patrons evaluate relevance."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has reading log activity (popularity signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Reading log activity from other patrons signals the book is being actively read."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Appears on lists (popularity signal)"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Presence on curated lists helps patrons gauge relevance and community interest."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has page count"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Page count helps patrons estimate the length and time commitment of the book."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Series information helps patrons understand the book's place in a broader narrative."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has author photo"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "An author photo helps patrons visually recognize the author."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has first publication year"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "The first publication year helps patrons understand when the work originally appeared."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publication year"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Publication year helps patrons understand the context and currency of the content."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has author biography"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "An author biography helps patrons understand the author's background and expertise."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publisher"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Publisher information helps patrons evaluate the credibility and source of the book."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Has author links"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Links to author websites or profiles provide additional context about the author."
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Edition Scorecard"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Access"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Discovery"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "How well can this edition be accurately surfaced in searches and recommendations?"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "Evaluation"
-msgstr ""
-
-#: openlibrary/edition_scorecard.py
-msgid "How well can a patron determine if this edition is relevant to their needs before accessing it?"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/api.py
-msgid "Search Results"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Arabic"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Korean"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Romanian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Filipino"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 subject"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 author"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 edition"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has work (orphaned)"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has cover"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has language"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 2 editions"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has dewey decimal"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has LoC classification"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has number of pages"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Better World Books"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid " - includes shipping"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Amazon"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Bookshop.org"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "This work does not appear on any lists."
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/pd.py
-msgid "I don't have one yet"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The email address you entered is invalid"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been blocked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been locked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "No account was found with this email. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The password you entered is incorrect. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Wrong password. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Open Library account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please fill out all fields and try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This email is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This username is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email provider not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password requirements not met."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid "Request failed with error code: %(error_code)s"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Username unavailable"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
-msgid "Email already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "An Internet Archive account already exists with this email"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Verification failed. The link may be invalid or expired. Please try registering again."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Your email has been verified. You are now logged in."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Notification preferences have been updated successfully."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid "this book"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-#, python-format
-msgid "Unable to return %s. Please try again later or contact info@archive.org."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-#, python-format
-msgid "%s has been returned."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "No user registered with this email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Disposable email not permitted"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email provider is not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username already used"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 letters and numbers"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Screen Name"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Public and cannot be changed later."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Invalid password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Choose a password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/models.py
-#, python-format
-msgid "This merge cannot be undone automatically because %(record)s references %(reference)s, which no longer exists."
-msgstr ""
-
-#: openlibrary/plugins/upstream/models.py
-#, python-format
-msgid "This merge cannot be undone automatically because %(record)s references %(reference)s, which has since been merged into another record."
-msgstr ""
-
-#: openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Continue %(link_start)s%(action)s%(link_mid)s%(name)s%(link_end)s"
-msgstr ""
-
-#: openlibrary/plugins/upstream/recentchanges.py
-msgid "This change could not be undone automatically."
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
 msgstr ""
 
-#: login.html
+#: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "Forgot your Internet Archive email?"
 msgstr ""
 
-#: account/email/forgot-ia.html login.html
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: SearchAuthorSuggestion.html books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
+#: SearchAuthorSuggestion.html books/add.html books/edit.html books/edit/edition.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "All Time"
 msgstr ""
 
-#: home/index.html trending.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
 msgid "Trending Books"
 msgstr ""
 
@@ -966,7 +966,7 @@ msgstr ""
 msgid "Solr Editions"
 msgstr ""
 
-#: account/reading_log.html search/availability_i18n.html type/author/view.html work_search.html
+#: account/reading_log.html openlibrary/plugins/worksearch/code.py search/availability_i18n.html type/author/view.html work_search.html
 msgid "Readable Only"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Filter by availability"
 msgstr ""
 
-#: search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
+#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
 msgstr ""
 
@@ -1033,7 +1033,7 @@ msgstr ""
 msgid "Authors"
 msgstr ""
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html work_search.html
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py work_search.html
 msgid "Books"
 msgstr ""
 
@@ -1098,11 +1098,11 @@ msgstr ""
 msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
 msgstr ""
 
-#: account/create.html
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account/create.html
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 
 #. Display name for the "already-read" reading log shelf used in page headings and breadcrumbs.
 #. Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1427,7 +1427,7 @@ msgstr ""
 msgid "My Reading Stats"
 msgstr ""
 
-#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "Click on a bar to see matching works"
 msgstr ""
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: admin/imports_by_date.html
+#: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
 msgstr ""
 
@@ -2362,7 +2362,7 @@ msgstr ""
 msgid "Admin Center"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
 msgstr ""
 
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Anonymize Account"
 msgstr ""
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -3498,36 +3498,44 @@ msgstr ""
 msgid "in %(languagelist)s"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Stopped Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
 msgstr ""
 
@@ -4340,7 +4348,7 @@ msgstr[1] ""
 msgid "Welcome to Open Library"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
 msgstr ""
 
@@ -4348,19 +4356,19 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Kids"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr ""
 
@@ -4563,7 +4571,7 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/browse_popover.html lib/nav_foot.html lib/nav_head.html subjects/notfound.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/browse_popover.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
@@ -4648,7 +4656,7 @@ msgstr ""
 msgid "New!"
 msgstr ""
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr ""
 
@@ -4722,7 +4730,7 @@ msgstr ""
 msgid "Just a sentence or two is good."
 msgstr ""
 
-#: lib/nav_foot.html site/head.html
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
 msgstr ""
 
@@ -5337,11 +5345,11 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
 msgstr ""
 
@@ -5634,7 +5642,7 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr ""
 
@@ -5906,15 +5914,15 @@ msgstr ""
 msgid "No <strong>authors</strong> directly matched your search"
 msgstr ""
 
-#: search/availability_i18n.html
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "All books"
 msgstr ""
 
-#: search/availability_i18n.html
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "Free to read now"
 msgstr ""
 
-#: search/availability_i18n.html
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "Borrow online"
 msgstr ""
 
@@ -6457,7 +6465,7 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -6913,7 +6921,7 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -7788,5 +7796,708 @@ msgstr ""
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
+msgstr ""
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Can be accessed in full online (read / borrowed)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Borrowable and readable books can be accessed by readers, researchers, and all patrons alike."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Can view snippets via search inside"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Books that allow search inside enable patrons to quickly find relevant content within the book."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Open access (can analyze in full)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Fully public books can be read online or downloaded without any restrictions, providing excellent access for patrons."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has purchase options"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "An ISBN, Amazon ASIN identifier, or BWB identifier enables patrons to purchase the book from retailers."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has library options (ISBN or OCLC)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "ISBN or OCLC numbers enable patrons to find the book through library catalogs."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has fan fiction link (Archive of Our Own)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A link to Archive of Our Own helps readers discover related fan-created works."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has Wikipedia link"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A Wikipedia link provides additional context and encyclopedic information about the work."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has first sentence"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "The first sentence gives patrons an immediate taste of the writing style."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has title field"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A title is essential for discovery and helps patrons identify the book in search results and catalogs."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has author information"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Author information is crucial for discovery and helps patrons find other works by the same author."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has genre/category tags"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Genre tags help patrons search by genre or category to discover relevant books."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has series information"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Series information helps patrons search by series and discover related books."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has table of contents"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Table of contents entries are indexed and searchable, improving discoverability."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has DDC or LCC classification"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Dewey Decimal or Library of Congress classifications help with organization and shelf browsing."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has language information"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Language information helps patrons filter and find books in their preferred language."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has ISBN"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "ISBNs allow searching by barcode scanner and help with identification."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has Lexile measure"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Lexile measures help educators and parents find books at the appropriate reading level."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has star ratings (ranking signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Star ratings contribute to search ranking so better-rated books surface higher."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Appears on reading logs (ranking signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Presence on reading logs is a popularity signal that helps with search ranking."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Appears on lists (ranking signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Presence on user lists is a popularity signal that helps with search ranking."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has contributor names"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Contributor names (editors, illustrators, translators) enable searching by contributor."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has a description"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A description helps patrons understand what the book is about before accessing it."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has cover image"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A cover image helps patrons visually identify the book and makes it more appealing in search results."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A table of contents helps patrons evaluate the structure and scope of the book."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Genre tags help patrons quickly assess whether a book matches their interests."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has star ratings (popularity signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Star ratings from other readers help patrons gauge the quality and reception of the book."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has a rich description (50+ characters)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "A detailed description (50+ characters) provides more context to help patrons evaluate relevance."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has reading log activity (popularity signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Reading log activity from other patrons signals the book is being actively read."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Appears on lists (popularity signal)"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Presence on curated lists helps patrons gauge relevance and community interest."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has page count"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Page count helps patrons estimate the length and time commitment of the book."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Series information helps patrons understand the book's place in a broader narrative."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has author photo"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "An author photo helps patrons visually recognize the author."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has first publication year"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "The first publication year helps patrons understand when the work originally appeared."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Publication year helps patrons understand the context and currency of the content."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has author biography"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "An author biography helps patrons understand the author's background and expertise."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Publisher information helps patrons evaluate the credibility and source of the book."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Has author links"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Links to author websites or profiles provide additional context about the author."
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Edition Scorecard"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Access"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Discovery"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "How well can this edition be accurately surfaced in searches and recommendations?"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "Evaluation"
+msgstr ""
+
+#: openlibrary/edition_scorecard.py
+msgid "How well can a patron determine if this edition is relevant to their needs before accessing it?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/api.py
+msgid "Search Results"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Korean"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email has been verified. You are now logged in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "this book"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "%s has been returned."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/models.py
+#, python-format
+msgid "This merge cannot be undone automatically because %(record)s references %(reference)s, which no longer exists."
+msgstr ""
+
+#: openlibrary/plugins/upstream/models.py
+#, python-format
+msgid "This merge cannot be undone automatically because %(record)s references %(reference)s, which has since been merged into another record."
+msgstr ""
+
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue %(link_start)s%(action)s%(link_mid)s%(name)s%(link_end)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/recentchanges.py
+msgid "This change could not be undone automatically."
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -59,6 +59,8 @@ $def analytics_attr(action):
     data-ol-link-track="CTAClick|$action"
 
 $if lending_state == 'borrowed':
+  $if secondary_action:
+    $:macros.PreviewSearchInside(ocaid)
   $:macros.ReadButton(ocaid, analytics_attr, loan=user_loan, listen=listen, edition_key=edition_key, book_title=book_title)
   $if secondary_action:
     $:macros.ReturnForm(ocaid, user_loan['expiry'])
@@ -69,9 +71,9 @@ $elif lending_state == 'partner':
 
 $elif lending_state == 'open':
   $# Open / Publicly Readable (Unrestricted)
-  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
+  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
 
 $elif lending_state == 'printdisabled':
   $# Exemptions for patrons with Print Disabilities
@@ -149,9 +151,13 @@ $elif lending_state == 'checkedout':
   </div>
 
 $elif lending_state == 'preview_only':
-  $:macros.BookPreview(ocaid, show_only=True)
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
+  <div class="cta-button-group">
+    <p class="waitinglist-message">
+      <span>Only a preview is available.</span>
+    </p>
+  </div>
 
 $else:
   $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -59,6 +59,8 @@ $def analytics_attr(action):
     data-ol-link-track="CTAClick|$action"
 
 $if lending_state == 'borrowed':
+  $if secondary_action:
+    $:macros.PreviewSearchInside(ocaid)
   $:macros.ReadButton(ocaid, analytics_attr, loan=user_loan, listen=listen, edition_key=edition_key, book_title=book_title)
   $if secondary_action:
     $:macros.ReturnForm(ocaid, user_loan['expiry'])
@@ -69,9 +71,9 @@ $elif lending_state == 'partner':
 
 $elif lending_state == 'open':
   $# Open / Publicly Readable (Unrestricted)
-  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
+  $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
 
 $elif lending_state == 'printdisabled':
   $# Exemptions for patrons with Print Disabilities
@@ -149,9 +151,9 @@ $elif lending_state == 'checkedout':
   </div>
 
 $elif lending_state == 'preview_only':
-  $:macros.BookPreview(ocaid, show_only=True)
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
+  $:macros.BookPreview(ocaid, show_only=True)
 
 $else:
   $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -155,7 +155,7 @@ $elif lending_state == 'preview_only':
     $:macros.PreviewSearchInside(ocaid)
   <div class="cta-button-group">
     <p class="waitinglist-message">
-      <span>Only a preview is available.</span>
+      <span>$_("Only a preview is available.")</span>
     </p>
   </div>
 

--- a/static/css/components/read-panel.css
+++ b/static/css/components/read-panel.css
@@ -8,6 +8,7 @@
   white-space: nowrap;
   margin: 0 0 10px;
   font-size: var(--font-size-label-medium);
+  width: 100%;
 }
 
 .mobile-vendor {
@@ -42,7 +43,6 @@
   text-decoration: none;
   position: relative;
   margin: 0 auto;
-  margin-top: -15px; /* offsets Illustration margin-bottom: 10px */
   background-color: transparent;
   transition: background-color 0.2s;
 
@@ -80,7 +80,6 @@
 .btn-notice .waitinglist-message {
   margin: 0 0 10px;
   font-size: var(--font-size-label-medium);
-  text-wrap: auto;
 }
 
 .read-options .cta-section,


### PR DESCRIPTION
Closes #13308

### Summary
Fixes an ordering issue where "Search Inside" / preview controls were being rendered below the "Read" button for open-access books.

### Technical
In `openlibrary/macros/LoanStatus.html`, the `open`, `borrowed`, and `preview_only` branches rendered the primary action button (`ReadButton` / `BookPreview`) before `$if secondary_action: $:macros.PreviewSearchInside(ocaid)`.

Since `.cta-button-group` is a flex container without flex order overrides, DOM sequence dictates vertical stacking order. Moving `PreviewSearchInside` before the primary action button aligns these branches with all other lending states (`borrowable`, `printdisabled`, `checkedout`, `waitlist`), ensuring "Search Inside" consistently appears above the Read button across all book pages.

### Testing
1. Visit an open-access edition page (e.g., `/books/OL25997618M/Les_Misrables`).
3. Observe the CTA button group beneath the book cover.
4. Confirm "Search Inside" appears above the "Read" button.
5. Also verify with borrowed book, as well as preview_only book.

### Screenshot
1. Open Access
<img width="368" height="332" alt="image" src="https://github.com/user-attachments/assets/ed8ca5be-2778-4239-8e13-57d24bc0ea31" />

2. Borrowable - Borrow
<img width="369" height="184" alt="image" src="https://github.com/user-attachments/assets/22b9fda9-9b33-4012-965c-c6bc3f03c25b" />

3. Borrowable - Borrowed
<img width="380" height="329" alt="image" src="https://github.com/user-attachments/assets/acf78cf3-a453-40c8-9c0d-d635272b3e78" />

4. Preview Only (additional fix, removed negative margin-top that caused overlap.)
<img width="351" height="220" alt="image" src="https://github.com/user-attachments/assets/c842f29c-bdbd-4f46-a9bb-6f3c0dbbac6f" />


### Stakeholders
@lokesh @mekarpeles
