### PR TITLE
Fix pycache not working on linux local dev boxes

### DIFF
--- a/compose.near-prod.yaml
+++ b/compose.near-prod.yaml
@@ -65,6 +65,7 @@ services:
       - ol-build:/openlibrary/static/build
       - ol-nodemodules:/openlibrary/node_modules
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
     networks:
       - webnet
       - dbnet

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -20,6 +20,9 @@ services:
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      # Writable pyc bytecode cache dir -- see PYTHONPYCACHEPREFIX in
+      # Dockerfile.olbase for why this is needed.
+      - ol-pycache:/pycache
     environment:
       - LOCAL_DEV=true
       - OL_EXPOSE_SOLR_INTERNALS_PARAMS=true
@@ -43,6 +46,7 @@ services:
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
     environment:
       - LOCAL_DEV=true
       - OL_EXPOSE_SOLR_INTERNALS_PARAMS=true
@@ -86,6 +90,7 @@ services:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
 
   db:
     image: postgres:${POSTGRES_VERSION:-18.3}
@@ -118,6 +123,7 @@ services:
     volumes:
       - ol-vendor:/openlibrary/vendor
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
 
   infobase:
     build:
@@ -133,6 +139,7 @@ services:
     volumes:
       - ol-vendor:/openlibrary/vendor
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
     depends_on:
       db:
         condition: service_healthy
@@ -158,6 +165,7 @@ services:
       - ol-build:/openlibrary/static/build
       - ol-nodemodules:/openlibrary/node_modules
       - ${OL_MOUNT_DIR:-.}:/openlibrary
+      - ol-pycache:/pycache
       # For OSP download persistence across restarts
       - solr-updater-data:/solr-updater-data
     depends_on:
@@ -189,3 +197,4 @@ volumes:
   ol-build:
   ol-nodemodules:
   ol-postgres:
+  ol-pycache:

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -32,6 +32,9 @@ services:
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
       - .:/openlibrary
+      # Writable pyc bytecode cache dir -- see PYTHONPYCACHEPREFIX in
+      # Dockerfile.olbase for why this is needed.
+      - ol-pycache:/pycache
 
   fast_web:
     build:
@@ -52,6 +55,7 @@ services:
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
       - .:/openlibrary
+      - ol-pycache:/pycache
 
 
   memcached:
@@ -61,3 +65,4 @@ volumes:
   ol-vendor:
   ol-build:
   ol-nodemodules:
+  ol-pycache:

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -61,9 +61,10 @@ RUN chmod 644 /usr/lib/nginx/modules/ngx_http_modsecurity_module.so \
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
  && mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary \
  && mkdir -p /var/lib/coverstore && chown openlibrary:openlibrary /var/lib/coverstore \
- # In order to write to solr-updater's named volume, this needs to be
- # pre-created with the right permissions
- && mkdir -p /solr-updater-data && chown openlibrary:openlibrary /solr-updater-data
+ # For the container to have write permissions to the ol-* named volumes, they need
+ # to be pre-created with the right permissions
+ && mkdir -p /solr-updater-data && chown openlibrary:openlibrary /solr-updater-data \
+ && mkdir -p /pycache && chown openlibrary:openlibrary /pycache
 WORKDIR /openlibrary
 
 USER openlibrary
@@ -79,6 +80,10 @@ RUN uv pip install -r requirements.txt
 
 USER openlibrary
 
+# The code volume mount doesn't have write access from the container on linux,
+# So need to redirect pyc bytecode caching here instead of alongside sources.
+ENV PYTHONPYCACHEPREFIX=/pycache
+
 COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci --no-audit
 
@@ -86,3 +91,9 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 # run make to initialize git submodules, build css and js files
 RUN ln -s vendor/infogami/infogami infogami \
  && make
+
+# Pre-warm the pyc bytecode cache so it ships baked into the image.
+RUN python -m compileall -q \
+ -x '/node_modules/' \
+ "$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" \
+ /openlibrary


### PR DESCRIPTION
Neither the bind-mounted app source nor site-packages are writable by the container user on Linux, so every process start recompiled the entire import tree from scratch. Redirects caching to a dedicated, pre-owned volume and pre-warms it at image build time.

### Technical
<!-- What should be noted about the implementation? -->

Total memory over time (non-solr containers, summed)

```mermaid
xychart-beta
    title "Total memory across non-solr containers (MB)"
    x-axis "Elapsed (s)" [0, 7, 15, 22, 29, 36, 44, 51, 58, 66, 73, 80, 87, 95, 102, 109, 116]
    y-axis "Memory (MB)" 0 --> 1400
    line [604 "before", 679, 671, 755, 1085, 955, 995, 1300, 918, 920, 923, 926, 921, 923, 922, 926, 920]
    line [633 "after", 616, 619, 628, 812, 885, 894, 797, 797, 797, 801, 804, 798, 804, 800, 803, 798]
```

The `before` line spikes harder mid-startup (peaking ~1.3GB around the reindex burst at 51s) than `after` (~895MB peak) — less to compile means less transient memory pressure during the busiest part of startup, not just a lower resting value.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
