### PR TITLE
Mount ol-vendor volume in fast_web like other containers to avoid initialization errors

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -39,6 +39,7 @@ services:
       # Debugger
       - 127.0.0.1:${FAST_WEB_DEBUG_PORT:-3001}:3000
     volumes:
+      - ol-vendor:/openlibrary/vendor
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
       - ${OL_MOUNT_DIR:-.}:/openlibrary


### PR DESCRIPTION
Previously, bringing up the site would cause the fast web container to error if you hadn't run `make git` on the host. This makes the fast web container have a volume mount for the vendors, so that is no longer necessary.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Site comes up.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
