### PR TITLE
Make local dev environment use ~650MB less memory

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -57,6 +57,8 @@ services:
         -Dsolr.max.booleanClauses=30000
         -Dsolr.environment=dev
       - LOCAL_DEV=true
+      # Local dev's index is tiny compared to prod; shrink the default 512m heap.
+      - SOLR_HEAP=128m
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8983/solr/openlibrary/admin/ping"]
       interval: 30s

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
-      - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
+      - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --timeout 180}
       - OL_COVERSTORE_PUBLIC_URL=${OL_COVERSTORE_PUBLIC_URL:-}
     command: docker/ol-web-start.sh
     ports:


### PR DESCRIPTION
With AI, it's more common that we might want to run multiple instances of the local dev environment at once, and memory usage is becoming a bottleneck for that workflow. Investigated with Claude, and found some opportunities to reduce memory usage:

- Since the number of documents solr is very small, we can reduce the solr heap size from the default of 512 MB to have the local environment use less memory. That wins ~400MB
- We no longer need multiple web workers; this was once required for login to work. Reducing to 1 web workers gives us another ~250MB.

That sends the local dev environment from using 1.6GB of memory down to about 1GB of memory! Still feels too high for open library, but it's an improvement.

### Technical
<!-- What should be noted about the implementation? -->

Here's the overall memory usage of each container -- note this is after reducing solr's heap size.

```mermaid
xychart-beta
    title "Per-service memory (MB)"
    x-axis "Elapsed (s)" [0, 7, 15, 22, 29, 37, 44, 51, 58, 66, 73, 80, 88, 95, 102, 109, 116]
    y-axis "Memory (MB)" 0 --> 500
    line [428 "solr", 426, 426, 426, 428, 432, 431, 436, 452, 456, 453, 456, 455, 458, 456, 455, 455 "solr"]
    line [395 "web", 396, 396, 396, 393, 393, 392, 392, 391, 391, 391, 392, 392, 390, 392, 392, 392 "web"]
    line [219 "fast_web", 271, 271, 271, 272, 274, 274, 273, 273, 274, 276, 275, 275, 275, 275, 275, 275 "fast_web"]
    line [9 "solr-updater", 7, 6, 7, 120, 260, 228, 224, 223, 224, 223, 224, 224, 224, 224, 224, 224 "solr-updater"]
    line [10 "home", 6, 6, 7, 7, 48, 150, 144, 143, 32, 252, 0 "home exits", 0, 0, 0, 0, 0 "home"]
    line [100 "covers", 100, 100, 100, 100, 101, 101, 105, 106, 112, 111, 112, 112, 115, 113, 113, 113 "covers"]
    line [53 "db", 56, 62, 58, 60, 66, 75, 71, 71, 69, 71, 66, 67, 67, 71, 67, 67 "db"]
    line [53 "infobase", 53, 53, 53, 53, 53, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54 "infobase"]
    line [49 "mockservices", 49, 49, 49, 50, 53, 49, 50, 50, 50, 50, 50, 54, 50, 50, 50, 50 "mockservices"]
    line [7 "memcached", 7, 7, 7, 7, 7, 18, 18, 18, 19, 19, 18, 18, 18, 18, 18, 18 "memcached"]
```

**solr** settles highest (~455MB even with the 128MB heap — JVM overhead beyond the heap itself), followed by
**web** (~392MB, flat throughout — already warm) and
**fast_web** (~275MB, quick ramp at startup). 
**solr-updater** ramps to ~224MB once it connects and starts polling.
**home** (the reindex process) ramps up, peaks ~252MB, then drops to 0 when it exits around 80s. The rest stay low and flat: **covers** (~113MB),
**db** (~67MB), **infobase** (~54MB), **mockservices** (~50MB),
**memcached** (~18MB).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

#### Solr heap
Confirmed editing works, searching works, facets work.

- **Baseline** (default Solr heap, `-Xms512m -Xmx512m`): `home` container exited (reindex complete) after **67.9s** wall time.
- **`SOLR_HEAP=128m`**: `home` container exited after **75.0s** wall time.

The ~7s difference is within the noise of this single run each (network variance from the docs-wiki clone `home` does on startup, etc.) — heap size had no meaningful effect on how long the reindex itself took.

Samples were taken every ~7s (5s requested interval + `docker stats` overhead):

```mermaid
xychart-beta
    title "Solr container memory (MB)"
    x-axis "Elapsed (s)" [0, 7, 15, 22, 29, 36, 44, 51, 58, 66]
    y-axis "Memory (MB)" 0 --> 900
    line [798 "512MB Heap", 791, 791, 791, 792, 799, 824, 826, 830, 830 ]
    line [362 "128MB Heap", 362, 361, 362, 362, 364, 404, 403, 410, 413]
```

#### Web workers

Confirmed logging in works

```mermaid
xychart-beta
    title "web container memory (MB): 4 vs 2 vs 1 workers"
    x-axis "Sample" [1, 2, 3, 4, 5]
    y-axis "Memory (MB)" 0 --> 450
    line [393 "4 workers", 393, 391, 391, 390]
    line [224 "2 workers", 224, 224, 224, 223]
    line [134 "1 worker", 135, 135, 135, 135]
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
