### PR TITLE
Remove unsued facets from subjects page Solr query to help reduce subject-page timeouts

### DIFF
--- a/openlibrary/fastapi/services/subject_service.py
+++ b/openlibrary/fastapi/services/subject_service.py
@@ -75,6 +75,7 @@ async def fetch_subject_data(
         sort=params.sort,
         details=params.details,
         request_label="SUBJECT_ENGINE_API",
+        facet_fields=None,
         **filters,
     )
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -347,7 +347,9 @@ def _prepare_solr_query_params(  # noqa: PLR0912
     spellcheck_count=None,
     offset=None,
     fields: str | list[str] | None = None,
-    facet: bool | Iterable[str] = True,
+    # Iterable items are either a bare field name or a
+    # {"name": ..., "sort"/"limit": ...} spec -- see the isinstance checks below.
+    facet: bool | Iterable[str | dict[str, Any]] = True,
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,
@@ -493,7 +495,9 @@ async def run_solr_query_async(
     spellcheck_count=None,
     offset=None,
     fields: str | list[str] | None = None,
-    facet: bool | Iterable[str] = True,
+    # Iterable items are either a bare field name or a
+    # {"name": ..., "sort"/"limit": ...} spec -- see the isinstance checks below.
+    facet: bool | Iterable[str | dict[str, Any]] = True,
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -7,7 +7,7 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from datetime import date
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import web
 
@@ -30,8 +30,11 @@ logger = logging.getLogger("openlibrary.worksearch")
 DEFAULT_RESULTS = 12
 MAX_RESULTS = 1000
 
+FacetSpec = str | dict[str, Any]
+"""A bare Solr facet field name, or a {"name": ..., "sort"/"limit": ...} spec."""
+
 # Facets requested when details=True and no facet_fields override is given.
-DEFAULT_FACET_FIELDS = [
+DEFAULT_FACET_FIELDS: list[FacetSpec] = [
     {"name": "author_facet", "sort": "count"},
     "language",
     "publisher_facet",
@@ -281,13 +284,14 @@ The key-like paths for a subject, eg:
 
 async def get_subject_async(
     key: SubjectPseudoKey,
-    details=False,
+    details: bool = False,
     offset=0,
     sort="editions",
     limit=DEFAULT_RESULTS,
     request_label: SolrRequestLabel = "UNLABELLED",
-    facet_fields: list | None = None,
-    **filters,
+    *,
+    facet_fields: list[FacetSpec] | None = None,
+    **filters: Any,
 ) -> Subject:
     """Returns data related to a subject.
 
@@ -378,13 +382,14 @@ class SubjectEngine:
     async def get_subject_async(
         self,
         key,
-        details=False,
+        details: bool = False,
         offset=0,
         limit=DEFAULT_RESULTS,
         sort="new",
         request_label: SolrRequestLabel = "UNLABELLED",
-        facet_fields: list | None = None,
-        **filters,
+        *,
+        facet_fields: list[FacetSpec] | None = None,
+        **filters: Any,
     ):
         # Circular imports are everywhere -_-
         from openlibrary.plugins.worksearch.code import (

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -30,6 +30,19 @@ logger = logging.getLogger("openlibrary.worksearch")
 DEFAULT_RESULTS = 12
 MAX_RESULTS = 1000
 
+# Facets requested when details=True and no facet_fields override is given.
+DEFAULT_FACET_FIELDS = [
+    {"name": "author_facet", "sort": "count"},
+    "language",
+    "publisher_facet",
+    {"name": "publish_year", "limit": -1},
+    "subject_facet",
+    "person_facet",
+    "place_facet",
+    "time_facet",
+    "has_fulltext",
+]
+
 # Works sampled per signal; 8 unique authors reliably appear in the first 40 rows.
 NOTABLE_AUTHORS_SAMPLE_SIZE = 40
 MAX_NOTABLE_AUTHORS = 8
@@ -56,6 +69,18 @@ class subjects(delegate.page):
         subj = get_subject(
             key,
             details=True,
+            # subjects.html doesn't render `works` -- the on-page carousel
+            # runs its own query via `page.solr_query`.
+            limit=0,
+            # subjects.html only renders these facets; author_facet/language/
+            # publisher_facet/has_fulltext are used solely by /publishers/<name>.
+            facet_fields=[
+                {"name": "publish_year", "limit": -1},
+                "subject_facet",
+                "person_facet",
+                "place_facet",
+                "time_facet",
+            ],
             filters={"public_scan_b": "false", "lending_edition_s": "*"},
             sort=web.input(sort="readinglog").sort,
             request_label="SUBJECT_ENGINE_PAGE",
@@ -261,6 +286,7 @@ async def get_subject_async(
     sort="editions",
     limit=DEFAULT_RESULTS,
     request_label: SolrRequestLabel = "UNLABELLED",
+    facet_fields: list | None = None,
     **filters,
 ) -> Subject:
     """Returns data related to a subject.
@@ -317,6 +343,9 @@ async def get_subject_async(
     Optional arguments limit and offset can be passed to limit the number of works returned and starting offset.
 
     Optional arguments has_fulltext and published_in can be passed to filter the results.
+
+    By default, details=True requests every facet in DEFAULT_FACET_FIELDS. Pass
+    facet_fields to request a specific subset instead.
     """
     engine = next((e for e in SUBJECTS if key.startswith(e.prefix)), None)
 
@@ -329,6 +358,7 @@ async def get_subject_async(
         offset=offset,
         sort=sort,
         limit=limit,
+        facet_fields=facet_fields,
         request_label=request_label,
         **filters,
     )
@@ -353,6 +383,7 @@ class SubjectEngine:
         limit=DEFAULT_RESULTS,
         sort="new",
         request_label: SolrRequestLabel = "UNLABELLED",
+        facet_fields: list | None = None,
         **filters,
     ):
         # Circular imports are everywhere -_-
@@ -400,20 +431,7 @@ class SubjectEngine:
                 "lending_edition_s",
                 "lending_identifier_s",
             ],
-            facet=(
-                details
-                and [
-                    {"name": "author_facet", "sort": "count"},
-                    "language",
-                    "publisher_facet",
-                    {"name": "publish_year", "limit": -1},
-                    "subject_facet",
-                    "person_facet",
-                    "place_facet",
-                    "time_facet",
-                    "has_fulltext",
-                ]
-            ),
+            facet=(facet_fields if facet_fields is not None else details and DEFAULT_FACET_FIELDS),
             extra_params=[
                 ("facet.mincount", 1),
                 ("facet.limit", 25),
@@ -442,25 +460,28 @@ class SubjectEngine:
                 for facet_field, facet_counts in result.facet_counts.items()
             }
 
-            subject.ebook_count = next(
-                (
-                    count
-                    for key, count in cast(  # These are fetched in a different format, we need to fix the types
-                        list[tuple[str, int]], result.facet_counts["has_fulltext"]
-                    )
-                    if key == "true"
-                ),
-                0,
-            )
+            # A facet_fields caller may omit any of these; default rather
+            # than assume every key is present.
+            if has_fulltext_counts := result.facet_counts.get("has_fulltext"):
+                subject.ebook_count = next(
+                    (
+                        count
+                        for key, count in cast(  # These are fetched in a different format, we need to fix the types
+                            list[tuple[str, int]], has_fulltext_counts
+                        )
+                        if key == "true"
+                    ),
+                    0,
+                )
 
-            subject.subjects = result.facet_counts["subject_facet"]
-            subject.places = result.facet_counts["place_facet"]
-            subject.people = result.facet_counts["person_facet"]
-            subject.times = result.facet_counts["time_facet"]
+            subject.subjects = result.facet_counts.get("subject_facet", [])
+            subject.places = result.facet_counts.get("place_facet", [])
+            subject.people = result.facet_counts.get("person_facet", [])
+            subject.times = result.facet_counts.get("time_facet", [])
 
-            subject.authors = result.facet_counts["author_key"]
-            subject.publishers = result.facet_counts["publisher_facet"]
-            subject.languages = result.facet_counts["language"]
+            subject.authors = result.facet_counts.get("author_key", [])
+            subject.publishers = result.facet_counts.get("publisher_facet", [])
+            subject.languages = result.facet_counts.get("language", [])
 
             # Phase 1 (epic #13135): "Notable authors" is computed and
             # cached separately -- see get_cached_notable_authors and
@@ -474,7 +495,7 @@ class SubjectEngine:
                 [year, count]
                 for year, count in cast(  # These are fetched in a different format, we need to fix the types
                     list[tuple[int, int]],
-                    result.facet_counts["publish_year"],
+                    result.facet_counts.get("publish_year", []),
                 )
                 if 1000 < year <= current_year + 1
             ]


### PR DESCRIPTION
Work towards #13192

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Some of the facet fields fetched here appear to be unused, so can be dropped in the hopes of making the subject page solr query faster and less likely to timeout.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
