### PR TITLE
Sync layout URL param when toggling list/grid view

### DIFF
--- a/openlibrary/plugins/openlibrary/js/list_books.js
+++ b/openlibrary/plugins/openlibrary/js/list_books.js
@@ -21,6 +21,9 @@ export class ListBooks {
         const layout = event.detail.value;
         this.listBooks.classList.toggle('list-books--grid', layout === 'grid');
         document.cookie = `LBL=${layout}; path=/; max-age=31536000`;
+        const url = new URL(window.location.href);
+        url.searchParams.set('layout', layout);
+        window.history.replaceState(null, '', url);
         // Shadow root, so data-ol-link-track can't see it. Same keys as before,
         // but this reports to Matomo rather than Athena.
         trackEvent('SearchLayout', layout === 'grid' ? 'Grid' : 'Details');

--- a/tests/unit/js/listBooks.test.js
+++ b/tests/unit/js/listBooks.test.js
@@ -25,6 +25,7 @@ function fire(el, value) {
 describe('ListBooks', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
+        document.cookie = 'LBL=; path=/; max-age=0';
         mockTrackEvent.mockClear();
         // Give each test a realistic URL with params worth preserving.
         window.history.replaceState(null, '', '/search?q=dune&sort=old');

--- a/tests/unit/js/listBooks.test.js
+++ b/tests/unit/js/listBooks.test.js
@@ -1,0 +1,88 @@
+import { ListBooks } from '../../../openlibrary/plugins/openlibrary/js/list_books.js';
+
+// Must be `mock`-prefixed: jest hoists the factory above the declarations.
+const mockTrackEvent = jest.fn();
+jest.mock('../../../openlibrary/plugins/openlibrary/js/ol.analytics.js', () => ({
+    trackEvent: (...args) => mockTrackEvent(...args),
+}));
+
+// Stand-in for <ol-segmented-control>: the consumer only listens for the
+// change event and reads `detail.value`.
+function makeFixture() {
+    const listBooks = document.createElement('ul');
+    listBooks.className = 'list-books';
+    const layoutControl = document.createElement('div');
+    layoutControl.className = 'tools--layout';
+    document.body.append(listBooks, layoutControl);
+    new ListBooks(listBooks, layoutControl).attach();
+    return { listBooks, layoutControl };
+}
+
+function fire(el, value) {
+    el.dispatchEvent(new CustomEvent('ol-segmented-control-change', { detail: { value } }));
+}
+
+describe('ListBooks', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        mockTrackEvent.mockClear();
+        // Give each test a realistic URL with params worth preserving.
+        window.history.replaceState(null, '', '/search?q=dune&sort=old');
+    });
+
+    test('toggles the grid class with the chosen layout', () => {
+        const { listBooks, layoutControl } = makeFixture();
+
+        fire(layoutControl, 'grid');
+        expect(listBooks.classList.contains('list-books--grid')).toBe(true);
+
+        fire(layoutControl, 'details');
+        expect(listBooks.classList.contains('list-books--grid')).toBe(false);
+    });
+
+    test('writes the layout into the URL, preserving existing params', () => {
+        const { layoutControl } = makeFixture();
+
+        fire(layoutControl, 'grid');
+
+        const params = new URLSearchParams(window.location.search);
+        expect(params.get('layout')).toBe('grid');
+        expect(params.get('q')).toBe('dune');
+        expect(params.get('sort')).toBe('old');
+    });
+
+    test('updates an existing layout param instead of duplicating it', () => {
+        window.history.replaceState(null, '', '/search?q=dune&layout=grid');
+        const { layoutControl } = makeFixture();
+
+        fire(layoutControl, 'details');
+
+        expect(window.location.search).toBe('?q=dune&layout=details');
+    });
+
+    test('replaces history rather than pushing entries', () => {
+        const { layoutControl } = makeFixture();
+        const before = window.history.length;
+
+        fire(layoutControl, 'grid');
+        fire(layoutControl, 'details');
+
+        expect(window.history.length).toBe(before);
+    });
+
+    test('persists the layout in the LBL cookie', () => {
+        const { layoutControl } = makeFixture();
+
+        fire(layoutControl, 'grid');
+
+        expect(document.cookie).toContain('LBL=grid');
+    });
+
+    test('reports the layout change to analytics', () => {
+        const { layoutControl } = makeFixture();
+
+        fire(layoutControl, 'grid');
+
+        expect(mockTrackEvent).toHaveBeenCalledWith('SearchLayout', 'Grid');
+    });
+});


### PR DESCRIPTION
Closes #13327

Feature: when the user toggles the List/Grid layout control, the URL now updates to reflect the chosen layout (e.g. `?layout=grid`), so the current view can be shared. Follows @RayBB's direction on the issue: `get_remembered_layout()` already resolves `?layout=` server-side, this adds the client-side URL sync.

### Technical
- Single change in `ListBooks.updateLayout()`: after toggling the class and setting the `LBL` cookie, the `layout` query param is written via `URLSearchParams` and `history.replaceState`, preserving existing params like `sort`.
- `replaceState` rather than `pushState` so toggling doesn't stack back-button entries (agreed on the issue).
- Because this handler is shared by the `ol-segmented-control`, the URL sync applies to lists, search, author, and reading log pages with no extra code.
- Adds `tests/unit/js/listBooks.test.js` (modeled on `sortOptions.test.js`): 6 cases covering the class toggle, URL param write with param preservation, no duplicate `layout` param, replaceState behavior, `LBL` cookie, and the analytics event. The two URL tests fail without this change. Test file drafted with AI assistance, then reviewed and verified locally, including a red/green check against the unpatched file.

### Testing
1. Open `/search?q=the&sort=old`
2. Click Grid: URL gains `layout=grid`, `q` and `sort` preserved
3. Click List: URL shows `layout=details`
4. Back button leaves the page in one press, it does not replay toggles
5. To verify the URL wins over the saved preference, edit the `layout` value directly in the address bar and hit Enter
6. `npx jest tests/unit/js/listBooks.test.js` passes (6 tests)

### Screenshot


https://github.com/user-attachments/assets/d3551dcf-65eb-4b2d-8272-f41a4958b1a2





### Stakeholders
@RayBB