### PR TITLE
Make expensive facet requests on subject page partials and async

### DIFF
--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -22,6 +22,7 @@ from openlibrary.plugins.openlibrary.partials import (
     MyBooksDropperListsPartial,
     ReadingGoalProgressPartial,
     SearchFacetsPartial,
+    SubjectPublishingHistoryPartial,
 )
 
 router = APIRouter()
@@ -49,6 +50,16 @@ async def search_facets_partial(
         raise HTTPException(status_code=400, detail="Invalid JSON in data parameter")
 
     return await SearchFacetsPartial.generate_async(data=parsed_data, sfw=sfw == "yes")
+
+
+@router.get("/partials/SubjectPublishingHistory.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)
+async def subject_publishing_history_partial(
+    key: Annotated[str, Query(description="Subject key (e.g. /subjects/cooking)")],
+) -> dict:
+    """
+    Get the subject page's publishing-history chart HTML.
+    """
+    return await SubjectPublishingHistoryPartial.generate_async(key=key)
 
 
 @router.get("/partials/AffiliateLinks.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)

--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -23,6 +23,7 @@ from openlibrary.plugins.openlibrary.partials import (
     ReadingGoalProgressPartial,
     SearchFacetsPartial,
     SubjectPublishingHistoryPartial,
+    SubjectRelatedPartial,
 )
 
 router = APIRouter()
@@ -60,6 +61,16 @@ async def subject_publishing_history_partial(
     Get the subject page's publishing-history chart HTML.
     """
     return await SubjectPublishingHistoryPartial.generate_async(key=key)
+
+
+@router.get("/partials/SubjectRelated.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)
+async def subject_related_partial(
+    key: Annotated[str, Query(description="Subject key (e.g. /subjects/cooking)")],
+) -> dict:
+    """
+    Get the subject page's related subjects/places/people/times widget HTML.
+    """
+    return await SubjectRelatedPartial.generate_async(key=key)
 
 
 @router.get("/partials/AffiliateLinks.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)

--- a/openlibrary/fastapi/services/subject_service.py
+++ b/openlibrary/fastapi/services/subject_service.py
@@ -75,6 +75,7 @@ async def fetch_subject_data(
         sort=params.sort,
         details=params.details,
         request_label="SUBJECT_ENGINE_API",
+        facet_fields=None,
         **filters,
     )
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Library Explorer"
 msgstr ""
 
-#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
+#: PublishingHistory.html RelatedSubjects.html account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Library Explorer"
 msgstr ""
 
-#: PublishingHistory.html RelatedSubjects.html account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
+#: RelatedSubjects.html account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr ""
 
@@ -7436,6 +7436,14 @@ msgstr ""
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
+msgstr ""
+
+#: PublishingHistory.html RelatedSubjects.html
+msgid "Something went wrong."
+msgstr ""
+
+#: PublishingHistory.html RelatedSubjects.html
+msgid "Retry"
 msgstr ""
 
 #: RawQueryCarousel.html

--- a/openlibrary/macros/PublishingHistory.html
+++ b/openlibrary/macros/PublishingHistory.html
@@ -13,7 +13,8 @@ $def with (publishing_history=None, async_load=False, key=None)
 
     $if async_load:
         <div class="chart">
-            <span class="small">$_("Loading...")</span>
+            <span class="loadingIndicator"></span>
+            <span class="small async-partial-retry hidden">$_("Something went wrong.") <a href="#" class="retry-btn">$_("Retry")</a></span>
         </div>
     $else:
         <script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(publishing_history)</script>

--- a/openlibrary/macros/PublishingHistory.html
+++ b/openlibrary/macros/PublishingHistory.html
@@ -1,20 +1,31 @@
-$def with (publishing_history)
+$def with (publishing_history=None, async_load=False, key=None)
 
-<div class="head">
-    <h2 class="inline">
-      $_("Publishing History")
-    </h2>
-    <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
-    <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
-    <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject.")</span>
-</div>
-
-<script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(publishing_history)</script>
-
-<div class="chart">
-    <div class="chartYaxis">$_("Editions Published")</div>
-    <div id="chartPubHistory" class="thisChart">
-        <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
+<div id="subjectPublishingHistory" data-async-load="$json_encode(async_load)" data-key="$json_encode(key)">
+    <div class="head">
+        <h2 class="inline">
+          $_("Publishing History")
+        </h2>
+        <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
+        $if not async_load:
+            <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
+            <span class="count chartUnzoom">&nbsp;$_('This graph charts editions published on this subject.')</span>
     </div>
-    <div class="chartXaxis">$_("Year of Publication")</div>
+
+    $if async_load:
+        <div class="chart">
+            <span class="small">$_("Loading...")</span>
+        </div>
+    $else:
+        <script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(publishing_history)</script>
+
+        <div class="chart">
+            <div class="chartYaxis">$_("Editions Published")</div>
+            <div id="chartPubHistory" class="thisChart">
+                <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
+            </div>
+            <div class="chartXaxis">$_("Year of Publication")</div>
+        </div>
+        $# .chart floats on desktop widths (chart.css); clear it inside this
+        $# wrapper so the wrapper's own box isn't collapsed to just .head.
+        <div class="clearfix"></div>
 </div>

--- a/openlibrary/macros/RelatedSubjects.html
+++ b/openlibrary/macros/RelatedSubjects.html
@@ -1,10 +1,6 @@
-$def with (page)
+$def with (page=None, async_load=False, key=None)
 
 $ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), ('people', _('People'), 10), ('times', _('Times'), 10)]
-
-<div class="head" id="subjectRelated">
-  <h2>$_("Related...")</h2>
-</div>
 
 $def renderSubjects(subjects):
     $if len(subjects) > 0:
@@ -15,8 +11,20 @@ $def renderSubjects(subjects):
     $else:
         <span class="title"><em>$_("None found.")</em></span>
 
-$for category, label, limit in subject_list:
-    <div class="contentQuarter link-box link-box--with-header">
-      <h3 class="black collapse uppercase">$label</h3>
-      $:renderSubjects(page[category][:limit])
+<div id="subjectRelatedFacets" data-async-load="$json_encode(async_load)" data-key="$json_encode(key)">
+    <div class="head" id="subjectRelated">
+      <h2>$_("Related...")</h2>
     </div>
+
+    $for category, label, limit in subject_list:
+        <div class="contentQuarter link-box link-box--with-header">
+          <h3 class="black collapse uppercase">$label</h3>
+          $if async_load:
+              <span class="small">$_("Loading...")</span>
+          $else:
+              $:renderSubjects(page[category][:limit])
+        </div>
+    $# .contentQuarter floats on desktop widths (layout/index.css); clear it
+    $# inside this wrapper so the wrapper's own box isn't collapsed to nothing.
+    <div class="clearfix"></div>
+</div>

--- a/openlibrary/macros/RelatedSubjects.html
+++ b/openlibrary/macros/RelatedSubjects.html
@@ -20,10 +20,12 @@ $def renderSubjects(subjects):
         <div class="contentQuarter link-box link-box--with-header">
           <h3 class="black collapse uppercase">$label</h3>
           $if async_load:
-              <span class="small">$_("Loading...")</span>
+              <span class="small loadingIndicator">$_("Loading...")</span>
           $else:
               $:renderSubjects(page[category][:limit])
         </div>
+    $if async_load:
+        <span class="small async-partial-retry hidden">$_("Something went wrong.") <a href="#" class="retry-btn">$_("Retry")</a></span>
     $# .contentQuarter floats on desktop widths (layout/index.css); clear it
     $# inside this wrapper so the wrapper's own box isn't collapsed to nothing.
     <div class="clearfix"></div>

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -1,4 +1,4 @@
-import { buildPartialsUrl } from './utils';
+import { buildPartialsUrl, whenVisible } from './utils';
 import { initAsyncFollowing } from './following';
 
 /**
@@ -6,58 +6,41 @@ import { initAsyncFollowing } from './following';
  *
  * @param elem {HTMLElement} Container for book page lists section
  */
-export function initListsSection(elem) {
+export async function initListsSection(elem) {
     // Show loading indicator
     const loadingIndicator = elem.querySelector('.loadingIndicator');
     loadingIndicator.classList.remove('hidden');
 
     const ids = JSON.parse(elem.dataset.ids);
 
-    const intersectionObserver = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                // Unregister intersection listener
-                intersectionObserver.unobserve(entries[0].target);
-                fetchPartials(ids.work, ids.edition)
-                    .then((resp) => {
-                        // Check response code, continue if not 4XX or 5XX
-                        return resp.json();
-                    })
-                    .then((data) => {
-                        // Replace loading indicator with partials
-                        const listSection = loadingIndicator.parentElement;
-                        const fragment = document.createDocumentFragment();
+    await whenVisible(elem);
 
-                        for (const htmlString of data.partials) {
-                            const template = document.createElement('template');
-                            template.innerHTML = htmlString;
-                            fragment.append(...template.content.childNodes);
-                        }
+    const data = await fetchPartials(ids.work, ids.edition).then(resp => resp.json());
 
-                        listSection.replaceChildren(fragment);
+    // Replace loading indicator with partials
+    const listSection = loadingIndicator.parentElement;
+    const fragment = document.createDocumentFragment();
 
-                        // Show "See All" link
-                        if (data.hasLists) {
-                            const showAllLink = elem.querySelector('.lists-heading a');
-                            if (showAllLink) {
-                                showAllLink.classList.remove('hidden');
-                            }
-                        }
-                        // Initialize private buttons after content is loaded
-                        initPrivateButtonsAfterLoad(listSection);
+    for (const htmlString of data.partials) {
+        const template = document.createElement('template');
+        template.innerHTML = htmlString;
+        fragment.append(...template.content.childNodes);
+    }
 
-                        const followForms = listSection.querySelectorAll('.follow-form');
-                        initAsyncFollowing(followForms);
-                    });
-            }
-        });
-    }, {
-        root: null,
-        rootMargin: '200px',
-        threshold: 0
-    });
+    listSection.replaceChildren(fragment);
 
-    intersectionObserver.observe(elem);
+    // Show "See All" link
+    if (data.hasLists) {
+        const showAllLink = elem.querySelector('.lists-heading a');
+        if (showAllLink) {
+            showAllLink.classList.remove('hidden');
+        }
+    }
+    // Initialize private buttons after content is loaded
+    initPrivateButtonsAfterLoad(listSection);
+
+    const followForms = listSection.querySelectorAll('.follow-form');
+    initAsyncFollowing(followForms);
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -320,6 +320,12 @@ jQuery(function() {
             .then((module) => module.initPublishingHistory(subjectPublishingHistory));
     }
 
+    const subjectRelatedFacets = document.getElementById('subjectRelatedFacets');
+    if (subjectRelatedFacets) {
+        import(/* webpackChunkName: "subjects" */ './subjects')
+            .then((module) => module.initRelatedSubjects(subjectRelatedFacets));
+    }
+
     const searchFilterBar = document.querySelector('.search-filter-row');
     if (searchFilterBar) {
         import(/* webpackChunkName: "search-filter-bar" */ './SearchFilterBar')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -314,6 +314,12 @@ jQuery(function() {
             .then((module) => module.initSearchFacets(searchFacets));
     }
 
+    const subjectPublishingHistory = document.getElementById('subjectPublishingHistory');
+    if (subjectPublishingHistory) {
+        import(/* webpackChunkName: "subjects" */ './subjects')
+            .then((module) => module.initPublishingHistory(subjectPublishingHistory));
+    }
+
     const searchFilterBar = document.querySelector('.search-filter-row');
     if (searchFilterBar) {
         import(/* webpackChunkName: "search-filter-bar" */ './SearchFilterBar')

--- a/openlibrary/plugins/openlibrary/js/lazy-carousel.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-carousel.js
@@ -1,5 +1,5 @@
 import {initialzeCarousels} from './carousel';
-import { buildPartialsUrl } from './utils';
+import { buildPartialsUrl, whenVisible } from './utils';
 
 let relatedBooksTracked = false;
 let bannerClicked = false;
@@ -17,16 +17,8 @@ document.addEventListener('click', (e) => {
  * @param elems {NodeList<HTMLElement>} Collection of placeholder carousel elements
  */
 export function initLazyCarousel(elems) {
-    // Create intersection observer
-    const intersectionObserver = new IntersectionObserver(intersectionCallback, {
-        root: null,
-        rootMargin: '200px',
-        threshold: 0
-    });
-
     elems.forEach(elem => {
-        // Observe element for intersections
-        intersectionObserver.observe(elem);
+        whenVisible(elem).then(() => doFetchAndUpdate(elem));
 
         // Add retry listener
         const retryElem = elem.querySelector('.retry-btn');
@@ -142,22 +134,4 @@ function handleRetry(target) {
         carouselFallbackElem.classList.add('hidden');
     }
     doFetchAndUpdate(target);
-}
-
-/**
- * Callback used by the lazy-loaded carousel intersection observer.
- *
- * Unregisters target from observer and fetches carousel HTML.
- *
- * @param entries {Array<IntersectionObserverEntry>}
- * @param observer {IntersectionObserver}
- */
-function intersectionCallback(entries, observer) {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            const target = entry.target;
-            observer.unobserve(target);
-            doFetchAndUpdate(target);
-        }
-    });
 }

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -2,7 +2,7 @@
  * Functionalities for templates/work_search and related templates.
  */
 
-import { buildPartialsUrl } from './utils';
+import { buildPartialsUrl, createElementFromMarkup, whenVisible } from './utils';
 
 /**
  * Displays more facets by removing the ui-helper-hidden class.
@@ -143,51 +143,3 @@ function fetchPartials(param) {
         });
 }
 
-/**
- * Returns an `HTMLElement` that was created using the given `markup`.
- *
- * `markup` is expected to be well-formed, and only have a single root
- * element.
- *
- * @param {string} markup HTML markup for a single element
- * @returns {HTMLElement}
- */
-function createElementFromMarkup(markup) {
-    const template = document.createElement('template');
-    template.innerHTML = markup;
-    return template.content.children[0];
-}
-
-
-/**
- * Waits until the given element is visible in the viewport, then resolves.
- *
- * @param {HTMLElement} elem
- * @param {IntersectionObserverInit} options
- * @returns {Promise<void>}
- */
-async function whenVisible(elem, options = {}) {
-    return new Promise((resolve) => {
-        const intersectionObserver = new IntersectionObserver(
-            (entries, observer) => {
-                entries.forEach(entry => {
-                    if (!entry.isIntersecting) {
-                        return;
-                    }
-
-                    // Stop observing once the element is visible
-                    observer.unobserve(entry.target);
-                    observer.disconnect();
-                    resolve();
-                });
-            },
-            Object.assign({
-                root: null,
-                rootMargin: '200px',
-                threshold: 0
-            }, options)
-        );
-
-        intersectionObserver.observe(elem);
-    });
-}

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -142,4 +142,3 @@ function fetchPartials(param) {
             return resp.json();
         });
 }
-

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -1,0 +1,38 @@
+/**
+ * Functionalities for templates/subjects and related templates.
+ */
+
+import { buildPartialsUrl, createElementFromMarkup, whenVisible } from './utils';
+
+/**
+ * Initializes the subject page's publishing-history chart.
+ *
+ * The chart initially contains a loading indicator instead of a graph. Once
+ * visible, a request is made for the chart's real markup (with the
+ * publish_year facet data baked in), the placeholder is replaced with it,
+ * and the flot chart is drawn against the newly-inserted markup.
+ *
+ * @param {HTMLElement} elem Root element of the publishing-history component
+ */
+export async function initPublishingHistory(elem) {
+    if (!elem.dataset.asyncLoad) {
+        return;
+    }
+    const key = JSON.parse(elem.dataset.key);
+    await whenVisible(elem);
+
+    try {
+        const resp = await fetch(buildPartialsUrl('SubjectPublishingHistory', {key}));
+        if (!resp.ok) {
+            throw new Error(`Failed to fetch publishing history partial. Status code: ${resp.status}`);
+        }
+        const data = await resp.json();
+        const newElem = createElementFromMarkup(data.partials);
+        elem.replaceWith(newElem);
+
+        const graphs = await import(/* webpackChunkName: "graphs" */ './graphs');
+        graphs.initPublishersGraph();
+    } catch {
+        // XXX : Handle case where `/partials` response is not `2XX` here
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -2,37 +2,7 @@
  * Functionalities for templates/subjects and related templates.
  */
 
-import { buildPartialsUrl, createElementFromMarkup, whenVisible } from './utils';
-
-/**
- * Once `elem` is visible, fetches `component`'s real markup (keyed off
- * `elem.dataset.key`) and replaces `elem` with it.
- *
- * @param {HTMLElement} elem Root element of an async-loaded subject component
- * @param {string} component Partial component name (e.g. 'SubjectRelated')
- * @returns {Promise<HTMLElement | null>} The element that replaced `elem`, or null on failure
- */
-async function fetchAndSwap(elem, component) {
-    if (!elem.dataset.asyncLoad) {
-        return null;
-    }
-    const key = JSON.parse(elem.dataset.key);
-    await whenVisible(elem);
-
-    try {
-        const resp = await fetch(buildPartialsUrl(component, {key}));
-        if (!resp.ok) {
-            throw new Error(`Failed to fetch ${component} partial. Status code: ${resp.status}`);
-        }
-        const data = await resp.json();
-        const newElem = createElementFromMarkup(data.partials);
-        elem.replaceWith(newElem);
-        return newElem;
-    } catch {
-        // XXX : Handle case where `/partials` response is not `2XX` here
-        return null;
-    }
-}
+import { fetchAndSwap } from './utils';
 
 /**
  * Initializes the subject page's publishing-history chart.

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -5,6 +5,36 @@
 import { buildPartialsUrl, createElementFromMarkup, whenVisible } from './utils';
 
 /**
+ * Once `elem` is visible, fetches `component`'s real markup (keyed off
+ * `elem.dataset.key`) and replaces `elem` with it.
+ *
+ * @param {HTMLElement} elem Root element of an async-loaded subject component
+ * @param {string} component Partial component name (e.g. 'SubjectRelated')
+ * @returns {Promise<HTMLElement | null>} The element that replaced `elem`, or null on failure
+ */
+async function fetchAndSwap(elem, component) {
+    if (!elem.dataset.asyncLoad) {
+        return null;
+    }
+    const key = JSON.parse(elem.dataset.key);
+    await whenVisible(elem);
+
+    try {
+        const resp = await fetch(buildPartialsUrl(component, {key}));
+        if (!resp.ok) {
+            throw new Error(`Failed to fetch ${component} partial. Status code: ${resp.status}`);
+        }
+        const data = await resp.json();
+        const newElem = createElementFromMarkup(data.partials);
+        elem.replaceWith(newElem);
+        return newElem;
+    } catch {
+        // XXX : Handle case where `/partials` response is not `2XX` here
+        return null;
+    }
+}
+
+/**
  * Initializes the subject page's publishing-history chart.
  *
  * The chart initially contains a loading indicator instead of a graph. Once
@@ -15,24 +45,21 @@ import { buildPartialsUrl, createElementFromMarkup, whenVisible } from './utils'
  * @param {HTMLElement} elem Root element of the publishing-history component
  */
 export async function initPublishingHistory(elem) {
-    if (!elem.dataset.asyncLoad) {
-        return;
-    }
-    const key = JSON.parse(elem.dataset.key);
-    await whenVisible(elem);
-
-    try {
-        const resp = await fetch(buildPartialsUrl('SubjectPublishingHistory', {key}));
-        if (!resp.ok) {
-            throw new Error(`Failed to fetch publishing history partial. Status code: ${resp.status}`);
-        }
-        const data = await resp.json();
-        const newElem = createElementFromMarkup(data.partials);
-        elem.replaceWith(newElem);
-
+    if (await fetchAndSwap(elem, 'SubjectPublishingHistory')) {
         const graphs = await import(/* webpackChunkName: "graphs" */ './graphs');
         graphs.initPublishersGraph();
-    } catch {
-        // XXX : Handle case where `/partials` response is not `2XX` here
     }
+}
+
+/**
+ * Initializes the subject page's related subjects/places/people/times widget.
+ *
+ * Each category initially contains a loading indicator. Once visible, a
+ * request is made for the widget's real markup, and the placeholder is
+ * replaced with it.
+ *
+ * @param {HTMLElement} elem Root element of the related-subjects component
+ */
+export async function initRelatedSubjects(elem) {
+    await fetchAndSwap(elem, 'SubjectRelated');
 }

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -15,10 +15,10 @@ import { fetchAndSwap } from './utils';
  * @param {HTMLElement} elem Root element of the publishing-history component
  */
 export async function initPublishingHistory(elem) {
-    if (await fetchAndSwap(elem, 'SubjectPublishingHistory')) {
+    await fetchAndSwap(elem, 'SubjectPublishingHistory', async() => {
         const graphs = await import(/* webpackChunkName: "graphs" */ './graphs');
         graphs.initPublishersGraph();
-    }
+    });
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -136,6 +136,36 @@ export async function whenVisible(elem, options = {}) {
     });
 }
 
+/**
+ * Once `elem` is visible, fetches `component`'s real markup (keyed off
+ * `elem.dataset.key`) and replaces `elem` with it.
+ *
+ * @param {HTMLElement} elem Root element of an async-loaded partial component
+ * @param {string} component Partial component name (e.g. 'SubjectRelated')
+ * @returns {Promise<HTMLElement | null>} The element that replaced `elem`, or null on failure
+ */
+export async function fetchAndSwap(elem, component) {
+    if (elem.dataset.asyncLoad !== 'true') {
+        return null;
+    }
+    const key = JSON.parse(elem.dataset.key);
+    await whenVisible(elem);
+
+    try {
+        const resp = await fetch(buildPartialsUrl(component, {key}));
+        if (!resp.ok) {
+            throw new Error(`Failed to fetch ${component} partial. Status code: ${resp.status}`);
+        }
+        const data = await resp.json();
+        const newElem = createElementFromMarkup(data.partials);
+        elem.replaceWith(newElem);
+        return newElem;
+    } catch {
+        // XXX : Handle case where `/partials` response is not `2XX` here
+        return null;
+    }
+}
+
 export function queueAction(actionName, itemName, targetUrl, itemType) {
     const data = {
         name: itemName,

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -140,17 +140,37 @@ export async function whenVisible(elem, options = {}) {
  * Once `elem` is visible, fetches `component`'s real markup (keyed off
  * `elem.dataset.key`) and replaces `elem` with it.
  *
+ * On failure, `elem`'s loading indicator(s) (`.loadingIndicator`) are hidden
+ * and its pre-rendered `.async-partial-retry` prompt is shown instead (see
+ * e.g. RawQueryCarousel.html/PublishingHistory.html for the expected markup).
+ * Clicking retry restores the loading indicator(s) and re-attempts the fetch.
+ *
  * @param {HTMLElement} elem Root element of an async-loaded partial component
  * @param {string} component Partial component name (e.g. 'SubjectRelated')
- * @returns {Promise<HTMLElement | null>} The element that replaced `elem`, or null on failure
+ * @param {(newElem: HTMLElement) => void} [onSwap] Called every time `elem`
+ *   is successfully replaced with fetched markup -- including on a later
+ *   retry, unlike the returned promise below.
+ * @returns {Promise<HTMLElement | null>} The element that replaced `elem` on
+ *   the first attempt, or null if that attempt failed
  */
-export async function fetchAndSwap(elem, component) {
+export async function fetchAndSwap(elem, component, onSwap) {
     if (elem.dataset.asyncLoad !== 'true') {
         return null;
     }
     const key = JSON.parse(elem.dataset.key);
     await whenVisible(elem);
+    return attemptFetchAndSwap(elem, component, key, onSwap);
+}
 
+/**
+ * @param {HTMLElement} elem Element to replace with the fetched markup (or,
+ *   on failure, show a retry prompt inside)
+ * @param {string} component
+ * @param {string} key
+ * @param {(newElem: HTMLElement) => void} [onSwap]
+ * @returns {Promise<HTMLElement | null>}
+ */
+async function attemptFetchAndSwap(elem, component, key, onSwap) {
     try {
         const resp = await fetch(buildPartialsUrl(component, {key}));
         if (!resp.ok) {
@@ -159,11 +179,36 @@ export async function fetchAndSwap(elem, component) {
         const data = await resp.json();
         const newElem = createElementFromMarkup(data.partials);
         elem.replaceWith(newElem);
+        onSwap?.(newElem);
         return newElem;
     } catch {
-        // XXX : Handle case where `/partials` response is not `2XX` here
+        showRetryPrompt(elem, () => attemptFetchAndSwap(elem, component, key, onSwap));
         return null;
     }
+}
+
+/**
+ * Hides `elem`'s loading indicator(s) and shows its pre-rendered retry
+ * prompt. Clicking retry restores the loading indicator(s) and calls
+ * `onRetry`.
+ *
+ * @param {HTMLElement} elem
+ * @param {() => void} onRetry
+ */
+function showRetryPrompt(elem, onRetry) {
+    const loadingIndicators = elem.querySelectorAll('.loadingIndicator');
+    const retryPrompt = elem.querySelector('.async-partial-retry');
+
+    loadingIndicators.forEach(indicator => indicator.classList.add('hidden'));
+    retryPrompt.classList.remove('hidden');
+
+    retryPrompt.querySelector('.retry-btn').addEventListener('click', function onClick(e) {
+        e.preventDefault();
+        e.currentTarget.removeEventListener('click', onClick);
+        retryPrompt.classList.add('hidden');
+        loadingIndicators.forEach(indicator => indicator.classList.remove('hidden'));
+        onRetry();
+    });
 }
 
 export function queueAction(actionName, itemName, targetUrl, itemType) {

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -88,6 +88,54 @@ export function buildPartialsUrl(component, params = {}) {
     return url;
 }
 
+/**
+ * Returns an `HTMLElement` that was created using the given `markup`.
+ *
+ * `markup` is expected to be well-formed, and only have a single root
+ * element.
+ *
+ * @param {string} markup HTML markup for a single element
+ * @returns {HTMLElement}
+ */
+export function createElementFromMarkup(markup) {
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    return template.content.children[0];
+}
+
+/**
+ * Waits until the given element is visible in the viewport, then resolves.
+ *
+ * @param {HTMLElement} elem
+ * @param {IntersectionObserverInit} options
+ * @returns {Promise<void>}
+ */
+export async function whenVisible(elem, options = {}) {
+    return new Promise((resolve) => {
+        const intersectionObserver = new IntersectionObserver(
+            (entries, observer) => {
+                entries.forEach(entry => {
+                    if (!entry.isIntersecting) {
+                        return;
+                    }
+
+                    // Stop observing once the element is visible
+                    observer.unobserve(entry.target);
+                    observer.disconnect();
+                    resolve();
+                });
+            },
+            Object.assign({
+                root: null,
+                rootMargin: '200px',
+                threshold: 0
+            }, options)
+        );
+
+        intersectionObserver.observe(elem);
+    });
+}
+
 export function queueAction(actionName, itemName, targetUrl, itemType) {
     const data = {
         name: itemName,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -388,7 +388,6 @@ class SubjectPublishingHistoryPartial:
             details=True,
             limit=0,
             facet_fields=[{"name": "publish_year", "limit": -1}],
-            filters={"public_scan_b": "false", "lending_edition_s": "*"},
             request_label="SUBJECT_PUBLISHING_HISTORY",
         )
         macro = render_macro(
@@ -411,7 +410,6 @@ class SubjectRelatedPartial:
             details=True,
             limit=0,
             facet_fields=["subject_facet", "person_facet", "place_facet", "time_facet"],
-            filters={"public_scan_b": "false", "lending_edition_s": "*"},
             request_label="SUBJECT_RELATED",
         )
         macro = render_macro(

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -401,6 +401,29 @@ class SubjectPublishingHistoryPartial:
         return {"partials": str(macro["__body__"])}
 
 
+class SubjectRelatedPartial:
+    """Handler for the subject page's related subjects/places/people/times widget."""
+
+    @classmethod
+    async def generate_async(cls, key: str) -> dict:
+        subject = await get_subject_async(
+            key,
+            details=True,
+            limit=0,
+            facet_fields=["subject_facet", "person_facet", "place_facet", "time_facet"],
+            filters={"public_scan_b": "false", "lending_edition_s": "*"},
+            request_label="SUBJECT_RELATED",
+        )
+        macro = render_macro(
+            "RelatedSubjects",
+            (),
+            page=subject,
+            async_load=False,
+            key=key,
+        )
+        return {"partials": str(macro["__body__"])}
+
+
 @dataclass
 class FullTextSuggestionsPartialResult:
     body: dict

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -378,6 +378,29 @@ class SearchFacetsPartial:
         }
 
 
+class SubjectPublishingHistoryPartial:
+    """Handler for the subject page's publishing-history chart."""
+
+    @classmethod
+    async def generate_async(cls, key: str) -> dict:
+        subject = await get_subject_async(
+            key,
+            details=True,
+            limit=0,
+            facet_fields=[{"name": "publish_year", "limit": -1}],
+            filters={"public_scan_b": "false", "lending_edition_s": "*"},
+            request_label="SUBJECT_PUBLISHING_HISTORY",
+        )
+        macro = render_macro(
+            "PublishingHistory",
+            (),
+            publishing_history=subject.get("publishing_history", []),
+            async_load=False,
+            key=key,
+        )
+        return {"partials": str(macro["__body__"])}
+
+
 @dataclass
 class FullTextSuggestionsPartialResult:
     body: dict

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -347,7 +347,9 @@ def _prepare_solr_query_params(  # noqa: PLR0912
     spellcheck_count=None,
     offset=None,
     fields: str | list[str] | None = None,
-    facet: bool | Iterable[str] = True,
+    # Iterable items are either a bare field name or a
+    # {"name": ..., "sort"/"limit": ...} spec -- see the isinstance checks below.
+    facet: bool | Iterable[str | dict[str, Any]] = True,
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,
@@ -493,7 +495,9 @@ async def run_solr_query_async(
     spellcheck_count=None,
     offset=None,
     fields: str | list[str] | None = None,
-    facet: bool | Iterable[str] = True,
+    # Iterable items are either a bare field name or a
+    # {"name": ..., "sort"/"limit": ...} spec -- see the isinstance checks below.
+    facet: bool | Iterable[str | dict[str, Any]] = True,
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -75,16 +75,10 @@ class subjects(delegate.page):
             # subjects.html doesn't render `works` -- the on-page carousel
             # runs its own query via `page.solr_query`.
             limit=0,
-            # subjects.html only renders these facets synchronously; publish_year
-            # is fetched by the PublishingHistory partial instead (see
-            # SubjectPublishingHistoryPartial), and author_facet/language/
-            # publisher_facet/has_fulltext are used solely by /publishers/<name>.
-            facet_fields=[
-                "subject_facet",
-                "person_facet",
-                "place_facet",
-                "time_facet",
-            ],
+            # All facets subjects.html used are now fetched by the
+            # PublishingHistory/RelatedSubjects partials instead (see
+            # SubjectPublishingHistoryPartial/SubjectRelatedPartial).
+            facet_fields=[],
             filters={"public_scan_b": "false", "lending_edition_s": "*"},
             sort=web.input(sort="readinglog").sort,
             request_label="SUBJECT_ENGINE_PAGE",

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -7,7 +7,7 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from datetime import date
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import web
 
@@ -30,8 +30,11 @@ logger = logging.getLogger("openlibrary.worksearch")
 DEFAULT_RESULTS = 12
 MAX_RESULTS = 1000
 
+FacetSpec = str | dict[str, Any]
+"""A bare Solr facet field name, or a {"name": ..., "sort"/"limit": ...} spec."""
+
 # Facets requested when details=True and no facet_fields override is given.
-DEFAULT_FACET_FIELDS = [
+DEFAULT_FACET_FIELDS: list[FacetSpec] = [
     {"name": "author_facet", "sort": "count"},
     "language",
     "publisher_facet",
@@ -281,13 +284,14 @@ The key-like paths for a subject, eg:
 
 async def get_subject_async(
     key: SubjectPseudoKey,
-    details=False,
+    details: bool = False,
     offset=0,
     sort="editions",
     limit=DEFAULT_RESULTS,
     request_label: SolrRequestLabel = "UNLABELLED",
-    facet_fields: list | None = None,
-    **filters,
+    *,
+    facet_fields: list[FacetSpec] | None = None,
+    **filters: Any,
 ) -> Subject:
     """Returns data related to a subject.
 
@@ -378,13 +382,14 @@ class SubjectEngine:
     async def get_subject_async(
         self,
         key,
-        details=False,
+        details: bool = False,
         offset=0,
         limit=DEFAULT_RESULTS,
         sort="new",
         request_label: SolrRequestLabel = "UNLABELLED",
-        facet_fields: list | None = None,
-        **filters,
+        *,
+        facet_fields: list[FacetSpec] | None = None,
+        **filters: Any,
     ):
         # Circular imports are everywhere -_-
         from openlibrary.plugins.worksearch.code import (

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("openlibrary.worksearch")
 DEFAULT_RESULTS = 12
 MAX_RESULTS = 1000
 
-FacetSpec = str | dict[str, Any]
+FacetSpec = str | dict[str, int | str]
 """A bare Solr facet field name, or a {"name": ..., "sort"/"limit": ...} spec."""
 
 # Facets requested when details=True and no facet_fields override is given.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -77,7 +77,6 @@ class subjects(delegate.page):
         subj = get_subject(
             key,
             limit=0,
-            filters={"public_scan_b": "false", "lending_edition_s": "*"},
             sort=web.input(sort="readinglog").sort,
             request_label="SUBJECT_ENGINE_PAGE",
         )
@@ -339,7 +338,7 @@ async def get_subject_async(
 
     Optional arguments limit and offset can be passed to limit the number of works returned and starting offset.
 
-    Optional arguments has_fulltext and published_in can be passed to filter the results.
+    Optional arguments has_fulltext and publish_year can be passed to filter the results.
 
     By default, details=True requests every facet in DEFAULT_FACET_FIELDS. Pass
     facet_fields to request a specific subset instead.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -75,10 +75,11 @@ class subjects(delegate.page):
             # subjects.html doesn't render `works` -- the on-page carousel
             # runs its own query via `page.solr_query`.
             limit=0,
-            # subjects.html only renders these facets; author_facet/language/
+            # subjects.html only renders these facets synchronously; publish_year
+            # is fetched by the PublishingHistory partial instead (see
+            # SubjectPublishingHistoryPartial), and author_facet/language/
             # publisher_facet/has_fulltext are used solely by /publishers/<name>.
             facet_fields=[
-                {"name": "publish_year", "limit": -1},
                 "subject_facet",
                 "person_facet",
                 "place_facet",

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -69,16 +69,14 @@ class subjects(delegate.page):
 
         # this needs to be updated to include:
         # q=public_scan_b:true+OR+lending_edition_s:*
+        # No facets, no docs: subjects.html doesn't render `works` (the on-page
+        # carousel runs its own query via `page.solr_query`), and every facet it
+        # used is now fetched by the PublishingHistory/RelatedSubjects partials
+        # instead (see SubjectPublishingHistoryPartial/SubjectRelatedPartial).
+        # This leaves just a plain work_count query.
         subj = get_subject(
             key,
-            details=True,
-            # subjects.html doesn't render `works` -- the on-page carousel
-            # runs its own query via `page.solr_query`.
             limit=0,
-            # All facets subjects.html used are now fetched by the
-            # PublishingHistory/RelatedSubjects partials instead (see
-            # SubjectPublishingHistoryPartial/SubjectRelatedPartial).
-            facet_fields=[],
             filters={"public_scan_b": "false", "lending_edition_s": "*"},
             sort=web.input(sort="readinglog").sort,
             request_label="SUBJECT_ENGINE_PAGE",

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -30,6 +30,19 @@ logger = logging.getLogger("openlibrary.worksearch")
 DEFAULT_RESULTS = 12
 MAX_RESULTS = 1000
 
+# Facets requested when details=True and no facet_fields override is given.
+DEFAULT_FACET_FIELDS = [
+    {"name": "author_facet", "sort": "count"},
+    "language",
+    "publisher_facet",
+    {"name": "publish_year", "limit": -1},
+    "subject_facet",
+    "person_facet",
+    "place_facet",
+    "time_facet",
+    "has_fulltext",
+]
+
 # Works sampled per signal; 8 unique authors reliably appear in the first 40 rows.
 NOTABLE_AUTHORS_SAMPLE_SIZE = 40
 MAX_NOTABLE_AUTHORS = 8
@@ -56,6 +69,18 @@ class subjects(delegate.page):
         subj = get_subject(
             key,
             details=True,
+            # subjects.html doesn't render `works` -- the on-page carousel
+            # runs its own query via `page.solr_query`.
+            limit=0,
+            # subjects.html only renders these facets; author_facet/language/
+            # publisher_facet/has_fulltext are used solely by /publishers/<name>.
+            facet_fields=[
+                {"name": "publish_year", "limit": -1},
+                "subject_facet",
+                "person_facet",
+                "place_facet",
+                "time_facet",
+            ],
             filters={"public_scan_b": "false", "lending_edition_s": "*"},
             sort=web.input(sort="readinglog").sort,
             request_label="SUBJECT_ENGINE_PAGE",
@@ -261,6 +286,7 @@ async def get_subject_async(
     sort="editions",
     limit=DEFAULT_RESULTS,
     request_label: SolrRequestLabel = "UNLABELLED",
+    facet_fields: list | None = None,
     **filters,
 ) -> Subject:
     """Returns data related to a subject.
@@ -317,6 +343,9 @@ async def get_subject_async(
     Optional arguments limit and offset can be passed to limit the number of works returned and starting offset.
 
     Optional arguments has_fulltext and published_in can be passed to filter the results.
+
+    By default, details=True requests every facet in DEFAULT_FACET_FIELDS. Pass
+    facet_fields to request a specific subset instead.
     """
     engine = next((e for e in SUBJECTS if key.startswith(e.prefix)), None)
 
@@ -329,6 +358,7 @@ async def get_subject_async(
         offset=offset,
         sort=sort,
         limit=limit,
+        facet_fields=facet_fields,
         request_label=request_label,
         **filters,
     )
@@ -353,6 +383,7 @@ class SubjectEngine:
         limit=DEFAULT_RESULTS,
         sort="new",
         request_label: SolrRequestLabel = "UNLABELLED",
+        facet_fields: list | None = None,
         **filters,
     ):
         # Circular imports are everywhere -_-
@@ -400,20 +431,7 @@ class SubjectEngine:
                 "lending_edition_s",
                 "lending_identifier_s",
             ],
-            facet=(
-                details
-                and [
-                    {"name": "author_facet", "sort": "count"},
-                    "language",
-                    "publisher_facet",
-                    {"name": "publish_year", "limit": -1},
-                    "subject_facet",
-                    "person_facet",
-                    "place_facet",
-                    "time_facet",
-                    "has_fulltext",
-                ]
-            ),
+            facet=(facet_fields if facet_fields is not None else details and DEFAULT_FACET_FIELDS),
             extra_params=[
                 ("facet.mincount", 1),
                 ("facet.limit", 25),
@@ -442,25 +460,28 @@ class SubjectEngine:
                 for facet_field, facet_counts in result.facet_counts.items()
             }
 
-            subject.ebook_count = next(
-                (
-                    count
-                    for key, count in cast(  # These are fetched in a different format, we need to fix the types
-                        list[tuple[str, int]], result.facet_counts["has_fulltext"]
-                    )
-                    if key == "true"
-                ),
-                0,
-            )
+            # A facet_fields caller may omit any of these; default rather
+            # than assume every key is present.
+            if has_fulltext_counts := result.facet_counts.get("has_fulltext"):
+                subject.ebook_count = next(
+                    (
+                        count
+                        for key, count in cast(  # These are fetched in a different format, we need to fix the types
+                            list[tuple[str, int]], has_fulltext_counts
+                        )
+                        if key == "true"
+                    ),
+                    0,
+                )
 
-            subject.subjects = result.facet_counts["subject_facet"]
-            subject.places = result.facet_counts["place_facet"]
-            subject.people = result.facet_counts["person_facet"]
-            subject.times = result.facet_counts["time_facet"]
+            subject.subjects = result.facet_counts.get("subject_facet", [])
+            subject.places = result.facet_counts.get("place_facet", [])
+            subject.people = result.facet_counts.get("person_facet", [])
+            subject.times = result.facet_counts.get("time_facet", [])
 
-            subject.authors = result.facet_counts["author_key"]
-            subject.publishers = result.facet_counts["publisher_facet"]
-            subject.languages = result.facet_counts["language"]
+            subject.authors = result.facet_counts.get("author_key", [])
+            subject.publishers = result.facet_counts.get("publisher_facet", [])
+            subject.languages = result.facet_counts.get("language", [])
 
             # Phase 1 (epic #13135): "Notable authors" is computed and
             # cached separately -- see get_cached_notable_authors and
@@ -474,7 +495,7 @@ class SubjectEngine:
                 [year, count]
                 for year, count in cast(  # These are fetched in a different format, we need to fix the types
                     list[tuple[int, int]],
-                    result.facet_counts["publish_year"],
+                    result.facet_counts.get("publish_year", []),
                 )
                 if 1000 < year <= current_year + 1
             ]

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -61,7 +61,7 @@ $ q = query_param('q')
     $:macros.PublishingHistory(async_load=True, key=page.key)
 
     <div class="clearfix"></div>
-    $:macros.RelatedSubjects(page)
+    $:macros.RelatedSubjects(async_load=True, key=page.key)
 
     <div class="clearfix"></div>
     $:macros.SubjectAuthors(page.get('notable_authors', []))

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -58,7 +58,7 @@ $ q = query_param('q')
     $else:
       $# Only show default carousel if subject doesn't have an associated Tag
       $:macros.QueryCarousel(query=page.solr_query, sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
-    $:macros.PublishingHistory(page.publishing_history)
+    $:macros.PublishingHistory(async_load=True, key=page.key)
 
     <div class="clearfix"></div>
     $:macros.RelatedSubjects(page)

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -36,6 +36,8 @@ SolrRequestLabel = Literal[
     "SUBJECT_ENGINE_API",
     # Cached "Notable authors" widget on subject pages
     "SUBJECT_NOTABLE_AUTHORS",
+    # Async-loaded publishing-history chart on subject pages
+    "SUBJECT_PUBLISHING_HISTORY",
     # Used for the internal request made by solr to choose the best edition
     # during a normal book search
     "EDITION_MATCH",

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -38,6 +38,8 @@ SolrRequestLabel = Literal[
     "SUBJECT_NOTABLE_AUTHORS",
     # Async-loaded publishing-history chart on subject pages
     "SUBJECT_PUBLISHING_HISTORY",
+    # Async-loaded related-subjects/places/people/times widget on subject pages
+    "SUBJECT_RELATED",
     # Used for the internal request made by solr to choose the best edition
     # during a normal book search
     "EDITION_MATCH",

--- a/static/css/components/chart.css
+++ b/static/css/components/chart.css
@@ -23,6 +23,12 @@
   background-position: 340px 60px;
   box-sizing: border-box;
 }
+/* Only show the spinner background while its loading indicator is visible --
+   otherwise it bleeds through the async-partial-retry prompt, which lives
+   alongside it rather than replacing .chart outright. */
+.chart:has(.loadingIndicator.hidden) {
+  background-image: none;
+}
 .chartYaxis {
   position: absolute;
   left: -65px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13192

Creates new partials endpoints for the publishing history graph and the subject/place/etc facets at the bottom of the page. Muuuch faster on testing! Note these new partials endpoints will need to be added to haproxy's fastapi redirect!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
