### PR TITLE
fix(manifest): add explicit share_target enctype

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -17,7 +17,7 @@ $def with (title)
         <link rel="preconnect" href="https://apollo.archive.org">
 
     <link rel="search" type="application/opensearchdescription+xml" title="Open Library" href="/static/opensearch.xml">
-    <link rel="manifest" href="/static/manifest.json?v=2">
+    <link rel="manifest" href="$static_url('manifest.json')">
 
     <link href="/static/images/openlibrary-128x128.png" rel="apple-touch-icon" />
     <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -17,7 +17,7 @@ $def with (title)
         <link rel="preconnect" href="https://apollo.archive.org">
 
     <link rel="search" type="application/opensearchdescription+xml" title="Open Library" href="/static/opensearch.xml">
-    <link rel="manifest" href="/static/manifest.json">
+    <link rel="manifest" href="/static/manifest.json?v=2">
 
     <link href="/static/images/openlibrary-128x128.png" rel="apple-touch-icon" />
     <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -34,6 +34,7 @@
     "share_target": {
         "action": "/search",
         "method": "GET",
+        "enctype": "application/x-www-form-urlencoded",
         "params": {
             "text": "q"
         }


### PR DESCRIPTION
### What

Chrome logs a manifest warning on every page load:

> Manifest: Enctype should be set to either application/x-www-form-urlencoded or multipart/form-data. It currently defaults to application/x-www-form-urlencoded

This PR silences that warning by making the encoding explicit, and version-busts the manifest link so browsers fetch the updated manifest instead of serving a stale cached copy.

Note: For whatever reason, this only seems to happen on chrome, not ff or safari.

### Changes

- `static/manifest.json` — set `"enctype": "application/x-www-form-urlencoded"` on the existing `share_target` object. The `GET` method and `params` mapping are unchanged, so share behavior is identical.
- `openlibrary/templates/site/head.html` — change the manifest link to `/static/manifest.json?v=2` so the updated manifest is picked up immediately.

### Why

The `enctype` warning appears in the browser console on `localhost:8080` and on production. The share target already relies on the default encoding, so making it explicit is a no-op behaviorally but removes the browser warning and documents intent.

### Verification

- Fresh Chrome load of `/` after clearing cache/service workers: the manifest `enctype` warning is gone.

### Notes

- Bump the `?v=` query when the manifest content changes in the future, since it is a manual cache-buster.

