### PR TITLE
fix: popovers render underneath header

### DIFF
--- a/docs/ai/web-components.md
+++ b/docs/ai/web-components.md
@@ -261,15 +261,23 @@ Two UA-stylesheet behaviours bite every time:
 
 Browsers without the Popover API (Safari < 17, below [the Lit layer's floor](#focus-and-shadow-dom)) keep the plain `position: fixed` path, which is correct everywhere except under a containing-block ancestor. The detection is a module constant in `top-layer.js`; don't re-roll it.
 
-**Pick the overlay mechanism by shape** — three are already correct, and new overlays should join one of them rather than invent a fourth:
+**Pick the overlay mechanism by shape** — four are already correct, and new overlays should join one of them rather than invent a fifth:
 
 | Overlay shape | Mechanism | Why it escapes the trap |
 |---|---|---|
 | Anchored to a trigger (`ol-popover`, `ol-tooltip`) | Popover API via `utils/top-layer.js` | Top layer; containing block is always the viewport |
 | Modal (`ol-dialog`) | native `<dialog>.showModal()` | Promoted to the top layer by the browser — nothing to add |
 | Viewport-fixed, unanchored (`ol-toast-region`, `OpenLibraryOTP`) | portal to `document.body` | No transformed ancestor exists on that path — **an invariant, not an accident**: mount these on `body`, never inside page content |
+| Small panel anchored *inside* the component's own box (`OLMarkdownEditor`'s link/image/overflow menus) | in-flow `position: absolute` against a `position: relative` wrapper | Never reads viewport coordinates, so the containing-block trap cannot apply — but see the conditions below |
 
 Composed components (`ol-menu-popover`, `ol-select-popover`, `ol-options-popover`) render through `ol-popover` and inherit the fix — don't add a second panel.
+
+The fourth row is only safe while both conditions hold, and they are *not* enforced by anything:
+
+1. **The panel fits inside the scroll container.** `OLMarkdownEditor` wraps everything in `.editor-wrapper { max-height: 70vh; overflow-y: auto }`, and `overflow-x: visible` computes to `auto` next to it — so the container clips on both axes. Vertically there is headroom by construction (`.editor-input` is `min-height: 200px`, the panels are ~40px). Horizontally there is not: the link panel is `min-width: 260px`, and measured on the real edit surfaces it clears the right edge by 256–502px, but a container narrower than **~470px** pushes it 20–40px past and raises a horizontal scrollbar. The demo on `/developers/design` sits at 478px and is already 2px over.
+2. **The narrow-container mitigation actually fires.** It is a `@media (max-width: 767px)` rule that pins the panel `left`/`right` — keyed to the **viewport**, so a narrow editor inside a wide viewport gets nothing. A container query would be the honest fix if this ever needs one.
+
+Prefer `ol-popover` for anything larger, anything that must escape its container, or anything on a new surface. `OLMarkdownEditor` deliberately does not use it: its toolbar `preventDefault()`s mousedown to keep the ProseMirror selection alive while you type a URL, and `ol-popover` moves focus into the panel and restores it on close, which would apply the link to the wrong range.
 
 Components that call `getBoundingClientRect()` for *relative* measurement (`ol-segmented-control`'s pill offset, `OLReadMore`'s scroll check) are unaffected: a delta between two rects in the same coordinate space is transform-independent.
 

--- a/docs/ai/web-components.md
+++ b/docs/ai/web-components.md
@@ -500,6 +500,6 @@ _onPopoverOpen() {
 2. Register the component by adding an export to `openlibrary/components/lit/index.js`.
 3. Add JSDoc to the class documenting the public API — `@prop`, `@fires`, `@slot`, `@cssprop`, `@csspart` (see [Documenting the API](#documenting-the-api-custom-elements-manifest)). This drives the generated API tables; no hand-written prop tables.
 4. Regenerate the Custom Elements Manifest (`npm run build-assets:lit-manifest`) and commit the updated `openlibrary/components/lit/custom-elements.json`.
-5. Add a demo `<section>` for the component to `openlibrary/templates/design.html` — the API tables render automatically from the manifest.
+5. Add a demo partial at `openlibrary/templates/design/components/<id>.html.jinja` defining a `{% macro demos() %}` of `ex.example(...)` calls, and register a `Component(...)` row in `COMPONENTS` in `openlibrary/plugins/openlibrary/design.py`. The row drives the sidebar, section order, and the *Use when* / *Avoid* lines; the API table renders from the manifest. Nothing on the page is hand-listed — `openlibrary/templates/design.html` is only a shim into `design/layout.html.jinja`, so there is no section markup to add there.
 6. If it renders an anchored overlay panel, promote it to the top layer — see [Overlays and the top layer](#overlays-and-the-top-layer).
 7. Build with `npm run watch:lit-components` and verify the component renders at http://localhost:8080/developers/design.

--- a/docs/ai/web-components.md
+++ b/docs/ai/web-components.md
@@ -233,6 +233,46 @@ Otherwise stay in shadow DOM: you keep style encapsulation, real `<slot>` compos
 - Use OL design tokens where possible. Token files live in `static/css/tokens/`.
 - Avoid outer margins on reusable components — spacing between elements is the parent's responsibility.
 
+## Overlays and the top layer
+
+Any panel that is **anchored to a trigger and positioned from viewport coordinates** — a popover, tooltip, menu, picker — must be promoted to the **top layer**. `position: fixed` is not enough and is the single most common way an overlay ships broken.
+
+A fixed element's containing block is the viewport *only* if no ancestor establishes one. `transform`, `filter`, `perspective`, `backdrop-filter`, `contain` and `will-change` all do — including a bare `translateZ(0)` someone added for GPU compositing, and the transformed track inside a carousel. Under one of those, coordinates read from `getBoundingClientRect()` are resolved against the wrong origin and the panel lands far from its trigger, clipped by the container. Measured on the design-system docs inside a `translateZ(0)` wrapper: **`ol-popover` 441×364px off, `ol-tooltip` 436×367px off**. The top layer also escapes ancestor `isolation: isolate` and z-index stacking, which no z-index value can.
+
+Use `utils/top-layer.js` rather than reaching for the Popover API directly:
+
+```js
+import { topLayerAttr, promoteToTopLayer, demoteFromTopLayer } from './utils/top-layer.js';
+
+// In render() — emits nothing when the browser lacks support
+html`<div class="panel" popover="${ifDefined(topLayerAttr())}">…</div>`;
+
+// On show, BEFORE measuring; on hide, in your teardown path
+promoteToTopLayer(panel);
+demoteFromTopLayer(panel);
+```
+
+**Always `manual`, never `auto`.** `auto` brings light-dismiss and force-closes sibling popovers outside the ancestor chain, which silently collapses a component's own nesting and dismissal handling (`ol-popover` keeps an open-popover stack so Escape dismisses one layer at a time).
+
+Two UA-stylesheet behaviours bite every time:
+
+1. **`[popover]` is `display: none` until shown.** Promote *before* measuring or `offsetWidth`/`offsetHeight` read 0 and the collision math silently works from a zero-sized panel.
+2. **The UA sets `inset: 0`, `margin: auto`, `width`/`height: fit-content`, `border`, `padding`, `overflow` and system colors on `[popover]`.** Author styles win by cascade origin — but *only for properties they actually declare*. Anything left undeclared inherits the UA value. Both bugs found this way were undeclared properties: `fit-content` beat `inset: 0` and collapsed `ol-popover`'s mobile backdrop to **0×0** (losing the dimming layer and its tap-to-dismiss target), and an undeclared `inset` on `.tooltip` would have combined with the inline `top` to stretch the tooltip to the viewport floor. Add an explicit `.panel[popover] { … }` reset next to the base rule, and place it *before* any variant rule (e.g. `.panel.tray`) that restates its own `inset`/`margin` — they carry equal specificity, so source order decides.
+
+Browsers without the Popover API (Safari < 17, below [the Lit layer's floor](#focus-and-shadow-dom)) keep the plain `position: fixed` path, which is correct everywhere except under a containing-block ancestor. The detection is a module constant in `top-layer.js`; don't re-roll it.
+
+**Pick the overlay mechanism by shape** — three are already correct, and new overlays should join one of them rather than invent a fourth:
+
+| Overlay shape | Mechanism | Why it escapes the trap |
+|---|---|---|
+| Anchored to a trigger (`ol-popover`, `ol-tooltip`) | Popover API via `utils/top-layer.js` | Top layer; containing block is always the viewport |
+| Modal (`ol-dialog`) | native `<dialog>.showModal()` | Promoted to the top layer by the browser — nothing to add |
+| Viewport-fixed, unanchored (`ol-toast-region`, `OpenLibraryOTP`) | portal to `document.body` | No transformed ancestor exists on that path — **an invariant, not an accident**: mount these on `body`, never inside page content |
+
+Composed components (`ol-menu-popover`, `ol-select-popover`, `ol-options-popover`) render through `ol-popover` and inherit the fix — don't add a second panel.
+
+Components that call `getBoundingClientRect()` for *relative* measurement (`ol-segmented-control`'s pill offset, `OLReadMore`'s scroll check) are unaffected: a delta between two rects in the same coordinate space is transform-independent.
+
 ## Lifecycle and Performance
 
 - Clean up listeners, observers, and timers in `disconnectedCallback`.
@@ -461,4 +501,5 @@ _onPopoverOpen() {
 3. Add JSDoc to the class documenting the public API — `@prop`, `@fires`, `@slot`, `@cssprop`, `@csspart` (see [Documenting the API](#documenting-the-api-custom-elements-manifest)). This drives the generated API tables; no hand-written prop tables.
 4. Regenerate the Custom Elements Manifest (`npm run build-assets:lit-manifest`) and commit the updated `openlibrary/components/lit/custom-elements.json`.
 5. Add a demo `<section>` for the component to `openlibrary/templates/design.html` — the API tables render automatically from the manifest.
-6. Build with `npm run watch:lit-components` and verify the component renders at http://localhost:8080/developers/design.
+6. If it renders an anchored overlay panel, promote it to the top layer — see [Overlays and the top layer](#overlays-and-the-top-layer).
+7. Build with `npm run watch:lit-components` and verify the component renders at http://localhost:8080/developers/design.

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  * A WYSIWYG markdown editor built on Tiptap.
@@ -494,6 +495,20 @@ export class OLMarkdownEditor extends LitElement {
         if (!e.target.closest('.toolbar-btn')) e.preventDefault();
     }
 
+    /**
+     * Escape closes the overflow menu and returns focus to its trigger, which
+     * would otherwise be removed from the DOM under the user's focus. Scoped to
+     * the menu's wrapper — the link and image inputs handle their own Escape.
+     */
+    _handleOverflowKeydown(e) {
+        if (e.key !== 'Escape' || !this.showOverflowMenu) return;
+        e.stopPropagation();
+        this.showOverflowMenu = false;
+        this.updateComplete.then(() => {
+            this.shadowRoot.querySelector('.overflow-menu-wrapper .toolbar-btn')?.focus();
+        });
+    }
+
     _focusEditor(e) {
         if (!this.editor) return;
         if (e && e.target.closest('.html-block')) return;
@@ -605,7 +620,13 @@ export class OLMarkdownEditor extends LitElement {
         }));
     }
 
-    _renderButton({ title, icon, action, isActive = false, isDisabled = false, customColor = null }) {
+    /**
+     * `isPressed` defaults to `isActive` so plain format toggles need nothing
+     * extra; pass `null` for a disclosure trigger, where `aria-pressed` would
+     * claim a formatting state the button doesn't have. `isExpanded` marks the
+     * button as a disclosure and reflects whether its panel is open.
+     */
+    _renderButton({ title, icon, action, isActive = false, isDisabled = false, customColor = null, isPressed = isActive, isExpanded = null }) {
         const isBtnDisabled = !this.editor || isDisabled;
 
         return html`
@@ -613,7 +634,8 @@ export class OLMarkdownEditor extends LitElement {
         type="button"
         title="${title}"
         aria-label="${title}"
-        aria-pressed="${isActive}"
+        aria-pressed="${ifDefined(isPressed === null ? undefined : isPressed)}"
+        aria-expanded="${ifDefined(isExpanded === null ? undefined : isExpanded)}"
         class="toolbar-btn ${isActive ? 'is-active' : ''}"
         style="${customColor ? `color: ${customColor};` : ''}"
         @click="${action}"
@@ -661,7 +683,7 @@ export class OLMarkdownEditor extends LitElement {
             ${this._renderButton({ title: 'Bold', icon: ICONS.bold, action: () => this.formatText('bold'), isActive: this._isActive('bold') })}
             ${this._renderButton({ title: 'Italic', icon: ICONS.italic, action: () => this.formatText('italic'), isActive: this._isActive('italic') })}
             <div class="link-popover-wrapper">
-              ${this._renderButton({ title: 'Link', icon: ICONS.link, action: this.toggleLinkPopover.bind(this), isActive: this._isActive('link') || this.showLinkPopover })}
+              ${this._renderButton({ title: 'Link', icon: ICONS.link, action: this.toggleLinkPopover.bind(this), isActive: this._isActive('link') || this.showLinkPopover, isPressed: this._isActive('link'), isExpanded: this.showLinkPopover })}
               ${this.showLinkPopover ? html`
                 <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
                   <input type="url" class="link-input" placeholder="https://..." .value="${this.linkInputValue}" @input="${this.handleLinkInput}" @keydown="${this.handleLinkKeydown}" />
@@ -672,7 +694,7 @@ export class OLMarkdownEditor extends LitElement {
             </div>
             <div class="link-popover-wrapper">
               <span class="overflow-secondary">
-                ${this._renderButton({ title: 'Image', icon: ICONS.image, action: this.toggleImagePopover.bind(this), isActive: this.showImagePopover })}
+                ${this._renderButton({ title: 'Image', icon: ICONS.image, action: this.toggleImagePopover.bind(this), isActive: this.showImagePopover, isPressed: null, isExpanded: this.showImagePopover })}
               </span>
               ${this.showImagePopover ? html`
                 <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
@@ -692,8 +714,8 @@ export class OLMarkdownEditor extends LitElement {
               ${this.enableCode ? this._renderButton({ title: 'Code Block', icon: ICONS.codeBlock, action: this.formatCodeBlock.bind(this), isActive: this._isActive('codeBlock') }) : ''}
               ${this.enableHtmlBlock ? this._renderButton({ title: 'HTML Block', icon: ICONS.code, action: this.insertHtmlBlock.bind(this) }) : ''}
             </span>
-            <div class="overflow-menu-wrapper overflow-toggle">
-              ${this._renderButton({ title: 'More', icon: ICONS.more, action: () => { this.showOverflowMenu = !this.showOverflowMenu; if (this.showOverflowMenu) this.showLinkPopover = false; }, isActive: this.showOverflowMenu })}
+            <div class="overflow-menu-wrapper overflow-toggle" @keydown="${this._handleOverflowKeydown}">
+              ${this._renderButton({ title: 'More', icon: ICONS.more, action: () => { this.showOverflowMenu = !this.showOverflowMenu; if (this.showOverflowMenu) this.showLinkPopover = false; }, isActive: this.showOverflowMenu, isPressed: null, isExpanded: this.showOverflowMenu })}
               ${this.showOverflowMenu ? html`
                 <div class="overflow-menu" @mousedown="${(e) => e.stopPropagation()}">
                   ${secondaryButtons}

--- a/openlibrary/components/lit/OlPopover.js
+++ b/openlibrary/components/lit/OlPopover.js
@@ -7,6 +7,13 @@ import { topLayerAttr, promoteToTopLayer, demoteFromTopLayer } from './utils/top
 let _idCounter = 0;
 
 /**
+ * How long to wait for the exit `transitionend` before finishing the close
+ * ourselves. Comfortably past the longest exit transition (150ms panel, 200ms
+ * tray) so it never truncates a real animation.
+ */
+const CLOSE_FALLBACK_MS = 400;
+
+/**
  * Open popovers, topmost (most recently shown) last. Escape is a document-level
  * listener, so every open popover sees the keypress; consulting this stack lets
  * only the innermost popover close, dismissing one layer at a time when popovers
@@ -304,6 +311,7 @@ export class OlPopover extends LitElement {
         this._panelId = `ol-popover-${++_idCounter}`;
         this._prevFocus = null;
         this._rafId = null;
+        this._closeFallbackId = null;
 
         // Touch drag state
         this._touchStartY = 0;
@@ -398,6 +406,9 @@ export class OlPopover extends LitElement {
     // ── Show / Hide ─────────────────────────────────────────────
 
     _show() {
+        // Reopening mid-exit cancels the pending close rather than letting its
+        // timer fire into the reopened popover.
+        this._clearCloseFallback();
         this._prevFocus = getDeepActiveElement();
 
         document.addEventListener('click', this._onOutsideClick, true);
@@ -413,7 +424,10 @@ export class OlPopover extends LitElement {
         this._mobile = window.matchMedia('(max-width: 767px)').matches;
         const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-        if (this._mobile) {
+        // Guard on _scrollLocked: reopening during the exit transition would take
+        // a second refcount that the single _releaseScrollLock() never gives
+        // back, pinning <body> for good.
+        if (this._mobile && !this._scrollLocked) {
             lockBodyScroll();
             this._scrollLocked = true;
         }
@@ -486,6 +500,36 @@ export class OlPopover extends LitElement {
         }
 
         this._animState = 'exiting';
+        this._armCloseFallback();
+    }
+
+    /**
+     * `transitionend` drives the whole close path — top-layer demotion, listener
+     * removal, scroll unlock, focus restore — so a transition that never runs
+     * strands the panel in the top layer, above the page, holding focus inside a
+     * `role="dialog"` whose trigger already reports `aria-expanded="false"`.
+     *
+     * Two ways to miss the event: a backgrounded tab paints no frames, so the
+     * transition never starts; and closing while still in "preparing" changes no
+     * property at all (preparing and exiting both compute to `opacity: 0` with
+     * the same transform), so nothing transitions. Finish the close on a timer
+     * when the event doesn't arrive.
+     */
+    _armCloseFallback() {
+        this._clearCloseFallback();
+        this._closeFallbackId = setTimeout(() => {
+            this._closeFallbackId = null;
+            if (this._animState !== 'exiting') return;
+            this._animState = 'closed';
+            this._cleanup();
+        }, CLOSE_FALLBACK_MS);
+    }
+
+    _clearCloseFallback() {
+        if (this._closeFallbackId) {
+            clearTimeout(this._closeFallbackId);
+            this._closeFallbackId = null;
+        }
     }
 
     _onTransitionEnd(e) {
@@ -504,6 +548,7 @@ export class OlPopover extends LitElement {
      * Removes all global listeners, unlocks scroll, and restores focus.
      */
     _cleanup() {
+        this._clearCloseFallback();
         this._removeListeners();
         this._releaseScrollLock();
         demoteFromTopLayer(this.shadowRoot?.querySelector('.panel'));
@@ -919,6 +964,7 @@ export class OlPopover extends LitElement {
 
     disconnectedCallback() {
         super.disconnectedCallback();
+        this._clearCloseFallback();
         this._removeListeners();
         this._releaseScrollLock();
     }

--- a/openlibrary/components/lit/OlPopover.js
+++ b/openlibrary/components/lit/OlPopover.js
@@ -6,6 +6,46 @@ import { getDeepActiveElement, getTabbableFromSlot } from './utils/focus-utils.j
 let _idCounter = 0;
 
 /**
+ * Whether the browser supports the Popover API (Chrome 114, Safari 17, Firefox 125).
+ * When it does, the panel is promoted to the **top layer**, whose containing block
+ * is always the viewport. Without it, `position: fixed` resolves against the
+ * nearest transformed ancestor instead — so a popover inside any transformed
+ * container (a carousel track, a `will-change` element) renders hundreds of pixels
+ * off and gets clipped. The top layer also escapes ancestor `isolation: isolate`
+ * and z-index stacking. Older browsers keep the plain `position: fixed` path,
+ * which is correct everywhere except under a transformed ancestor.
+ */
+const SUPPORTS_TOP_LAYER =
+    typeof HTMLElement !== 'undefined' &&
+    typeof HTMLElement.prototype.showPopover === 'function';
+
+/**
+ * Show `el` in the top layer, tolerating the states that make `showPopover()`
+ * throw (already open, not yet connected).
+ */
+function _promoteToTopLayer(el) {
+    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
+    if (el.matches(':popover-open')) return;
+    try {
+        el.showPopover();
+    } catch {
+        // Not promotable (disconnected mid-flight) — the fixed-position
+        // fallback still paints it in the right place off a transform.
+    }
+}
+
+/** Drop `el` out of the top layer, tolerating an already-hidden element. */
+function _demoteFromTopLayer(el) {
+    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
+    if (!el.matches(':popover-open')) return;
+    try {
+        el.hidePopover();
+    } catch {
+        // Already hidden by removal from the DOM.
+    }
+}
+
+/**
  * Open popovers, topmost (most recently shown) last. Escape is a document-level
  * listener, so every open popover sees the keypress; consulting this stack lets
  * only the innermost popover close, dismissing one layer at a time when popovers
@@ -24,8 +64,12 @@ function _removeFromOverlayStack(el) {
  * A reusable popover component that anchors to a trigger element.
  *
  * Renders a trigger slot and a popover panel that opens/closes with animation.
- * The popover uses `position: fixed` to escape overflow clipping and animates
- * from the trigger's location using `transform-origin`.
+ * The panel is promoted to the top layer via the Popover API so it escapes
+ * overflow clipping, ancestor transforms and z-index stacking, falling back to
+ * plain `position: fixed` on browsers without it. It animates from the trigger's
+ * location using `transform-origin`. The `popover` type is `manual`, not `auto`:
+ * this component owns its Escape, outside-click and nesting behaviour, and
+ * `auto` would force-close sibling popovers outside the ancestor chain.
  *
  * Self-manages open state by default — clicking the slotted trigger toggles
  * the popover, Escape and outside-click close it. Consumers can drive `open`
@@ -106,6 +150,21 @@ export class OlPopover extends LitElement {
             pointer-events: none;
         }
 
+        /* Neutralize the UA's [popover] defaults (inset: 0, margin: auto,
+           border, padding, overflow, system colors) so the top-layer panel is
+           laid out purely by the inline top/left we compute. Must precede
+           .panel.tray, which restates its own inset and margin. */
+        .panel[popover] {
+            inset: auto;
+            width: auto;
+            height: auto;
+            margin: 0;
+            padding: 0;
+            border: none;
+            overflow: visible;
+            color: inherit;
+        }
+
         .panel[data-state="preparing"],
         .panel[data-state="entering"] {
             will-change: transform, opacity;
@@ -140,6 +199,14 @@ export class OlPopover extends LitElement {
             position: fixed;
             inset: 0;
             z-index: var(--z-index-dropdown);
+            /* Undo the UA [popover] defaults. width/height matter most: the UA's
+               fit-content beats inset: 0, collapsing the backdrop to 0x0 and
+               taking the dimming layer and its tap-to-dismiss target with it. */
+            width: auto;
+            height: auto;
+            margin: 0;
+            padding: 0;
+            border: none;
             background: hsla(0, 0%, 0%, 0.3);
             opacity: 0;
             backdrop-filter: blur(1px);
@@ -301,6 +368,7 @@ export class OlPopover extends LitElement {
                 ${this._mobile ? html`
                     <div
                         class="backdrop"
+                        popover="${ifDefined(SUPPORTS_TOP_LAYER ? 'manual' : undefined)}"
                         data-state="${this._animState}"
                         @click="${this._onBackdropClick}"
                     ></div>
@@ -320,6 +388,7 @@ export class OlPopover extends LitElement {
                 <div
                     id="${this._panelId}"
                     class="panel ${this._mobile ? 'tray' : ''}"
+                    popover="${ifDefined(SUPPORTS_TOP_LAYER ? 'manual' : undefined)}"
                     data-state="${this._animState}"
                     role="dialog"
                     aria-label="${ifDefined(this.getAttribute('aria-label') || undefined)}"
@@ -399,6 +468,12 @@ export class OlPopover extends LitElement {
             const panel = this.shadowRoot.querySelector('.panel');
             if (!panel) return;
 
+            // Promote to the top layer before measuring — a [popover] element is
+            // `display: none` until shown, so offsetWidth/Height would read 0.
+            // Backdrop first: within the top layer, later-shown paints on top.
+            _promoteToTopLayer(this.shadowRoot.querySelector('.backdrop'));
+            _promoteToTopLayer(panel);
+
             // Desktop: measure and position relative to trigger.
             // Use offsetWidth/Height — getBoundingClientRect includes the
             // scale(0.95) transform from the preparing state, under-reporting
@@ -470,6 +545,8 @@ export class OlPopover extends LitElement {
     _cleanup() {
         this._removeListeners();
         this._releaseScrollLock();
+        _demoteFromTopLayer(this.shadowRoot?.querySelector('.panel'));
+        _demoteFromTopLayer(this.shadowRoot?.querySelector('.backdrop'));
         this._restoreFocus();
     }
 

--- a/openlibrary/components/lit/OlPopover.js
+++ b/openlibrary/components/lit/OlPopover.js
@@ -2,48 +2,9 @@ import { LitElement, html, css, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { lockBodyScroll, unlockBodyScroll } from './utils/scroll-lock.js';
 import { getDeepActiveElement, getTabbableFromSlot } from './utils/focus-utils.js';
+import { topLayerAttr, promoteToTopLayer, demoteFromTopLayer } from './utils/top-layer.js';
 
 let _idCounter = 0;
-
-/**
- * Whether the browser supports the Popover API (Chrome 114, Safari 17, Firefox 125).
- * When it does, the panel is promoted to the **top layer**, whose containing block
- * is always the viewport. Without it, `position: fixed` resolves against the
- * nearest transformed ancestor instead — so a popover inside any transformed
- * container (a carousel track, a `will-change` element) renders hundreds of pixels
- * off and gets clipped. The top layer also escapes ancestor `isolation: isolate`
- * and z-index stacking. Older browsers keep the plain `position: fixed` path,
- * which is correct everywhere except under a transformed ancestor.
- */
-const SUPPORTS_TOP_LAYER =
-    typeof HTMLElement !== 'undefined' &&
-    typeof HTMLElement.prototype.showPopover === 'function';
-
-/**
- * Show `el` in the top layer, tolerating the states that make `showPopover()`
- * throw (already open, not yet connected).
- */
-function _promoteToTopLayer(el) {
-    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
-    if (el.matches(':popover-open')) return;
-    try {
-        el.showPopover();
-    } catch {
-        // Not promotable (disconnected mid-flight) — the fixed-position
-        // fallback still paints it in the right place off a transform.
-    }
-}
-
-/** Drop `el` out of the top layer, tolerating an already-hidden element. */
-function _demoteFromTopLayer(el) {
-    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
-    if (!el.matches(':popover-open')) return;
-    try {
-        el.hidePopover();
-    } catch {
-        // Already hidden by removal from the DOM.
-    }
-}
 
 /**
  * Open popovers, topmost (most recently shown) last. Escape is a document-level
@@ -368,7 +329,7 @@ export class OlPopover extends LitElement {
                 ${this._mobile ? html`
                     <div
                         class="backdrop"
-                        popover="${ifDefined(SUPPORTS_TOP_LAYER ? 'manual' : undefined)}"
+                        popover="${ifDefined(topLayerAttr())}"
                         data-state="${this._animState}"
                         @click="${this._onBackdropClick}"
                     ></div>
@@ -388,7 +349,7 @@ export class OlPopover extends LitElement {
                 <div
                     id="${this._panelId}"
                     class="panel ${this._mobile ? 'tray' : ''}"
-                    popover="${ifDefined(SUPPORTS_TOP_LAYER ? 'manual' : undefined)}"
+                    popover="${ifDefined(topLayerAttr())}"
                     data-state="${this._animState}"
                     role="dialog"
                     aria-label="${ifDefined(this.getAttribute('aria-label') || undefined)}"
@@ -471,8 +432,8 @@ export class OlPopover extends LitElement {
             // Promote to the top layer before measuring — a [popover] element is
             // `display: none` until shown, so offsetWidth/Height would read 0.
             // Backdrop first: within the top layer, later-shown paints on top.
-            _promoteToTopLayer(this.shadowRoot.querySelector('.backdrop'));
-            _promoteToTopLayer(panel);
+            promoteToTopLayer(this.shadowRoot.querySelector('.backdrop'));
+            promoteToTopLayer(panel);
 
             // Desktop: measure and position relative to trigger.
             // Use offsetWidth/Height — getBoundingClientRect includes the
@@ -545,8 +506,8 @@ export class OlPopover extends LitElement {
     _cleanup() {
         this._removeListeners();
         this._releaseScrollLock();
-        _demoteFromTopLayer(this.shadowRoot?.querySelector('.panel'));
-        _demoteFromTopLayer(this.shadowRoot?.querySelector('.backdrop'));
+        demoteFromTopLayer(this.shadowRoot?.querySelector('.panel'));
+        demoteFromTopLayer(this.shadowRoot?.querySelector('.backdrop'));
         this._restoreFocus();
     }
 

--- a/openlibrary/components/lit/OlTooltip.js
+++ b/openlibrary/components/lit/OlTooltip.js
@@ -1,4 +1,6 @@
 import { LitElement, html, css, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { topLayerAttr, promoteToTopLayer, demoteFromTopLayer } from './utils/top-layer.js';
 
 /**
  * A tooltip component that displays contextual information on hover/focus.
@@ -7,6 +9,10 @@ import { LitElement, html, css, nothing } from 'lit';
  * and arrow. The tooltip appears after a short delay and is shown/hidden
  * instantly with no animation. Each tooltip is independent — moving from one
  * trigger to another hides the old tooltip and shows the new one.
+ *
+ * The panel is promoted to the top layer via the Popover API so it escapes
+ * overflow clipping, ancestor transforms and z-index stacking, falling back to
+ * plain `position: fixed` on browsers without it. See ./utils/top-layer.js.
  *
  * @element ol-tooltip
  *
@@ -76,6 +82,17 @@ export class OlTooltip extends LitElement {
             pointer-events: none;
             user-select: none;
             width: max-content;
+        }
+
+        /* Undo the UA [popover] defaults this rule does not already override.
+           inset matters most: the UA's inset: 0 combines with our inline top
+           to stretch the tooltip down to the viewport floor. */
+        .tooltip[popover] {
+            inset: auto;
+            height: auto;
+            margin: 0;
+            border: none;
+            overflow: visible;
         }
 
         .tooltip[data-visible] {
@@ -172,6 +189,7 @@ export class OlTooltip extends LitElement {
                 class="tooltip"
                 id="${this._tooltipId}"
                 role="tooltip"
+                popover="${ifDefined(topLayerAttr())}"
                 ?data-visible="${this._visible}"
                 style="top: ${this._position.top}px; left: ${this._position.left}px;"
             >
@@ -266,6 +284,10 @@ export class OlTooltip extends LitElement {
             const tooltip = this.shadowRoot.querySelector('.tooltip');
             if (!tooltip) return;
 
+            // Promote before measuring — a [popover] element is display: none
+            // until shown, so offsetWidth/Height would read 0.
+            promoteToTopLayer(tooltip);
+
             this._computePosition(tooltip.offsetWidth, tooltip.offsetHeight);
             this.dispatchEvent(new CustomEvent('ol-tooltip-show', {
                 bubbles: true, composed: true
@@ -277,6 +299,7 @@ export class OlTooltip extends LitElement {
         if (!this._visible) return;
 
         window.removeEventListener('scroll', this._onScroll, true);
+        demoteFromTopLayer(this.shadowRoot?.querySelector('.tooltip'));
         this._visible = false;
         this.dispatchEvent(new CustomEvent('ol-tooltip-hide', {
             bubbles: true, composed: true
@@ -418,4 +441,6 @@ export class OlTooltip extends LitElement {
     }
 }
 
-customElements.define('ol-tooltip', OlTooltip);
+if (!customElements.get('ol-tooltip')) {
+    customElements.define('ol-tooltip', OlTooltip);
+}

--- a/openlibrary/components/lit/utils/top-layer.js
+++ b/openlibrary/components/lit/utils/top-layer.js
@@ -1,0 +1,83 @@
+/**
+ * Top-layer promotion for anchored overlay panels (popovers, tooltips).
+ *
+ * Overlay panels are positioned from viewport coordinates read off the
+ * trigger's `getBoundingClientRect()`. Plain `position: fixed` looks like the
+ * right way to paint them, but a fixed element's containing block is the
+ * nearest *transformed* ancestor rather than the viewport — and `transform`,
+ * `filter`, `perspective`, `backdrop-filter`, `contain` and `will-change` all
+ * create one. Inside a carousel track (or any such container) the panel is
+ * measured against the wrong origin and lands hundreds of pixels off its
+ * trigger, clipped by the container's bounds.
+ *
+ * The top layer sidesteps all of it: its containing block is always the
+ * viewport, and it paints above the page regardless of ancestor
+ * `isolation: isolate` or z-index stacking.
+ *
+ * Browsers without the Popover API (Safari < 17) keep the plain
+ * `position: fixed` path, which is correct everywhere except under one of
+ * those containing-block ancestors.
+ *
+ * Two UA-stylesheet behaviours callers must handle in their own CSS and
+ * sequencing:
+ *
+ * 1. `[popover]` is `display: none` until shown — promote a panel *before*
+ *    measuring it, or `offsetWidth`/`offsetHeight` read 0.
+ * 2. The UA sets `inset: 0`, `margin: auto`, `width`/`height: fit-content`,
+ *    `border`, `padding`, `overflow` and system colors on `[popover]`. Author
+ *    styles win by cascade origin, but only for properties they actually
+ *    declare — anything left undeclared silently inherits the UA value. The
+ *    `fit-content` sizing in particular beats `inset: 0`, collapsing a
+ *    full-viewport overlay to 0x0.
+ */
+
+/** Whether the browser supports the Popover API (Chrome 114, Safari 17, Firefox 125). */
+export const SUPPORTS_TOP_LAYER =
+    typeof HTMLElement !== 'undefined' &&
+    typeof HTMLElement.prototype.showPopover === 'function';
+
+/**
+ * The `popover` attribute value to render on a promotable panel, or `undefined`
+ * when the browser lacks support (so no attribute is emitted).
+ *
+ * Always `manual`, never `auto`: `auto` brings light-dismiss and force-closes
+ * sibling popovers outside the ancestor chain, which would collapse a
+ * component's own nesting and dismissal handling.
+ *
+ * @returns {String|undefined}
+ */
+export function topLayerAttr() {
+    return SUPPORTS_TOP_LAYER ? 'manual' : undefined;
+}
+
+/**
+ * Show `el` in the top layer, tolerating the states that make `showPopover()`
+ * throw (already showing, not connected to the document).
+ *
+ * @param {Element|null|undefined} el
+ */
+export function promoteToTopLayer(el) {
+    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
+    if (el.matches(':popover-open')) return;
+    try {
+        el.showPopover();
+    } catch {
+        // Not promotable (disconnected mid-flight) — the position: fixed
+        // fallback still paints it correctly off a transform.
+    }
+}
+
+/**
+ * Drop `el` out of the top layer, tolerating an already-hidden element.
+ *
+ * @param {Element|null|undefined} el
+ */
+export function demoteFromTopLayer(el) {
+    if (!SUPPORTS_TOP_LAYER || !el || !el.isConnected) return;
+    if (!el.matches(':popover-open')) return;
+    try {
+        el.hidePopover();
+    } catch {
+        // Already hidden, e.g. by removal from the DOM.
+    }
+}

--- a/tests/unit/js/OlPopover.test.js
+++ b/tests/unit/js/OlPopover.test.js
@@ -39,9 +39,9 @@ function installPopoverApiStub() {
     };
 }
 
-function installMatchMediaStub() {
+function installMatchMediaStub(matches = false) {
     window.matchMedia = (query) => ({
-        matches: false,
+        matches: typeof matches === 'function' ? matches(query) : matches,
         media: query,
         addEventListener() {},
         removeEventListener() {},
@@ -153,5 +153,108 @@ describe('ol-popover top-layer promotion', () => {
 
         el._cleanup();
         expect(() => el._cleanup()).not.toThrow();
+    });
+});
+
+/**
+ * The close path hangs off a single `transitionend`. When that event never
+ * arrives — a backgrounded tab paints no frames, and preparing → exiting
+ * changes no animatable property — the panel stayed promoted, above the page
+ * and holding focus, while the trigger already reported aria-expanded="false".
+ */
+describe('ol-popover close fallback', () => {
+    let popoverApi;
+
+    let realScrollTo;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        installMatchMediaStub();
+        // jsdom has no scrollTo; releasing the mobile scroll lock calls it.
+        realScrollTo = window.scrollTo;
+        window.scrollTo = () => {};
+        document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+        window.scrollTo = realScrollTo;
+        jest.useRealTimers();
+        popoverApi?.restore();
+        popoverApi = null;
+        document.body.innerHTML = '';
+    });
+
+    it('demotes and restores focus when transitionend never fires', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+        const trigger = el.querySelector('[slot="trigger"]');
+        trigger.focus();
+
+        await openAndSettle(el);
+        const panel = panelOf(el);
+        expect(popoverApi.isOpen(panel)).toBe(true);
+
+        el.open = false;
+        await el.updateComplete;
+        expect(el._animState).toBe('exiting');
+
+        // No transitionend in jsdom, exactly as in a tab that paints no frames.
+        jest.advanceTimersByTime(400);
+
+        expect(el._animState).toBe('closed');
+        expect(popoverApi.isOpen(panel)).toBe(false);
+        expect(document.activeElement).toBe(trigger);
+    });
+
+    it('lets a real transitionend win, without a second cleanup', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+        const panel = panelOf(el);
+
+        el.open = false;
+        await el.updateComplete;
+        panel.dispatchEvent(new Event('transitionend'));
+        expect(el._animState).toBe('closed');
+
+        // The armed timer must not fire a second cleanup into the closed popover.
+        const hideCalls = HTMLElement.prototype.hidePopover.mock.calls.length;
+        jest.advanceTimersByTime(400);
+        expect(HTMLElement.prototype.hidePopover.mock.calls.length).toBe(hideCalls);
+    });
+
+    it('cancels the pending close when reopened mid-exit', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+        el.open = false;
+        await el.updateComplete;
+
+        await openAndSettle(el);
+        jest.advanceTimersByTime(400);
+
+        expect(el._animState).not.toBe('closed');
+        expect(popoverApi.isOpen(panelOf(el))).toBe(true);
+    });
+
+    it('takes only one body scroll lock when reopened mid-exit', async() => {
+        // A second lock would outlive the single _releaseScrollLock() and leave
+        // <body> pinned at position: fixed for the rest of the session.
+        installMatchMediaStub((q) => q.includes('max-width'));
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+        el.open = false;
+        await el.updateComplete;
+        await openAndSettle(el);
+
+        el.open = false;
+        await el.updateComplete;
+        jest.advanceTimersByTime(400);
+
+        expect(document.body.style.position).toBe('');
     });
 });

--- a/tests/unit/js/OlPopover.test.js
+++ b/tests/unit/js/OlPopover.test.js
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for <ol-popover>'s top-layer promotion.
+ *
+ * The panel is positioned with viewport coordinates from
+ * getBoundingClientRect(). Plain `position: fixed` resolves against the nearest
+ * *transformed* ancestor rather than the viewport, so inside a carousel track
+ * (or any transformed container) the panel rendered hundreds of pixels off and
+ * clipped. Promoting it to the top layer via the Popover API makes the viewport
+ * the containing block again.
+ *
+ * jsdom has no layout engine, so these tests assert the mechanism — the popover
+ * attribute and the show/hide calls — rather than the resulting geometry, which
+ * is verified in the browser.
+ */
+
+/** Minimal Popover API stand-in: jsdom implements neither the methods nor the pseudo-class. */
+function installPopoverApiStub() {
+    const open = new WeakSet();
+    HTMLElement.prototype.showPopover = jest.fn(function() {
+        if (open.has(this)) throw new DOMException('already open', 'InvalidStateError');
+        open.add(this);
+    });
+    HTMLElement.prototype.hidePopover = jest.fn(function() {
+        if (!open.has(this)) throw new DOMException('not open', 'InvalidStateError');
+        open.delete(this);
+    });
+    const realMatches = Element.prototype.matches;
+    Element.prototype.matches = function(selector) {
+        if (selector === ':popover-open') return open.has(this);
+        return realMatches.call(this, selector);
+    };
+    return {
+        isOpen: (el) => open.has(el),
+        restore: () => {
+            delete HTMLElement.prototype.showPopover;
+            delete HTMLElement.prototype.hidePopover;
+            Element.prototype.matches = realMatches;
+        },
+    };
+}
+
+function installMatchMediaStub() {
+    window.matchMedia = (query) => ({
+        matches: false,
+        media: query,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+    });
+}
+
+/**
+ * Import OlPopover fresh and register it under a unique tag. The support check
+ * is a module-level constant read at import time, so each scenario needs its own
+ * module instance — and customElements.define is one-shot per name.
+ */
+let tagSeq = 0;
+async function mountPopover() {
+    const tag = `ol-popover-test-${++tagSeq}`;
+    let el;
+    await jest.isolateModulesAsync(async() => {
+        const { OlPopover } = await import('../../../openlibrary/components/lit/OlPopover.js');
+        customElements.define(tag, class extends OlPopover {});
+        el = document.createElement(tag);
+        el.innerHTML = '<button slot="trigger">Open</button><div>Panel content</div>';
+        document.body.appendChild(el);
+    });
+    await el.updateComplete;
+    return el;
+}
+
+const panelOf = (el) => el.shadowRoot.querySelector('.panel');
+
+/**
+ * Opening runs across several update cycles: `open` triggers `_show()`, which
+ * sets the animation state, and the promotion happens in a follow-up
+ * `updateComplete` callback. Settle all of them.
+ */
+async function openAndSettle(el) {
+    el.open = true;
+    for (let i = 0; i < 5; i++) {
+        await el.updateComplete;
+        await Promise.resolve();
+    }
+}
+
+describe('ol-popover top-layer promotion', () => {
+    let popoverApi;
+
+    beforeEach(() => {
+        installMatchMediaStub();
+        document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+        popoverApi?.restore();
+        popoverApi = null;
+        document.body.innerHTML = '';
+    });
+
+    it('promotes the panel to the top layer when the Popover API exists', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+
+        const panel = panelOf(el);
+        expect(panel).not.toBeNull();
+        expect(panel.getAttribute('popover')).toBe('manual');
+        expect(popoverApi.isOpen(panel)).toBe(true);
+    });
+
+    it('uses popover="manual", never "auto"', async() => {
+        // "auto" would light-dismiss and force-close sibling popovers outside the
+        // ancestor chain, collapsing the component's own nesting stack.
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+
+        expect(panelOf(el).getAttribute('popover')).not.toBe('auto');
+    });
+
+    it('falls back to plain position: fixed without the Popover API', async() => {
+        // No stub installed — jsdom has no showPopover, standing in for Safari < 17.
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+
+        expect(panelOf(el).hasAttribute('popover')).toBe(false);
+    });
+
+    it('demotes the panel out of the top layer when it closes', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+        const panel = panelOf(el);
+        expect(popoverApi.isOpen(panel)).toBe(true);
+
+        el._cleanup();
+
+        expect(popoverApi.isOpen(panel)).toBe(false);
+        expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+    });
+
+    it('does not throw when cleanup runs on an already-hidden panel', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountPopover();
+
+        await openAndSettle(el);
+
+        el._cleanup();
+        expect(() => el._cleanup()).not.toThrow();
+    });
+});

--- a/tests/unit/js/OlTooltip.test.js
+++ b/tests/unit/js/OlTooltip.test.js
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for <ol-tooltip>'s top-layer promotion.
+ *
+ * Same failure as <ol-popover>: the panel is positioned from viewport
+ * coordinates, but plain `position: fixed` resolves against the nearest
+ * transformed ancestor, so inside a carousel track the tooltip lands far from
+ * its trigger and is clipped. See openlibrary/components/lit/utils/top-layer.js.
+ *
+ * jsdom has no layout engine, so these assert the mechanism rather than the
+ * geometry, which is verified in the browser.
+ */
+
+/** Minimal Popover API stand-in: jsdom implements neither the methods nor the pseudo-class. */
+function installPopoverApiStub() {
+    const open = new WeakSet();
+    HTMLElement.prototype.showPopover = jest.fn(function() {
+        if (open.has(this)) throw new DOMException('already open', 'InvalidStateError');
+        open.add(this);
+    });
+    HTMLElement.prototype.hidePopover = jest.fn(function() {
+        if (!open.has(this)) throw new DOMException('not open', 'InvalidStateError');
+        open.delete(this);
+    });
+    const realMatches = Element.prototype.matches;
+    Element.prototype.matches = function(selector) {
+        if (selector === ':popover-open') return open.has(this);
+        return realMatches.call(this, selector);
+    };
+    return {
+        isOpen: (el) => open.has(el),
+        restore: () => {
+            delete HTMLElement.prototype.showPopover;
+            delete HTMLElement.prototype.hidePopover;
+            Element.prototype.matches = realMatches;
+        },
+    };
+}
+
+/**
+ * Import OlTooltip fresh and register it under a unique tag. The support check
+ * is a module-level constant read at import time, so each scenario needs its own
+ * module instance — and customElements.define is one-shot per name.
+ */
+let tagSeq = 0;
+async function mountTooltip() {
+    const tag = `ol-tooltip-test-${++tagSeq}`;
+    let el;
+    await jest.isolateModulesAsync(async() => {
+        const { OlTooltip } = await import('../../../openlibrary/components/lit/OlTooltip.js');
+        customElements.define(tag, class extends OlTooltip {});
+        el = document.createElement(tag);
+        el.setAttribute('content', 'Tooltip text');
+        el.setAttribute('show-delay', '0');
+        el.innerHTML = '<button>Trigger</button>';
+        document.body.appendChild(el);
+    });
+    await el.updateComplete;
+    return el;
+}
+
+const tooltipOf = (el) => el.shadowRoot.querySelector('.tooltip');
+
+/** Showing spans several update cycles; the promotion runs in a follow-up callback. */
+async function settle(el) {
+    for (let i = 0; i < 5; i++) {
+        await el.updateComplete;
+        await Promise.resolve();
+    }
+}
+
+describe('ol-tooltip top-layer promotion', () => {
+    let popoverApi;
+
+    beforeEach(() => {
+        // jsdom has no matchMedia; the component reads it on construction.
+        window.matchMedia = (query) => ({
+            matches: false,
+            media: query,
+            addEventListener() {},
+            removeEventListener() {},
+            addListener() {},
+            removeListener() {},
+        });
+        document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+        popoverApi?.restore();
+        popoverApi = null;
+        document.body.innerHTML = '';
+    });
+
+    it('promotes the tooltip to the top layer when it shows', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountTooltip();
+
+        el._show();
+        await settle(el);
+
+        const tooltip = tooltipOf(el);
+        expect(tooltip.getAttribute('popover')).toBe('manual');
+        expect(popoverApi.isOpen(tooltip)).toBe(true);
+    });
+
+    it('demotes the tooltip when it hides', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountTooltip();
+
+        el._show();
+        await settle(el);
+        const tooltip = tooltipOf(el);
+        expect(popoverApi.isOpen(tooltip)).toBe(true);
+
+        el._hide();
+        await settle(el);
+
+        expect(popoverApi.isOpen(tooltip)).toBe(false);
+    });
+
+    it('falls back to plain position: fixed without the Popover API', async() => {
+        // No stub installed — jsdom has no showPopover, standing in for Safari < 17.
+        const el = await mountTooltip();
+
+        el._show();
+        await settle(el);
+
+        expect(tooltipOf(el).hasAttribute('popover')).toBe(false);
+    });
+
+    it('does not throw when hide runs without a preceding show', async() => {
+        popoverApi = installPopoverApiStub();
+        const el = await mountTooltip();
+
+        expect(() => el._hide()).not.toThrow();
+    });
+});


### PR DESCRIPTION
Closes #13325.

### What was wrong

Popovers and tooltips would sometimes render *underneath* the things around them — the Language filter panel slid under the site header, and tooltips inside carousels got cut off at the edge of the carousel. You can't fix this with z-index: once a panel sits inside a container that has a transform on it (a carousel track, anything with `will-change`), the browser treats that container as the panel's whole world. The panel can't paint outside of it.

### What this does

Anchored panels are now promoted to the browser's **top layer** — the same place native dialogs live — while they're open. Up there they always position against the real viewport and always paint above the page, no matter what they're nested inside.

The nice part is that we get this from the platform rather than from more CSS. Popovers and tooltips now use the browser's built-in [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API), which joins the native `<dialog>` our modals already use — so both kinds of overlay are handled by the same standard browser machinery instead of a homegrown stack of z-index rules. Less of our own code to maintain, better accessibility and behavior for free, and it keeps improving as browsers do. Browsers too old for the Popover API (Safari < 17) fall back to what we had before, so nothing regresses.

A few related fixes from the same pass:

- The popover no longer gets stuck open-but-invisible when its close animation never runs (e.g. you hit Escape in a background tab). That could also leave the page unscrollable for the rest of the session.
- `ol-tooltip` threw an error if it got imported twice.
- In the markdown editor, the Link/Image/More buttons now tell screen readers whether their panel is open, and the overflow menu closes on Escape.

The rule and its gotchas are written up in `docs/ai/web-components.md` so the next overlay doesn't have to rediscover it.

### Testing

Open popovers, tooltips and dialogs on `/developers/design/components` and on the search results pages. They should land on their trigger, paint above everything around them, and close normally. Worth checking the mobile tray at ≤767px too — the dark backdrop should cover the screen and stay tap-to-dismiss.

`npm run test:js` — 558 pass, 9 new.

### Stakeholders

@mekarpeles @cdrini
