### PR TITLE
Only auto-run npm ci on LOCAL_DEV to speed up testing deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ all: git css js components lit-components i18n
 frontend: css js components lit-components
 
 node_modules: package-lock.json package.json
+ifeq ($(LOCAL_DEV),true)
 	npm ci --no-audit --no-fund
+endif
 
 css: node_modules
 	mkdir -p $(BUILD)/css_new


### PR DESCRIPTION
Fixes some testing slowness


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="515" height="110" alt="image" src="https://github.com/user-attachments/assets/241f40a2-c09d-4223-8316-0ba7c9ff7945" />

Before:
<img width="512" height="115" alt="image" src="https://github.com/user-attachments/assets/af351321-2de0-4154-a038-595ea5a244cb" />
After:
<img width="515" height="118" alt="image" src="https://github.com/user-attachments/assets/f49afea5-0f3c-4dff-97d8-dbccea05adc1" />



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
