### PR TITLE
Subject-page carousel on ol-books-display: covers/list toggle + per-book actions popover

### DIFF
--- a/CAROUSEL-ACTIONS-PLAN.md
+++ b/CAROUSEL-ACTIONS-PLAN.md
@@ -1,0 +1,179 @@
+# Carousel actions — plan
+
+Branch `carousel-actions` off `upstream/master` (297ed7c20). Goal: on the
+subject page, replace the slick carousel with `<ol-carousel>`, add a
+Covers/List view toggle, and add a per-book "+" popover with shelf actions,
+rating, and add-to-list.
+
+## 1. What exists today (findings)
+
+**Subject page carousel** — `templates/subjects.html:60` calls
+`macros.QueryCarousel(query=page.solr_query, sort='trending,...', lazy=True)`.
+Lazy path emits a `.lazy-carousel` stub → `js/lazy-carousel.js` →
+`GET /partials/LazyCarousel.json` → `{"partials": "<html>"}` (whole section,
+rendered by `books/custom_carousel.html` + `custom_carousel_card.html`) →
+slick (`js/carousel/Carousel.js`). Load-more: `GET /partials/CarouselLoadMore.json`
+→ `{"partials": ["<card html>", ...]}`. Data: `_CAROUSEL_FIELDS`
+(`plugins/openlibrary/partials.py:470`) = key, title, subtitle, editions,
+author_name, availability, cover_i, ia, provider ids. **Missing** for the
+list view: `author_key`, `ratings_average`, `ratings_count`,
+`first_publish_year`, `edition_count`, `ebook_count_i` — all exist in Solr,
+just not requested. CTA/availability is server-side only
+(`macros/LoanStatus.html` → `lending.get_lending_state()`).
+
+**`<ol-carousel>`** (`components/lit/OlCarousel.js`) — presentation only:
+light-DOM children, scroll-snap, arrows, `ol-carousel-page-change` event,
+`next()/prev()/goToPage()`. No fetch/pagination. Wants real `src` +
+`loading="lazy"` (not slick's `data-lazy`). Unused in prod templates so far.
+
+**Shelves** — `POST /works/OL..W/bookshelves.json` form body
+`bookshelf_id=1|2|3|4|-1`, `edition_id?`, `dont_remove?` → FastAPI
+`fastapi/internal/api.py:281`; returns 401 JSON when logged out (legacy JS
+doesn't handle that — star-ratings JS does, `js/star-ratings/index.js:35`).
+Shelf ids `core/bookshelves.py:35`. Per-user state for a batch of works:
+`Bookshelves.get_users_read_status_of_works(username, work_ids)`
+(`core/bookshelves.py:613`) — server-side only, no JSON endpoint.
+
+**Ratings** — `POST /works/OL..W/ratings.json` form `rating=1..5` (omit →
+delete); server auto-shelves to Already Read (`core/ratings.py:174`). Current
+user's rating: only `get_users_rating_for_work` (single) — no batch helper.
+
+**Lists** — `js/lists/ListService.js`: create `POST {userKey}/lists.json`
+`{name, description, seeds}`; add/remove `POST {listKey}/seeds.json`
+`{add|remove: [{key}]}`; user's lists + membership
+`GET /partials/MyBooksDropperLists.json` → `{dropper: html, listData:
+{listKey: {members: [seedKeys], listName}}}` (401 logged-out). Lists-for-seed
+`GET /works/OL..W/lists.json` (no ownership flag).
+
+**Auth in JS** — inferred from server markup (`.generic-dropper--disabled`,
+`data-user-key`); login intent via `queueAction()` cookie + redirect.
+
+**Icons** — `<ol-icon>` / `$:macros.icon()` are on PR #12955 (still open),
+NOT on master. Master Lit components inline Lucide `<svg>` paths
+(`OlCarousel.js:272`). Leftover untracked `static/icons/sprite.svg` and
+`icons.generated.js` on this checkout are orphans.
+
+**Popover-in-carousel blocker (F2 in BOOK-ACTIONS-AUDIT.md)** — resolved on
+master: `OlPopover` promotes to the top layer (`utils/top-layer.js`).
+
+**Dev caveat** — availability mock always returns `{}`, so every card is
+"Find in a library" locally (see memory `reference_dev_availability_always_empty`).
+
+## 2. Architecture
+
+### Data: JSON, split into public + per-user
+- **`GET /partials/… → new `GET /api/carousel.json`** (FastAPI, alongside
+  `fastapi/partials.py`) — params mirror `LazyCarouselParams`/`CarouselLoadMore`:
+  `q, sort, limit, offset, has_fulltext_only, safe_mode, fallback`. Returns
+  `{docs: [...], num_found, offset, limit}`. Reuses
+  `gather_lazy_carousel_data_async` (memcached 300s) with an extended field
+  list. Each doc is normalized server-side into a flat card model:
+  `key, title, subtitle, authors[{key,name}], cover_id, cover_edition_key,
+  edition_key, ia, first_publish_year,
+  ratings{average,count}, access{state, label, url, external?, copies?}`.
+  `access` comes from `get_lending_state()` so the CTA logic isn't duplicated
+  in JS. Cacheable (no user data).
+- **`GET /api/me/book-state.json?work_ids=OL1W,OL2W`** — new, uncached, 401
+  when logged out. `{shelves: {OL1W: 1}, ratings: {OL1W: 4}}`. Backed by
+  `get_users_read_status_of_works` + a new `Ratings.get_users_ratings_of_works`
+  (same SQL shape). Client fires it after each page of docs arrives.
+- Lists: reuse `MyBooksDropperLists.json` `listData` for the user's lists +
+  membership (fetched lazily on first "Add to list", cached per page);
+  `ListService` for create/add/remove.
+- Existing shelf/rating POST endpoints reused as-is; add 401 handling →
+  `queueAction()` + login redirect (decided).
+
+### Components (Lit, `openlibrary/components/lit/`)
+- **`<ol-books-display>`** — the controller. Named for what it is (a set of
+  books) not how it lays them out: `view` is an open enum — `covers` (carousel),
+  `list` (rows) now; `grid` (multi-row cover grid) and others later. Attributes:
+  `query, sort, limit, url (see-all), title, has-fulltext-only, fallback`,
+  `view="covers|list"` (default set in code; no user preference saved yet),
+  plus `label-*` strings for i18n. Owns: fetch +
+  pagination (`ol-carousel-page-change` near end → next page; list view
+  "Show N more"), the Covers/List `<ol-segmented-control>` toggle, the
+  user-state overlay, "Show N more · Collapse · See all" footer in list view.
+  Renders `<ol-carousel>` (covers) or a `<ul>` (list) from the same docs.
+- **`<ol-book-card>`** — one doc, `variant="cover|row"`. Cover variant: cover
+  image (real `src`, `loading="lazy"`), availability badge (NOT ONLINE /
+  PREVIEW), "+"/"✓" corner button, title + author below, CTA button. Row
+  variant: cover, title, "by author" link, stars + avg · count, "First
+  published Y", CTA + shelf split button (`✓ Want to Read | ▾`; the main
+  button toggles the shown shelf, the chevron opens `<ol-book-actions>`).
+  Dropped from the mock: "N editions · N ebooks" and "N of M copies available".
+  Blank-cover fallback = title/author on tinted block (as in mock).
+- **`<ol-book-actions>`** — the popover. Header: title + "by author" (single
+  line, ellipsis). Pane 1: four shelf rows (Lucide bookmark / book-open /
+  circle-check / circle-pause; current shelf marked), star rater ("Rate this
+  book"), "Add to list ›", then (phase 2) Preview / Search inside / Find in a
+  library / Download options. Pane 2 (slides in from right, Back slides out):
+  "+ Create a list" (inlines name input + Create), "Filter lists…" input,
+  checkbox rows with seed count, spinner while lists load. Optimistic updates
+  + toast on failure. Fires `ol-book-state-change` so the card's ✓ / split
+  button and list-view row stay in sync.
+- Icons: inline Lucide `<svg>` templates in a shared `book-icons.js` module
+  now; swap to `<ol-icon>` when #12955 lands.
+- Logged-out "+" / shelf clicks: `queueAction()` intent cookie + redirect to
+  login (site convention).
+
+### Templates
+- `macros/QueryCarousel.html` gains a `component=True` (or new
+  `macros/BookCarouselSection.html`) branch that emits the Lit element with
+  the same config the `.lazy-carousel` stub carries today. `subjects.html:60`
+  opts in. Home page etc. keep slick until later.
+
+## 3. Phases
+
+1. **Data** — `/api/carousel.json` (+ tests), `/api/me/book-state.json`,
+   `Ratings.get_users_ratings_of_works`. Verify list-view fields in dev Solr.
+2. **Covers view** — `<ol-books-display>` + `<ol-book-card
+   variant="cover">` on `<ol-carousel>`, pagination, subject page opt-in.
+   Parity with today (no actions yet).
+3. **Toggle + list view** — segmented control, row variant, show-more /
+   collapse / see-all. Default view set in code, nothing persisted.
+4. **Actions popover** — shelves + rating + user-state overlay + ✓ state on
+   cards + split button in list view. Logged-out handling.
+5. **Add to list** — pane 2, filter, inline create, membership, spinner.
+6. **Phase 2 items** — Preview / Search inside / Find in a library /
+   Download options in the popover (coordinate with `BOOK-ACTIONS-AUDIT.md`
+   branch `action-button`), roll out to other QueryCarousel surfaces.
+
+## 4. Decisions (2026-08-16)
+
+- Name: `ol-books-display`, `view` is extensible (covers / list / grid…).
+- Icons inline for now. Logged-out → login redirect. Split button in list
+  view opens the same popover. Preview/Search inside/Find/Download rows are
+  phase 2. No saved view preference. No edition/ebook counts, no copies
+  line; keep first-publish year. Subject page only.
+- Availability API stays in the data path for the CTA (see chat).
+
+## 5. Status (2026-08-16, end of first build session)
+
+Phases 1–5 built and committed on `carousel-actions` (7 commits on top of
+297ed7c20), verified in dev on /subjects/fiction, signed in and out:
+
+- Endpoints: `GET /books-display.json`, `GET /books-display/user-state.json`
+  (`fastapi/books_display.py`, `fastapi/services/books_display.py`, tests in
+  `tests/fastapi/test_books_display.py`). Dev proxy paths registered in
+  `deprecated_handler.py`; `fast_web` gets `OL_COVERSTORE_PUBLIC_URL`.
+- Components: `components/lit/OlBooksDisplay.js` (light DOM),
+  `OlBookActions.js` (shadow), `utils/books-api.js`, `utils/book-icons.js`;
+  CSS `static/css/components/ol-books-display.css` (imported by
+  `ol-components.css`); jest tests `tests/unit/js/OlBooksDisplay.test.js`,
+  `OlBookActions.test.js`.
+- Templates: `macros/BooksDisplay.html`, `subjects.html` switched, design
+  docs `design/components/books-display.html.jinja` + `book-actions.html.jinja`.
+
+Follow-ups / known gaps:
+- Icons: still inline Lucide paths; swap to `<ol-icon>` when #12955 merges.
+- Phase-2 popover rows (Preview / Search inside / Find in a library /
+  Download options) — coordinate with `BOOK-ACTIONS-AUDIT.md`.
+- `grid` view (multi-row cover grid) — `view` enum is ready for it.
+- Lists come from `/partials/MyBooksDropperLists.json`, which also renders
+  (and we discard) the dropper HTML; a JSON-only lists+membership endpoint
+  would be cheaper.
+- `join_waitlist` renders a POST form to `/borrow/ia/{ocaid}`; unverified in
+  dev (mock availability never yields waitlist state).
+- Book preview modal (`data-book-preview`) isn't used for `preview` CTAs; they
+  link straight to archive.org.
+- Other QueryCarousel callers (home page etc.) still on slick.

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ services:
     environment:
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --timeout 180 --max-requests 500}
+      - OL_COVERSTORE_PUBLIC_URL=${OL_COVERSTORE_PUBLIC_URL:-}
     command: docker/ol-web-fastapi-start.sh
     ports:
       - ${FAST_WEB_PORT:-18080}:8080

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -216,6 +216,7 @@ def create_app() -> FastAPI | None:
 
     from openlibrary.fastapi.account import router as account_router
     from openlibrary.fastapi.books import router as books_router
+    from openlibrary.fastapi.books_display import router as books_display_router
     from openlibrary.fastapi.cdn import router as cdn_router
     from openlibrary.fastapi.checkins import router as checkins_router
     from openlibrary.fastapi.importapi import router as importapi_router
@@ -236,6 +237,7 @@ def create_app() -> FastAPI | None:
     # Include routers
     app.include_router(account_router)
     app.include_router(books_router)
+    app.include_router(books_display_router)
     app.include_router(cdn_router)
     app.include_router(checkins_router)
     app.include_router(importapi_router)

--- a/openlibrary/components/lit/OlBookActions.js
+++ b/openlibrary/components/lit/OlBookActions.js
@@ -1,0 +1,752 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { icon } from './utils/book-icons.js';
+import { SHELF, setShelf, setRating, fetchUserLists, addToList, removeFromList, createList } from './utils/books-api.js';
+import { showToast } from './OlToastRegion.js';
+import './OlPopover.js';
+
+/**
+ * Per-book action popover: reading-log shelves, a star rating, and an
+ * "Add to list" pane that slides in from the right. Composes `<ol-popover>`
+ * for the shell; the caller supplies the trigger.
+ *
+ * Only for logged-in users — the caller sends logged-out visitors to login
+ * instead of rendering this. State is optimistic: the UI updates first and
+ * an error toast rolls back.
+ *
+ * @element ol-book-actions
+ *
+ * @prop {Object} book     - `{ key, title, authors: [{name}], editionKey? }`
+ * @prop {Number} shelf    - Current shelf id (1–4) or null
+ * @prop {Number} rating   - Current rating (1–5) or null
+ * @prop {String} userKey  - "/people/<username>", needed to create lists
+ * @prop {Object} labels   - Translated strings (see DEFAULT_LABELS)
+ * @prop {String} placement - ol-popover placement (default "bottom-end")
+ *
+ * @fires ol-book-state-change - After a shelf or rating change is accepted by
+ *     the server. detail: { key, shelf, rating }
+ *
+ * @slot trigger - The button that opens the popover.
+ */
+export const DEFAULT_LABELS = {
+    by: 'by %(name)s',
+    actionsFor: 'Actions for %(title)s',
+    wantToRead: 'Want to Read',
+    currentlyReading: 'Currently Reading',
+    alreadyRead: 'Already Read',
+    stoppedReading: 'Stopped Reading',
+    rateThisBook: 'Rate this book',
+    yourRating: 'Your rating: %(rating)s of 5',
+    rateStar: 'Rate %(rating)s of 5',
+    clearRating: 'Clear rating',
+    addToList: 'Add to list',
+    back: 'Back',
+    createList: 'Create a list',
+    listName: 'List name',
+    create: 'Create',
+    filterLists: 'Filter lists…',
+    noLists: 'You have no lists yet.',
+    noMatchingLists: 'No lists match.',
+    loadingLists: 'Loading lists…',
+    itemsInList: '%(count)s items',
+    errorGeneric: 'Something went wrong. Please try again.',
+};
+
+const SHELF_ROWS = [
+    { id: SHELF.WANT_TO_READ, icon: 'bookmark', label: 'wantToRead' },
+    { id: SHELF.CURRENTLY_READING, icon: 'book-open', label: 'currentlyReading' },
+    { id: SHELF.ALREADY_READ, icon: 'circle-check', label: 'alreadyRead' },
+    { id: SHELF.STOPPED_READING, icon: 'circle-pause', label: 'stoppedReading' },
+];
+
+// One in-flight lists request shared by every popover on the page.
+let _listsPromise = null;
+/** Drop the shared lists cache (tests, or after a mutation elsewhere). */
+export function resetListsCache() {
+    _listsPromise = null;
+}
+
+/** "%(name)s" style interpolation, matching the server-side i18n strings. */
+export function fmt(template, vars) {
+    return template.replace(/%\((\w+)\)s/g, (_, k) => (vars[k] ?? ''));
+}
+
+export class OlBookActions extends LitElement {
+    static properties = {
+        book: { type: Object },
+        shelf: { type: Number },
+        rating: { type: Number },
+        userKey: { type: String, attribute: 'user-key' },
+        labels: { type: Object },
+        placement: { type: String },
+        _pane: { state: true },
+        _lists: { state: true },
+        _listsLoading: { state: true },
+        _listFilter: { state: true },
+        _creating: { state: true },
+        _createBusy: { state: true },
+        _hoverRating: { state: true },
+        _busy: { state: true },
+    };
+
+    static styles = css`
+        :host {
+            display: inline-flex;
+            font-family: var(--font-family-body);
+        }
+
+        .panel {
+            width: 300px;
+            max-width: 90vw;
+            color: var(--color-text);
+            font-size: var(--font-size-body-medium);
+            /* clip, not hidden: focusing the off-screen pane must not scroll
+               the panel (that would double up with the track's translate). */
+            overflow: clip;
+            border-radius: var(--border-radius-overlay);
+        }
+
+        .header {
+            padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+            border-bottom: var(--border-divider);
+            font-size: var(--font-size-label-medium);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .header strong {
+            font-weight: 700;
+        }
+
+        .header .byline {
+            color: var(--color-text-secondary);
+        }
+
+        /* Two panes side by side in a track twice the panel width; the track
+           slides to reveal the second one. */
+        .track {
+            display: flex;
+            width: 200%;
+            transition: transform 220ms cubic-bezier(0.165, 0.84, 0.44, 1);
+        }
+
+        .track.pane-lists {
+            transform: translateX(-50%);
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .track {
+                transition: none;
+            }
+        }
+
+        .pane {
+            width: 50%;
+            flex: 0 0 50%;
+            box-sizing: border-box;
+        }
+
+        /* Off-screen pane must not be reachable */
+        .pane[inert] {
+            visibility: hidden;
+        }
+
+        .group {
+            padding: var(--spacing-inset-xs) 0;
+        }
+
+        .group + .group {
+            border-top: var(--border-divider);
+        }
+
+        .row {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-inline-sm);
+            width: 100%;
+            box-sizing: border-box;
+            margin: 0;
+            padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+            border: 0;
+            background: none;
+            color: inherit;
+            font: inherit;
+            text-align: left;
+            cursor: pointer;
+            text-decoration: none;
+        }
+
+        .row .obd-icon {
+            width: 20px;
+            height: 20px;
+            flex: 0 0 20px;
+            color: var(--color-text-secondary);
+        }
+
+        .row .label {
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .row .trail {
+            width: 16px;
+            height: 16px;
+            color: var(--color-text-muted);
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            .row:hover {
+                background: var(--color-hover-overlay);
+            }
+        }
+
+        .row:focus-visible {
+            outline: 2px solid var(--color-focus-ring);
+            outline-offset: -2px;
+        }
+
+        .row[aria-checked="true"] {
+            color: var(--color-link);
+            font-weight: 600;
+        }
+
+        .row[aria-checked="true"] .obd-icon {
+            color: var(--color-link);
+        }
+
+        .row[disabled] {
+            cursor: default;
+            opacity: 0.6;
+        }
+
+        /* Stars */
+        .stars {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-inline-sm);
+            padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+        }
+
+        .star-buttons {
+            display: inline-flex;
+        }
+
+        .star {
+            padding: 0;
+            border: 0;
+            background: none;
+            color: var(--gold);
+            cursor: pointer;
+            line-height: 0;
+        }
+
+        .star .obd-icon {
+            width: 24px;
+            height: 24px;
+        }
+
+        .star:focus-visible {
+            outline: 2px solid var(--color-focus-ring);
+            border-radius: var(--border-radius-sm);
+        }
+
+        .stars .caption {
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-label-medium);
+        }
+
+        /* Lists pane */
+        .lists-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--spacing-inline-sm);
+            padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+            border-bottom: var(--border-divider);
+        }
+
+        .back {
+            display: inline-flex;
+            align-items: center;
+            gap: 2px;
+            padding: 0;
+            border: 0;
+            background: none;
+            color: inherit;
+            font: inherit;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .back .obd-icon {
+            width: 16px;
+            height: 16px;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px;
+            height: var(--control-height-small);
+            padding: 0 var(--spacing-inset-sm);
+            border: 1px solid transparent;
+            border-radius: var(--border-radius-button);
+            background: var(--color-primary);
+            color: var(--color-on-primary);
+            font: inherit;
+            font-size: var(--font-size-label-medium);
+            font-weight: 600;
+            white-space: nowrap;
+            cursor: pointer;
+        }
+
+        .btn:hover {
+            background: var(--color-primary-hover);
+        }
+
+        .btn:focus-visible {
+            outline: 2px solid var(--color-focus-ring);
+            outline-offset: 2px;
+        }
+
+        .btn[disabled] {
+            background: var(--color-disabled-bg);
+            color: var(--color-disabled-fg);
+            cursor: default;
+        }
+
+        .btn .obd-icon {
+            width: 14px;
+            height: 14px;
+        }
+
+        .field {
+            display: flex;
+            gap: var(--spacing-inline-sm);
+            padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+        }
+
+        .input {
+            flex: 1;
+            min-width: 0;
+            height: var(--control-height-small);
+            box-sizing: border-box;
+            padding: 0 var(--spacing-inset-sm);
+            border: var(--border-input);
+            border-radius: var(--border-radius-input);
+            background: var(--color-surface);
+            color: inherit;
+            font: inherit;
+        }
+
+        .input:focus {
+            outline: 2px solid var(--color-focus-ring);
+            outline-offset: -1px;
+        }
+
+        .list-items {
+            max-height: 240px;
+            overflow-y: auto;
+            padding-bottom: var(--spacing-inset-xs);
+        }
+
+        .list-row {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-inline-sm);
+            padding: var(--spacing-inset-xs) var(--spacing-inset-md);
+            cursor: pointer;
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            .list-row:hover {
+                background: var(--color-hover-overlay);
+            }
+        }
+
+        .list-row input {
+            width: 18px;
+            height: 18px;
+            margin: 0;
+            accent-color: var(--color-primary);
+            flex: 0 0 auto;
+        }
+
+        .list-row .name {
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .count {
+            min-width: 20px;
+            padding: 1px 8px;
+            border-radius: var(--border-radius-pill);
+            background: var(--color-surface-sunken);
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-label-small);
+            text-align: center;
+        }
+
+        .empty,
+        .loading {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-inline-sm);
+            padding: var(--spacing-inset-md);
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-label-medium);
+        }
+
+        .spinner {
+            width: 18px;
+            height: 18px;
+            animation: spin 0.9s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .spinner {
+                animation-duration: 3s;
+            }
+        }
+    `;
+
+    constructor() {
+        super();
+        this.book = null;
+        this.shelf = null;
+        this.rating = null;
+        this.userKey = '';
+        this.labels = {};
+        this.placement = 'bottom-end';
+        this._pane = 'main';
+        this._lists = null;
+        this._listsLoading = false;
+        this._listFilter = '';
+        this._creating = false;
+        this._createBusy = false;
+        this._hoverRating = 0;
+        this._busy = false;
+    }
+
+    /** @param {string} key */
+    t(key, vars) {
+        const s = this.labels?.[key] ?? DEFAULT_LABELS[key] ?? key;
+        return vars ? fmt(s, vars) : s;
+    }
+
+    get _seedKey() {
+        return this.book?.key || '';
+    }
+
+    render() {
+        if (!this.book) return html`<slot name="trigger"></slot>`;
+        const title = this.book.title || '';
+        return html`
+            <ol-popover
+                placement=${this.placement}
+                offset="6"
+                aria-label=${this.t('actionsFor', { title })}
+                @ol-popover-open=${this._onOpen}
+                @ol-popover-close=${this._onCloseRequest}
+            >
+                <slot name="trigger" slot="trigger"></slot>
+                <div class="panel">
+                    <div class="track ${classMap({ 'pane-lists': this._pane === 'lists' })}">
+                        <div class="pane" ?inert=${this._pane !== 'main'}>${this._renderMain()}</div>
+                        <div class="pane" ?inert=${this._pane !== 'lists'}>${this._renderLists()}</div>
+                    </div>
+                </div>
+            </ol-popover>
+        `;
+    }
+
+    _renderMain() {
+        const authors = (this.book.authors || []).map(a => a.name).filter(Boolean).join(', ');
+        return html`
+            <div class="header">
+                <strong>${this.book.title}</strong>
+                ${authors ? html` <span class="byline">${this.t('by', { name: authors })}</span>` : nothing}
+            </div>
+            <div class="group" role="group">
+                ${SHELF_ROWS.map(row => html`
+                    <button
+                        type="button"
+                        class="row"
+                        role="menuitemradio"
+                        aria-checked=${this.shelf === row.id ? 'true' : 'false'}
+                        ?disabled=${this._busy}
+                        @click=${() => this._onShelfClick(row.id)}
+                    >
+                        ${icon(row.icon)}
+                        <span class="label">${this.t(row.label)}</span>
+                        ${this.shelf === row.id ? icon('check', { cls: 'obd-icon trail' }) : nothing}
+                    </button>
+                `)}
+            </div>
+            <div class="group">
+                ${this._renderStars()}
+            </div>
+            <div class="group">
+                <button type="button" class="row" @click=${this._openLists}>
+                    ${icon('list-plus')}
+                    <span class="label">${this.t('addToList')}</span>
+                    ${icon('chevron-right', { cls: 'obd-icon trail' })}
+                </button>
+            </div>
+        `;
+    }
+
+    _renderStars() {
+        const shown = this._hoverRating || this.rating || 0;
+        const caption = this.rating
+            ? this.t('yourRating', { rating: this.rating })
+            : this.t('rateThisBook');
+        return html`
+            <div class="stars">
+                <span class="star-buttons" role="radiogroup" aria-label=${this.t('rateThisBook')} @mouseleave=${() => { this._hoverRating = 0; }}>
+                    ${[1, 2, 3, 4, 5].map(n => html`
+                        <button
+                            type="button"
+                            class="star"
+                            role="radio"
+                            aria-checked=${this.rating === n ? 'true' : 'false'}
+                            aria-label=${this.rating === n ? this.t('clearRating') : this.t('rateStar', { rating: n })}
+                            ?disabled=${this._busy}
+                            @mouseenter=${() => { this._hoverRating = n; }}
+                            @focus=${() => { this._hoverRating = n; }}
+                            @blur=${() => { this._hoverRating = 0; }}
+                            @click=${() => this._onRate(n)}
+                        >${icon('star', { fill: n <= shown ? 'currentColor' : 'none', strokeWidth: 1.5 })}</button>
+                    `)}
+                </span>
+                <span class="caption">${caption}</span>
+            </div>
+        `;
+    }
+
+    _renderLists() {
+        return html`
+            <div class="lists-header">
+                <button type="button" class="back" @click=${this._closeLists}>
+                    ${icon('chevron-left')}${this.t('back')}
+                </button>
+                ${this._creating ? nothing : html`
+                    <button type="button" class="btn" @click=${this._startCreate}>
+                        ${icon('plus')}${this.t('createList')}
+                    </button>
+                `}
+            </div>
+            ${this._creating ? html`
+                <form class="field" @submit=${this._onCreateSubmit}>
+                    <input
+                        class="input"
+                        name="name"
+                        type="text"
+                        required
+                        maxlength="200"
+                        placeholder=${this.t('listName')}
+                        aria-label=${this.t('listName')}
+                        ?disabled=${this._createBusy}
+                        @keydown=${e => { if (e.key === 'Escape') { e.stopPropagation(); this._cancelCreate(); } }}
+                    />
+                    <button type="submit" class="btn" ?disabled=${this._createBusy}>${this.t('create')}</button>
+                </form>
+            ` : html`
+                <div class="field">
+                    <input
+                        class="input"
+                        type="search"
+                        placeholder=${this.t('filterLists')}
+                        aria-label=${this.t('filterLists')}
+                        .value=${this._listFilter}
+                        @input=${e => { this._listFilter = e.target.value; }}
+                    />
+                </div>
+            `}
+            <div class="list-items">${this._renderListItems()}</div>
+        `;
+    }
+
+    _renderListItems() {
+        if (this._listsLoading || this._lists === null) {
+            return html`<div class="loading" role="status">${icon('loader', { cls: 'obd-icon spinner' })}${this.t('loadingLists')}</div>`;
+        }
+        const entries = Object.entries(this._lists);
+        if (!entries.length) return html`<div class="empty">${this.t('noLists')}</div>`;
+        const filter = this._listFilter.trim().toLowerCase();
+        const shown = filter ? entries.filter(([, l]) => l.listName.toLowerCase().includes(filter)) : entries;
+        if (!shown.length) return html`<div class="empty">${this.t('noMatchingLists')}</div>`;
+        return shown.map(([key, list]) => {
+            const checked = list.members.includes(this._seedKey);
+            return html`
+                <label class="list-row">
+                    <input type="checkbox" .checked=${checked} @change=${e => this._onListToggle(key, e.target.checked)} />
+                    <span class="name">${list.listName}</span>
+                    <span class="count" aria-label=${this.t('itemsInList', { count: list.members.length })}>${list.members.length}</span>
+                </label>
+            `;
+        });
+    }
+
+    // ── Popover lifecycle ────────────────────────────────────
+
+    _onOpen() {
+        this._pane = 'main';
+        this._creating = false;
+        this._listFilter = '';
+    }
+
+    _onCloseRequest(e) {
+        // Escape from the lists pane goes back a step instead of closing.
+        if (e.detail?.reason === 'escape' && this._pane === 'lists') {
+            e.preventDefault();
+            this._closeLists();
+        }
+    }
+
+    _emitState() {
+        this.dispatchEvent(new CustomEvent('ol-book-state-change', {
+            bubbles: true,
+            composed: true,
+            detail: { key: this.book.key, shelf: this.shelf, rating: this.rating },
+        }));
+    }
+
+    _fail(error) {
+        if (error?.status === 401) {
+            window.location.href = `/account/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+            return;
+        }
+        showToast(this.t('errorGeneric'), { type: 'error' });
+    }
+
+    // ── Shelves ──────────────────────────────────────────────
+
+    async _onShelfClick(shelfId) {
+        const previous = this.shelf;
+        this.shelf = previous === shelfId ? null : shelfId;
+        this._busy = true;
+        try {
+            // Posting the current shelf toggles it off server-side.
+            await setShelf(this.book.key, shelfId, { editionKey: this.book.editionKey });
+            this._emitState();
+        } catch (error) {
+            this.shelf = previous;
+            this._fail(error);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    // ── Rating ───────────────────────────────────────────────
+
+    async _onRate(n) {
+        const previous = this.rating;
+        const previousShelf = this.shelf;
+        const next = previous === n ? null : n;
+        this.rating = next;
+        // The server moves a rated book to Already Read.
+        if (next) this.shelf = SHELF.ALREADY_READ;
+        this._busy = true;
+        try {
+            await setRating(this.book.key, next, { editionKey: this.book.editionKey });
+            this._emitState();
+        } catch (error) {
+            this.rating = previous;
+            this.shelf = previousShelf;
+            this._fail(error);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    // ── Lists ────────────────────────────────────────────────
+
+    async _openLists() {
+        this._pane = 'lists';
+        await this.updateComplete;
+        this.shadowRoot.querySelector('.pane:nth-child(2) .input')?.focus({ preventScroll: true });
+        this._loadLists();
+    }
+
+    async _closeLists() {
+        this._pane = 'main';
+        this._creating = false;
+        await this.updateComplete;
+        this.shadowRoot.querySelector('.pane:nth-child(1) .group:last-child .row')?.focus({ preventScroll: true });
+    }
+
+    async _loadLists() {
+        if (this._lists !== null && !this._listsLoading) return;
+        this._listsLoading = true;
+        try {
+            _listsPromise ||= fetchUserLists();
+            this._lists = await _listsPromise;
+        } catch (error) {
+            _listsPromise = null;
+            this._lists = {};
+            this._fail(error);
+        } finally {
+            this._listsLoading = false;
+        }
+    }
+
+    async _onListToggle(listKey, checked) {
+        const list = this._lists[listKey];
+        const before = list.members;
+        list.members = checked ? [...before, this._seedKey] : before.filter(k => k !== this._seedKey);
+        this.requestUpdate();
+        try {
+            await (checked ? addToList(listKey, this._seedKey) : removeFromList(listKey, this._seedKey));
+        } catch (error) {
+            list.members = before;
+            this.requestUpdate();
+            this._fail(error);
+        }
+    }
+
+    async _startCreate() {
+        this._creating = true;
+        await this.updateComplete;
+        this.shadowRoot.querySelector('form.field .input')?.focus({ preventScroll: true });
+    }
+
+    async _cancelCreate() {
+        this._creating = false;
+        await this.updateComplete;
+        this.shadowRoot.querySelector('.field .input')?.focus({ preventScroll: true });
+    }
+
+    async _onCreateSubmit(e) {
+        e.preventDefault();
+        const name = e.target.querySelector('input').value.trim();
+        if (!name || this._createBusy) return;
+        this._createBusy = true;
+        try {
+            const created = await createList(this.userKey, name, this._seedKey);
+            // Prepend so the new list is visible immediately; the shared cache
+            // is the same object, so sibling popovers see it too.
+            this._lists = { [created.key]: { listName: name, members: [this._seedKey] }, ...this._lists };
+            _listsPromise = Promise.resolve(this._lists);
+            this._creating = false;
+        } catch (error) {
+            this._fail(error);
+        } finally {
+            this._createBusy = false;
+        }
+    }
+}
+
+customElements.define('ol-book-actions', OlBookActions);

--- a/openlibrary/components/lit/OlBookActions.js
+++ b/openlibrary/components/lit/OlBookActions.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 import { icon } from './utils/book-icons.js';
 import { SHELF, setShelf, setRating, fetchUserLists, addToList, removeFromList, createList } from './utils/books-api.js';
 import { showToast } from './OlToastRegion.js';
@@ -36,7 +37,6 @@ export const DEFAULT_LABELS = {
     alreadyRead: 'Already Read',
     stoppedReading: 'Stopped Reading',
     rateThisBook: 'Rate this book',
-    yourRating: 'Your rating: %(rating)s of 5',
     rateStar: 'Rate %(rating)s of 5',
     clearRating: 'Clear rating',
     addToList: 'Add to list',
@@ -49,6 +49,7 @@ export const DEFAULT_LABELS = {
     noMatchingLists: 'No lists match.',
     loadingLists: 'Loading lists…',
     itemsInList: '%(count)s items',
+    inLists: 'In %(count)s of your lists',
     errorGeneric: 'Something went wrong. Please try again.',
 };
 
@@ -80,6 +81,8 @@ export class OlBookActions extends LitElement {
         labels: { type: Object },
         placement: { type: String },
         _pane: { state: true },
+        _snap: { state: true },
+        _trackHeight: { state: true },
         _lists: { state: true },
         _listsLoading: { state: true },
         _listFilter: { state: true },
@@ -124,15 +127,25 @@ export class OlBookActions extends LitElement {
         }
 
         /* Two panes side by side in a track twice the panel width; the track
-           slides to reveal the second one. */
+           slides to reveal the second one. Its height is set inline to the
+           active pane's height (measured), so the panel doesn't stretch to
+           the taller pane. */
         .track {
             display: flex;
+            align-items: flex-start;
             width: 200%;
-            transition: transform 220ms cubic-bezier(0.165, 0.84, 0.44, 1);
+            transition:
+                transform 220ms cubic-bezier(0.165, 0.84, 0.44, 1),
+                height 220ms cubic-bezier(0.165, 0.84, 0.44, 1);
         }
 
         .track.pane-lists {
             transform: translateX(-50%);
+        }
+
+        /* Reset to the main pane on close without a visible slide. */
+        .track.snap {
+            transition: none;
         }
 
         @media (prefers-reduced-motion: reduce) {
@@ -227,7 +240,7 @@ export class OlBookActions extends LitElement {
         .stars {
             display: flex;
             align-items: center;
-            gap: var(--spacing-inline-sm);
+            gap: var(--spacing-inline-md);
             padding: var(--spacing-inset-sm) var(--spacing-inset-md);
         }
 
@@ -257,6 +270,25 @@ export class OlBookActions extends LitElement {
         .stars .caption {
             color: var(--color-text-secondary);
             font-size: var(--font-size-label-medium);
+        }
+
+        .stars .clear {
+            padding: 0;
+            border: 0;
+            background: none;
+            font: inherit;
+            font-size: var(--font-size-label-medium);
+            text-decoration: underline;
+            cursor: pointer;
+        }
+
+        .stars .clear:hover {
+            color: var(--color-text-primary);
+        }
+
+        .stars .clear:focus-visible {
+            outline: 2px solid var(--color-focus-ring);
+            border-radius: var(--border-radius-sm);
         }
 
         /* Lists pane */
@@ -329,6 +361,7 @@ export class OlBookActions extends LitElement {
             display: flex;
             gap: var(--spacing-inline-sm);
             padding: var(--spacing-inset-sm) var(--spacing-inset-md);
+            margin-bottom: var(--spacing-stack-xs);
         }
 
         .input {
@@ -358,7 +391,7 @@ export class OlBookActions extends LitElement {
         .list-row {
             display: flex;
             align-items: center;
-            gap: var(--spacing-inline-sm);
+            gap: var(--spacing-inline-md);
             padding: var(--spacing-inset-xs) var(--spacing-inset-md);
             cursor: pointer;
         }
@@ -431,6 +464,8 @@ export class OlBookActions extends LitElement {
         this.labels = {};
         this.placement = 'bottom-end';
         this._pane = 'main';
+        this._snap = false;
+        this._trackHeight = 0;
         this._lists = null;
         this._listsLoading = false;
         this._listFilter = '';
@@ -463,7 +498,10 @@ export class OlBookActions extends LitElement {
             >
                 <slot name="trigger" slot="trigger"></slot>
                 <div class="panel">
-                    <div class="track ${classMap({ 'pane-lists': this._pane === 'lists' })}">
+                    <div
+                        class="track ${classMap({ 'pane-lists': this._pane === 'lists', snap: this._snap })}"
+                        style=${styleMap({ height: this._trackHeight ? `${this._trackHeight}px` : null })}
+                    >
                         <div class="pane" ?inert=${this._pane !== 'main'}>${this._renderMain()}</div>
                         <div class="pane" ?inert=${this._pane !== 'lists'}>${this._renderLists()}</div>
                     </div>
@@ -502,6 +540,7 @@ export class OlBookActions extends LitElement {
                 <button type="button" class="row" @click=${this._openLists}>
                     ${icon('list-plus')}
                     <span class="label">${this.t('addToList')}</span>
+                    ${this._listCount ? html`<span class="count" aria-label=${this.t('inLists', { count: this._listCount })}>${this._listCount}</span>` : nothing}
                     ${icon('chevron-right', { cls: 'obd-icon trail' })}
                 </button>
             </div>
@@ -510,9 +549,10 @@ export class OlBookActions extends LitElement {
 
     _renderStars() {
         const shown = this._hoverRating || this.rating || 0;
+        // Once rated, the caption becomes an actionable "Clear rating" link.
         const caption = this.rating
-            ? this.t('yourRating', { rating: this.rating })
-            : this.t('rateThisBook');
+            ? html`<button type="button" class="caption clear" ?disabled=${this._busy} @click=${() => this._onRate(this.rating)}>${this.t('clearRating')}</button>`
+            : html`<span class="caption">${this.t('rateThisBook')}</span>`;
         return html`
             <div class="stars">
                 <span class="star-buttons" role="radiogroup" aria-label=${this.t('rateThisBook')} @mouseleave=${() => { this._hoverRating = 0; }}>
@@ -531,7 +571,7 @@ export class OlBookActions extends LitElement {
                         >${icon('star', { fill: n <= shown ? 'currentColor' : 'none', strokeWidth: 1.5 })}</button>
                     `)}
                 </span>
-                <span class="caption">${caption}</span>
+                ${caption}
             </div>
         `;
     }
@@ -600,12 +640,40 @@ export class OlBookActions extends LitElement {
         });
     }
 
+    updated(changed) {
+        // Panes only exist once `book` is set, so observe them lazily.
+        if (!this._resizeObserver) {
+            const panes = this.shadowRoot.querySelectorAll('.pane');
+            if (panes.length) {
+                this._resizeObserver = new ResizeObserver(() => this._syncTrackHeight());
+                panes.forEach(pane => this._resizeObserver.observe(pane));
+            }
+        }
+        if (changed.has('_pane')) this._syncTrackHeight();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._resizeObserver?.disconnect();
+    }
+
+    /** Size the track to the active pane so the panel doesn't stretch to the taller one. */
+    _syncTrackHeight() {
+        const pane = this.shadowRoot.querySelector(`.pane:nth-child(${this._pane === 'lists' ? 2 : 1})`);
+        // 0 means the popover is hidden; keep the last real height.
+        if (pane?.offsetHeight) this._trackHeight = pane.offsetHeight;
+    }
+
     // ── Popover lifecycle ────────────────────────────────────
 
     _onOpen() {
         this._pane = 'main';
+        this._snap = false;
         this._creating = false;
         this._listFilter = '';
+        // If another popover already fetched the user's lists, reuse them so
+        // the "in N lists" count shows without opening the lists pane.
+        if (this._lists === null && _listsPromise) this._loadLists();
     }
 
     _onCloseRequest(e) {
@@ -613,7 +681,13 @@ export class OlBookActions extends LitElement {
         if (e.detail?.reason === 'escape' && this._pane === 'lists') {
             e.preventDefault();
             this._closeLists();
+            return;
         }
+        // Reset to the main pane now, so the next open doesn't slide back from
+        // the lists pane. `snap` skips the slide while the popover fades out.
+        this._snap = true;
+        this._pane = 'main';
+        this._creating = false;
     }
 
     _emitState() {
@@ -686,6 +760,12 @@ export class OlBookActions extends LitElement {
         this._creating = false;
         await this.updateComplete;
         this.shadowRoot.querySelector('.pane:nth-child(1) .group:last-child .row')?.focus({ preventScroll: true });
+    }
+
+    /** How many of the user's (loaded) lists contain this book. */
+    get _listCount() {
+        if (!this._lists) return 0;
+        return Object.values(this._lists).filter(l => l.members.includes(this._seedKey)).length;
     }
 
     async _loadLists() {

--- a/openlibrary/components/lit/OlBooksDisplay.js
+++ b/openlibrary/components/lit/OlBooksDisplay.js
@@ -26,6 +26,8 @@ import './OlBookActions.js';
  * @element ol-books-display
  *
  * @prop {String} query   - Solr work query
+ * @prop {String} fallbackQuery - Query to retry with when `query` returns nothing
+ *     (e.g. the same query without the user-language filter)
  * @prop {String} sort    - Solr sort (default "new")
  * @prop {Number} limit   - Page size (default 20)
  * @prop {String} title   - Section heading
@@ -95,6 +97,7 @@ const VIEWS = ['covers', 'list'];
 export class OlBooksDisplay extends LitElement {
     static properties = {
         query: { type: String },
+        fallbackQuery: { type: String, attribute: 'fallback-query' },
         sort: { type: String },
         limit: { type: Number },
         title: { type: String },
@@ -122,6 +125,7 @@ export class OlBooksDisplay extends LitElement {
     constructor() {
         super();
         this.query = '';
+        this.fallbackQuery = '';
         this.sort = 'new';
         this.limit = 20;
         this.title = '';
@@ -201,6 +205,14 @@ export class OlBooksDisplay extends LitElement {
             this._docs = [...this._docs, ...page.docs];
             this._numFound = page.num_found;
             this._loadUserState(page.docs.map(d => d.key));
+            if (!this._docs.length && this.fallbackQuery && this.fallbackQuery !== this.query) {
+                // Nothing under the narrow query (typically the user-language
+                // filter): widen once and refetch.
+                this.query = this.fallbackQuery;
+                this._numFound = null;
+                this._loading = false;
+                return this.loadMore();
+            }
         } catch (error) {
             this._error = true;
         } finally {

--- a/openlibrary/components/lit/OlBooksDisplay.js
+++ b/openlibrary/components/lit/OlBooksDisplay.js
@@ -1,0 +1,564 @@
+import { LitElement, html, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { icon } from './utils/book-icons.js';
+import { fetchBooks, fetchUserState, setShelf, redirectToLogin, SHELF } from './utils/books-api.js';
+import { fmt, DEFAULT_LABELS as ACTION_LABELS } from './OlBookActions.js';
+import { showToast } from './OlToastRegion.js';
+import './OlCarousel.js';
+import './OlSegmentedControl.js';
+import './OlBookActions.js';
+
+/**
+ * A titled set of books for a Solr query, switchable between views. Fetches
+ * from `/books-display.json`, overlays the signed-in user's shelf/rating from
+ * `/books-display/user-state.json`, and hands per-book actions to
+ * `<ol-book-actions>`.
+ *
+ * `view` is an open enum: `covers` (an `<ol-carousel>` of cover cards) and
+ * `list` (full-width rows) today; more layouts (e.g. a multi-row grid) slot in
+ * alongside without changing the data path.
+ *
+ * Renders into the light DOM (like `<ol-button>`) so `<ol-carousel>` gets the
+ * cards as real children, sitewide handlers (`.js-login-intent`, analytics)
+ * keep working, and `static/css/components/ol-books-display.css` styles it.
+ *
+ * @element ol-books-display
+ *
+ * @prop {String} query   - Solr work query
+ * @prop {String} sort    - Solr sort (default "new")
+ * @prop {Number} limit   - Page size (default 20)
+ * @prop {String} title   - Section heading
+ * @prop {String} url     - "See all" link
+ * @prop {String} view    - "covers" | "list" (default "covers")
+ * @prop {Boolean} hasFulltextOnly - Restrict to readable books (default true; attr has-fulltext-only="false" to disable)
+ * @prop {Boolean} safeMode - Hide content-warning covers (default true; attr safe-mode="false" to disable)
+ * @prop {String} userKey - "/people/<username>" when signed in; empty when not
+ * @prop {String} analyticsKey - Suffix for data-ol-link-track values
+ * @prop {Object} labels  - Translated strings, merged over DEFAULT_LABELS
+ *
+ * @fires ol-books-display-view-change - detail: { view }
+ */
+export const DEFAULT_LABELS = {
+    ...ACTION_LABELS,
+    viewAs: 'View as',
+    covers: 'Covers',
+    list: 'List',
+    save: 'Save %(title)s to your reading log',
+    saved: '%(title)s is on your reading log',
+    read: 'Read',
+    audiobook: 'Audiobook',
+    borrow: 'Borrow',
+    specialAccess: 'Special Access',
+    preview: 'Preview',
+    joinWaitlist: 'Join Waitlist',
+    checkedOut: 'Checked Out',
+    findInLibrary: 'Find in a library',
+    notInLibrary: 'Not in Library',
+    notOnline: 'Not online',
+    previewBadge: 'Preview',
+    ratingsOne: '%(count)s rating',
+    ratingsMany: '%(count)s ratings',
+    ratingsAverage: 'Rated %(average)s out of 5',
+    firstPublished: 'First published %(year)s',
+    shelfMenu: 'More options for %(title)s',
+    showMore: 'Show %(count)s more',
+    collapse: 'Collapse',
+    seeAll: 'See all',
+    loading: 'Loading…',
+    loadError: 'Couldn’t load these books.',
+    retry: 'Retry',
+    empty: 'No books found.',
+};
+
+const CTA_LABEL = {
+    read: 'read',
+    audiobook: 'audiobook',
+    borrow: 'borrow',
+    special_access: 'specialAccess',
+    preview: 'preview',
+    join_waitlist: 'joinWaitlist',
+    checked_out: 'checkedOut',
+    find_in_library: 'findInLibrary',
+    not_in_library: 'notInLibrary',
+};
+
+const SHELF_LABEL = {
+    [SHELF.WANT_TO_READ]: 'wantToRead',
+    [SHELF.CURRENTLY_READING]: 'currentlyReading',
+    [SHELF.ALREADY_READ]: 'alreadyRead',
+    [SHELF.STOPPED_READING]: 'stoppedReading',
+};
+
+const VIEWS = ['covers', 'list'];
+
+export class OlBooksDisplay extends LitElement {
+    static properties = {
+        query: { type: String },
+        sort: { type: String },
+        limit: { type: Number },
+        title: { type: String },
+        url: { type: String },
+        view: { type: String, reflect: true },
+        // Default-true flags: written as has-fulltext-only="false" to turn off,
+        // since a bare boolean attribute can't express false.
+        hasFulltextOnly: { attribute: 'has-fulltext-only', converter: v => v !== 'false' },
+        safeMode: { attribute: 'safe-mode', converter: v => v !== 'false' },
+        userKey: { type: String, attribute: 'user-key' },
+        analyticsKey: { type: String, attribute: 'analytics-key' },
+        labels: { type: Object },
+        _docs: { state: true },
+        _numFound: { state: true },
+        _loading: { state: true },
+        _error: { state: true },
+        _visible: { state: true },
+        _userState: { state: true },
+    };
+
+    createRenderRoot() {
+        return this;
+    }
+
+    constructor() {
+        super();
+        this.query = '';
+        this.sort = 'new';
+        this.limit = 20;
+        this.title = '';
+        this.url = '';
+        this.view = 'covers';
+        this.hasFulltextOnly = true;
+        this.safeMode = true;
+        this.userKey = '';
+        this.analyticsKey = '';
+        this.labels = {};
+        this._docs = [];
+        this._numFound = null;
+        this._loading = false;
+        this._error = false;
+        this._visible = 0;
+        this._userState = { shelves: {}, ratings: {} };
+        this._started = false;
+    }
+
+    t(key, vars) {
+        const s = this.labels?.[key] ?? DEFAULT_LABELS[key] ?? key;
+        return vars ? fmt(s, vars) : s;
+    }
+
+    get docs() {
+        return this._docs;
+    }
+
+    get hasMore() {
+        return this._numFound === null || this._docs.length < this._numFound;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        // Defer the first fetch until the section is near the viewport, as
+        // the legacy lazy carousel does.
+        if ('IntersectionObserver' in window) {
+            this._observer = new IntersectionObserver(entries => {
+                if (entries.some(e => e.isIntersecting)) {
+                    this._observer.disconnect();
+                    this.start();
+                }
+            }, { rootMargin: '200px' });
+            this._observer.observe(this);
+        } else {
+            this.start();
+        }
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._observer?.disconnect();
+    }
+
+    /** Kick off the first fetch (idempotent). */
+    start() {
+        if (this._started) return;
+        this._started = true;
+        this._visible = this.limit;
+        this.loadMore();
+    }
+
+    /** Fetch the next page and append it. Resolves when the DOM has updated. */
+    async loadMore() {
+        if (this._loading || !this.hasMore) return;
+        this._loading = true;
+        this._error = false;
+        try {
+            const page = await fetchBooks({
+                q: this.query,
+                sort: this.sort,
+                limit: this.limit,
+                offset: this._docs.length,
+                hasFulltextOnly: this.hasFulltextOnly,
+                safeMode: this.safeMode,
+            });
+            this._docs = [...this._docs, ...page.docs];
+            this._numFound = page.num_found;
+            this._loadUserState(page.docs.map(d => d.key));
+        } catch (error) {
+            this._error = true;
+        } finally {
+            this._loading = false;
+        }
+        await this.updateComplete;
+    }
+
+    async _loadUserState(keys) {
+        if (!this.userKey || !keys.length) return;
+        try {
+            const state = await fetchUserState(keys);
+            this._userState = {
+                shelves: { ...this._userState.shelves, ...state.shelves },
+                ratings: { ...this._userState.ratings, ...state.ratings },
+            };
+        } catch (error) {
+            // Not fatal — cards simply show no shelf state.
+        }
+    }
+
+    _stateFor(doc) {
+        const id = doc.key.split('/').pop();
+        return {
+            shelf: this._userState.shelves[id] ?? null,
+            rating: this._userState.ratings[id] ?? null,
+        };
+    }
+
+    // ── Render ───────────────────────────────────────────────
+
+    render() {
+        return html`
+            <div class="obd">
+                ${this._renderHeader()}
+                ${this._error ? this._renderError() : this._renderView()}
+            </div>
+        `;
+    }
+
+    _renderHeader() {
+        return html`
+            <div class="obd__header">
+                <h2 class="obd__title">
+                    ${this.url ? html`<a class="obd-link" href=${this.url}>${this.title}</a>` : this.title}
+                </h2>
+                <ol-segmented-control
+                    class="obd__toggle"
+                    size="small"
+                    .value=${this.view}
+                    accessible-label=${this.t('viewAs')}
+                    @ol-segmented-control-change=${this._onViewChange}
+                >
+                    <ol-segment value="covers" label="">${icon('layout-grid')} <span>${this.t('covers')}</span></ol-segment>
+                    <ol-segment value="list" label="">${icon('list')} <span>${this.t('list')}</span></ol-segment>
+                </ol-segmented-control>
+            </div>
+        `;
+    }
+
+    _renderError() {
+        return html`
+            <div class="obd__status" role="alert">
+                ${this.t('loadError')}
+                <button type="button" class="obd__link-btn" @click=${() => this.loadMore()}>${this.t('retry')}</button>
+            </div>
+        `;
+    }
+
+    _renderView() {
+        if (!this._docs.length) {
+            return html`<div class="obd__status" role="status">${this._loading || !this._started ? this.t('loading') : this.t('empty')}</div>`;
+        }
+        return this.view === 'list' ? this._renderList() : this._renderCovers();
+    }
+
+    _renderCovers() {
+        return html`
+            <ol-carousel
+                class="obd__carousel"
+                label=${this.title}
+                gap="16"
+                @ol-carousel-page-change=${this._onPageChange}
+            >
+                ${this._docs.map(doc => this._renderCoverCard(doc))}
+            </ol-carousel>
+        `;
+    }
+
+    _renderList() {
+        const shown = this._docs.slice(0, this._visible);
+        const remaining = (this._numFound ?? this._docs.length) - shown.length;
+        return html`
+            <div class="obd__list-wrap">
+                <ul class="obd__list">
+                    ${shown.map(doc => this._renderRow(doc))}
+                </ul>
+                <div class="obd__list-footer">
+                    ${remaining > 0 ? html`
+                        <button type="button" class="obd__link-btn" ?disabled=${this._loading} @click=${this._onShowMore}>
+                            ${this.t('showMore', { count: Math.min(remaining, this.limit) })}
+                        </button>
+                    ` : nothing}
+                    ${shown.length > this.limit ? html`
+                        <span class="obd__dot" aria-hidden="true">·</span>
+                        <button type="button" class="obd__link-btn" @click=${this._onCollapse}>${this.t('collapse')}</button>
+                    ` : nothing}
+                    ${this.url ? html`
+                        <span class="obd__dot" aria-hidden="true">·</span>
+                        <a class="obd__link-btn" href=${this.url}>${this.t('seeAll')} →</a>
+                    ` : nothing}
+                </div>
+            </div>
+        `;
+    }
+
+    _authorsText(doc) {
+        return (doc.authors || []).map(a => a.name).filter(Boolean).join(', ');
+    }
+
+    _renderCover(doc, size) {
+        const authors = this._authorsText(doc);
+        const alt = authors ? `${doc.title} ${this.t('by', { name: authors })}` : doc.title;
+        if (doc.cover_url) {
+            return html`<img class="obd-cover__img" src=${doc.cover_url} alt=${alt} loading="lazy" />`;
+        }
+        return html`
+            <span class="obd-cover__blank" role="img" aria-label=${alt}>
+                <span class="obd-cover__blank-title">${doc.title}</span>
+                ${authors && size !== 'small' ? html`<span class="obd-cover__blank-author">${authors}</span>` : nothing}
+            </span>
+        `;
+    }
+
+    _renderBadge(doc) {
+        const badge = doc.access?.badge;
+        if (!badge) return nothing;
+        return html`<span class="obd-badge">${badge === 'preview' ? this.t('previewBadge') : this.t('notOnline')}</span>`;
+    }
+
+    _renderCoverCard(doc) {
+        const { shelf, rating } = this._stateFor(doc);
+        return html`
+            <div class="obd-card" data-key=${doc.key}>
+                <div class="obd-cover">
+                    <a class="obd-cover__link" href=${doc.key} data-ol-link-track="BookCarousel|CoverClick|${this.analyticsKey}">
+                        ${this._renderCover(doc)}
+                    </a>
+                    ${this._renderBadge(doc)}
+                    ${this._renderSaveButton(doc, shelf, rating)}
+                </div>
+                <a class="obd-card__title" href=${doc.key}>${doc.title}</a>
+                ${this._renderByline(doc, 'obd-card__author')}
+                ${this._renderCta(doc, 'obd-card__cta')}
+            </div>
+        `;
+    }
+
+    _renderRow(doc) {
+        const { shelf, rating } = this._stateFor(doc);
+        return html`
+            <li class="obd-row" data-key=${doc.key}>
+                <a class="obd-row__cover obd-cover" href=${doc.key}>${this._renderCover(doc, 'small')}</a>
+                <div class="obd-row__body">
+                    <a class="obd-row__title" href=${doc.key}>${doc.title}</a>
+                    ${this._renderByline(doc, 'obd-row__author')}
+                    ${this._renderRating(doc)}
+                    ${doc.first_publish_year ? html`<div class="obd-row__meta">${this.t('firstPublished', { year: doc.first_publish_year })}</div>` : nothing}
+                </div>
+                <div class="obd-row__actions">
+                    ${this._renderCta(doc, 'obd-row__cta')}
+                    ${this._renderShelfSplit(doc, shelf, rating)}
+                </div>
+            </li>
+        `;
+    }
+
+    _renderByline(doc, cls) {
+        const authors = doc.authors || [];
+        if (!authors.length) return nothing;
+        const names = authors.map((a, i) => html`${i ? ', ' : ''}${a.key ? html`<a class="obd-link" href=${a.key}>${a.name}</a>` : a.name}`);
+        // Split "by %(name)s" around its placeholder so the names stay links.
+        const [before, after = ''] = this.t('by').split('%(name)s');
+        return html`<div class=${cls}>${before}${names}${after}</div>`;
+    }
+
+    _renderRating(doc) {
+        if (!doc.ratings_count) return nothing;
+        const avg = doc.ratings_average || 0;
+        const rounded = Math.round(avg);
+        const count = doc.ratings_count.toLocaleString();
+        return html`
+            <div class="obd-row__rating">
+                <span class="obd-stars" role="img" aria-label=${this.t('ratingsAverage', { average: avg.toFixed(1) })}>
+                    ${[1, 2, 3, 4, 5].map(n => icon('star', { fill: n <= rounded ? 'currentColor' : 'none', strokeWidth: 1.5 }))}
+                </span>
+                <span class="obd-row__rating-text">${avg.toFixed(1)} · ${this.t(doc.ratings_count === 1 ? 'ratingsOne' : 'ratingsMany', { count })}</span>
+            </div>
+        `;
+    }
+
+    _renderCta(doc, cls) {
+        const access = doc.access || {};
+        const label = this.t(CTA_LABEL[access.cta] || 'notInLibrary');
+        const track = `BookCarousel|CTAClick|${this.analyticsKey}`;
+        const primary = ['read', 'audiobook', 'borrow', 'special_access', 'preview'].includes(access.cta);
+        const classes = { 'obd-cta': true, 'obd-cta--primary': primary, 'obd-cta--secondary': !primary, [cls]: true };
+
+        if (!access.url) {
+            return html`<span class="${classMap({ ...classes, 'obd-cta--static': true })}">${label}</span>`;
+        }
+        if (access.method === 'post') {
+            return html`
+                <form method="POST" action=${access.url} class="obd-cta-form">
+                    <input type="hidden" name="action" value="join-waitinglist" />
+                    <button type="submit" class=${classMap(classes)} data-ol-link-track=${track}>${label}</button>
+                </form>
+            `;
+        }
+        const loginIntent = access.login_intent && !this.userKey;
+        return html`
+            <a
+                class="${classMap({ ...classes, 'js-login-intent': loginIntent })}"
+                href=${access.url}
+                target=${ifDefined(access.external ? '_blank' : undefined)}
+                rel=${ifDefined(access.external ? 'noopener noreferrer' : undefined)}
+                data-ol-link-track=${track}
+                data-action=${ifDefined(loginIntent ? label : undefined)}
+                data-title=${ifDefined(loginIntent ? doc.title : undefined)}
+                data-type=${ifDefined(loginIntent ? 'book' : undefined)}
+                data-resumeurl=${ifDefined(loginIntent && doc.edition_key ? `/books/${doc.edition_key}` : undefined)}
+            >${label}${access.external ? icon('arrow-up-right', { cls: 'obd-icon obd-cta__ext' }) : nothing}</a>
+        `;
+    }
+
+    _actionsBook(doc) {
+        return { key: doc.key, title: doc.title, authors: doc.authors, editionKey: doc.edition_key };
+    }
+
+    _renderSaveButton(doc, shelf, rating) {
+        const saved = shelf !== null;
+        const button = html`
+            <button
+                type="button"
+                slot="trigger"
+                class="obd-save ${classMap({ 'obd-save--on': saved })}"
+                aria-label=${saved ? this.t('saved', { title: doc.title }) : this.t('save', { title: doc.title })}
+                @click=${this.userKey ? undefined : e => this._onLoggedOutAction(e, doc)}
+            >${icon(saved ? 'check' : 'plus', { strokeWidth: 2.5 })}</button>
+        `;
+        if (!this.userKey) return button;
+        return html`
+            <ol-book-actions
+                .book=${this._actionsBook(doc)}
+                .shelf=${shelf}
+                .rating=${rating}
+                .labels=${this.labels}
+                user-key=${this.userKey}
+                @ol-book-state-change=${this._onStateChange}
+            >${button}</ol-book-actions>
+        `;
+    }
+
+    _renderShelfSplit(doc, shelf, rating) {
+        const on = shelf !== null;
+        const label = this.t(SHELF_LABEL[shelf ?? SHELF.WANT_TO_READ]);
+        const main = html`
+            <button
+                type="button"
+                class="obd-shelf__main ${classMap({ 'obd-shelf__main--on': on })}"
+                @click=${e => this._onShelfMainClick(e, doc, shelf)}
+            >${on ? icon('check') : nothing}<span>${label}</span></button>
+        `;
+        const chevron = html`
+            <button
+                type="button"
+                slot="trigger"
+                class="obd-shelf__more"
+                aria-label=${this.t('shelfMenu', { title: doc.title })}
+                @click=${this.userKey ? undefined : e => this._onLoggedOutAction(e, doc)}
+            >${icon('chevron-down')}</button>
+        `;
+        return html`
+            <div class="obd-shelf ${classMap({ 'obd-shelf--on': on })}">
+                ${main}
+                ${this.userKey ? html`
+                    <ol-book-actions
+                        .book=${this._actionsBook(doc)}
+                        .shelf=${shelf}
+                        .rating=${rating}
+                        .labels=${this.labels}
+                        user-key=${this.userKey}
+                        @ol-book-state-change=${this._onStateChange}
+                    >${chevron}</ol-book-actions>
+                ` : chevron}
+            </div>
+        `;
+    }
+
+    // ── Events ───────────────────────────────────────────────
+
+    _onViewChange(e) {
+        const view = e.detail?.value;
+        if (!VIEWS.includes(view) || view === this.view) return;
+        this.view = view;
+        this.dispatchEvent(new CustomEvent('ol-books-display-view-change', { bubbles: true, detail: { view } }));
+    }
+
+    _onPageChange(e) {
+        const { page, totalPages } = e.detail;
+        if (page >= totalPages - 2) this.loadMore();
+    }
+
+    async _onShowMore() {
+        const target = this._visible + this.limit;
+        if (this._docs.length < target && this.hasMore) await this.loadMore();
+        this._visible = Math.min(target, this._docs.length);
+    }
+
+    _onCollapse() {
+        this._visible = this.limit;
+        this.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    }
+
+    _onLoggedOutAction(e, doc) {
+        e.preventDefault();
+        redirectToLogin({ action: this.t('wantToRead'), title: doc.title, resumeUrl: doc.key });
+    }
+
+    _onStateChange(e) {
+        const { key, shelf, rating } = e.detail;
+        this._applyState(key, shelf, rating);
+    }
+
+    _applyState(key, shelf, rating) {
+        const id = key.split('/').pop();
+        const shelves = { ...this._userState.shelves };
+        const ratings = { ...this._userState.ratings };
+        if (shelf === null || shelf === undefined) delete shelves[id]; else shelves[id] = shelf;
+        if (rating === null || rating === undefined) delete ratings[id]; else ratings[id] = rating;
+        this._userState = { shelves, ratings };
+    }
+
+    async _onShelfMainClick(e, doc, shelf) {
+        if (!this.userKey) return this._onLoggedOutAction(e, doc);
+        const { rating } = this._stateFor(doc);
+        // On a shelf → clicking removes; otherwise → Want to Read.
+        const target = shelf ?? SHELF.WANT_TO_READ;
+        const next = shelf === null ? SHELF.WANT_TO_READ : null;
+        this._applyState(doc.key, next, rating);
+        try {
+            await setShelf(doc.key, target, { editionKey: doc.edition_key });
+        } catch (error) {
+            this._applyState(doc.key, shelf, rating);
+            if (error?.status === 401) return this._onLoggedOutAction(e, doc);
+            showToast(this.t('errorGeneric'), { type: 'error' });
+        }
+    }
+}
+
+customElements.define('ol-books-display', OlBooksDisplay);

--- a/openlibrary/components/lit/OlBooksDisplay.js
+++ b/openlibrary/components/lit/OlBooksDisplay.js
@@ -266,7 +266,7 @@ export class OlBooksDisplay extends LitElement {
                     accessible-label=${this.t('viewAs')}
                     @ol-segmented-control-change=${this._onViewChange}
                 >
-                    <ol-segment value="covers" label="">${icon('layout-grid')} <span>${this.t('covers')}</span></ol-segment>
+                    <ol-segment value="covers" label="">${icon('covers-row')} <span>${this.t('covers')}</span></ol-segment>
                     <ol-segment value="list" label="">${icon('list')} <span>${this.t('list')}</span></ol-segment>
                 </ol-segmented-control>
             </div>
@@ -394,9 +394,7 @@ export class OlBooksDisplay extends LitElement {
         const authors = doc.authors || [];
         if (!authors.length) return nothing;
         const names = authors.map((a, i) => html`${i ? ', ' : ''}${a.key ? html`<a class="obd-link" href=${a.key}>${a.name}</a>` : a.name}`);
-        // Split "by %(name)s" around its placeholder so the names stay links.
-        const [before, after = ''] = this.t('by').split('%(name)s');
-        return html`<div class=${cls}>${before}${names}${after}</div>`;
+        return html`<div class=${cls}>${names}</div>`;
     }
 
     _renderRating(doc) {

--- a/openlibrary/components/lit/OlSegmentedControl.js
+++ b/openlibrary/components/lit/OlSegmentedControl.js
@@ -206,6 +206,8 @@ export class OlSegmentedControl extends FormAssociatedMixin(LitElement) {
             display: inline-flex;
             align-items: center;
             justify-content: center;
+            /* Icon-to-label gap, same as ol-button. */
+            gap: var(--spacing-inline-md);
             box-sizing: border-box;
             height: 100%;
             padding: 0 var(--spacing-md);

--- a/openlibrary/components/lit/index.js
+++ b/openlibrary/components/lit/index.js
@@ -26,3 +26,5 @@ export { OlToastRegion, showToast } from './OlToastRegion.js';
 export { OpenLibraryOTP } from './OpenLibraryOTP.js';
 export { OlCarousel } from './OlCarousel.js';
 export { OlScorecard } from './OlScorecard.js';
+export { OlBookActions } from './OlBookActions.js';
+export { OlBooksDisplay } from './OlBooksDisplay.js';

--- a/openlibrary/components/lit/utils/book-icons.js
+++ b/openlibrary/components/lit/utils/book-icons.js
@@ -1,0 +1,34 @@
+import { html, svg } from 'lit';
+
+/**
+ * Lucide glyphs used by the books-display components, inlined until the
+ * shared <ol-icon> system (PR #12955) lands — then swap these for it.
+ * Each is a bare <svg> path set; the wrapping <svg> attrs live in `icon()`.
+ */
+const PATHS = {
+    plus: svg`<path d="M5 12h14"/><path d="M12 5v14"/>`,
+    check: svg`<path d="M20 6 9 17l-5-5"/>`,
+    bookmark: svg`<path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/>`,
+    'book-open': svg`<path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>`,
+    'circle-check': svg`<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>`,
+    'circle-pause': svg`<circle cx="12" cy="12" r="10"/><line x1="10" x2="10" y1="15" y2="9"/><line x1="14" x2="14" y1="15" y2="9"/>`,
+    'list-plus': svg`<path d="M11 12H3"/><path d="M16 6H3"/><path d="M16 18H3"/><path d="M18 9v6"/><path d="M21 12h-6"/>`,
+    'chevron-right': svg`<path d="m9 18 6-6-6-6"/>`,
+    'chevron-left': svg`<path d="m15 18-6-6 6-6"/>`,
+    'chevron-down': svg`<path d="m6 9 6 6 6-6"/>`,
+    'arrow-up-right': svg`<path d="M7 7h10v10"/><path d="M7 17 17 7"/>`,
+    'layout-grid': svg`<rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/>`,
+    list: svg`<path d="M3 12h.01"/><path d="M3 18h.01"/><path d="M3 6h.01"/><path d="M8 12h13"/><path d="M8 18h13"/><path d="M8 6h13"/>`,
+    star: svg`<path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/>`,
+    loader: svg`<path d="M12 2v4"/><path d="m16.2 7.8 2.9-2.9"/><path d="M18 12h4"/><path d="m16.2 16.2 2.9 2.9"/><path d="M12 18v4"/><path d="m4.9 19.1 2.9-2.9"/><path d="M2 12h4"/><path d="m4.9 4.9 2.9 2.9"/>`,
+};
+
+/**
+ * @param {keyof typeof PATHS} name
+ * @param {{fill?: string, strokeWidth?: number, cls?: string}} [opts]
+ */
+export function icon(name, { fill = 'none', strokeWidth = 2, cls = 'obd-icon' } = {}) {
+    return html`<svg class=${cls} viewBox="0 0 24 24" fill=${fill} stroke="currentColor" stroke-width=${strokeWidth} stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${PATHS[name]}</svg>`;
+}
+
+export const ICON_NAMES = Object.keys(PATHS);

--- a/openlibrary/components/lit/utils/book-icons.js
+++ b/openlibrary/components/lit/utils/book-icons.js
@@ -17,7 +17,9 @@ const PATHS = {
     'chevron-left': svg`<path d="m15 18-6-6 6-6"/>`,
     'chevron-down': svg`<path d="m6 9 6 6 6-6"/>`,
     'arrow-up-right': svg`<path d="M7 7h10v10"/><path d="M7 17 17 7"/>`,
-    'layout-grid': svg`<rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/>`,
+    // Not Lucide: two portrait cover thumbnails, for the carousel view.
+    // Two (not three) so the gaps survive at 14px.
+    'covers-row': svg`<rect width="7" height="14" x="3" y="5" rx="1"/><rect width="7" height="14" x="14" y="5" rx="1"/>`,
     list: svg`<path d="M3 12h.01"/><path d="M3 18h.01"/><path d="M3 6h.01"/><path d="M8 12h13"/><path d="M8 18h13"/><path d="M8 6h13"/>`,
     star: svg`<path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/>`,
     loader: svg`<path d="M12 2v4"/><path d="m16.2 7.8 2.9-2.9"/><path d="M18 12h4"/><path d="m16.2 16.2 2.9 2.9"/><path d="M12 18v4"/><path d="m4.9 19.1 2.9-2.9"/><path d="M2 12h4"/><path d="m4.9 4.9 2.9 2.9"/>`,

--- a/openlibrary/components/lit/utils/books-api.js
+++ b/openlibrary/components/lit/utils/books-api.js
@@ -1,0 +1,107 @@
+/**
+ * Thin fetch wrappers for the books-display components. Every function
+ * resolves to parsed JSON and rejects with an Error carrying `.status`, so
+ * callers can branch on 401 (send to login) vs anything else (toast).
+ */
+
+export const SHELF = Object.freeze({
+    WANT_TO_READ: 1,
+    CURRENTLY_READING: 2,
+    ALREADY_READ: 3,
+    STOPPED_READING: 4,
+});
+
+/** Work key "/works/OL1W" → "OL1W". */
+export function olid(key) {
+    return key.split('/').pop();
+}
+
+async function request(url, init) {
+    const response = await fetch(url, { credentials: 'same-origin', ...init });
+    if (!response.ok) {
+        const error = new Error(`${init?.method || 'GET'} ${url} → ${response.status}`);
+        error.status = response.status;
+        throw error;
+    }
+    return response.json();
+}
+
+function form(data) {
+    const body = new URLSearchParams();
+    for (const [k, v] of Object.entries(data)) {
+        if (v !== undefined && v !== null) body.set(k, String(v));
+    }
+    return { method: 'POST', body, headers: { 'Content-Type': 'application/x-www-form-urlencoded' } };
+}
+
+function json(data) {
+    return { method: 'POST', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } };
+}
+
+/** GET /books-display.json — public, cacheable book cards for a query. */
+export function fetchBooks({ q, sort, limit, offset, hasFulltextOnly = true, safeMode = true }) {
+    const params = new URLSearchParams({
+        q,
+        sort,
+        limit: String(limit),
+        offset: String(offset),
+        has_fulltext_only: String(hasFulltextOnly),
+        safe_mode: String(safeMode),
+    });
+    return request(`/books-display.json?${params}`);
+}
+
+/** GET /books-display/user-state.json — the current user's shelf + rating per work. */
+export function fetchUserState(workKeys) {
+    if (!workKeys.length) return Promise.resolve({ shelves: {}, ratings: {} });
+    const ids = workKeys.map(olid).join(',');
+    return request(`/books-display/user-state.json?work_ids=${encodeURIComponent(ids)}`);
+}
+
+/**
+ * POST /works/OL..W/bookshelves.json. Posting the shelf the work is already
+ * on removes it; `-1` removes unconditionally.
+ */
+export function setShelf(workKey, shelfId, { editionKey } = {}) {
+    return request(`/works/${olid(workKey)}/bookshelves.json`, form({ bookshelf_id: shelfId, edition_id: editionKey }));
+}
+
+/** POST /works/OL..W/ratings.json. `null` clears the rating. */
+export function setRating(workKey, rating, { editionKey } = {}) {
+    return request(`/works/${olid(workKey)}/ratings.json`, form({ rating, edition_id: editionKey }));
+}
+
+/**
+ * The user's lists with membership: `{ [listKey]: { listName, members: [seedKey…] } }`.
+ * Reuses the dropper partial so the list-modelling stays in one place.
+ */
+export async function fetchUserLists() {
+    const data = await request('/partials/MyBooksDropperLists.json');
+    return data.listData || {};
+}
+
+export function addToList(listKey, seedKey) {
+    return request(`${listKey}/seeds.json`, json({ add: [{ key: seedKey }] }));
+}
+
+export function removeFromList(listKey, seedKey) {
+    return request(`${listKey}/seeds.json`, json({ remove: [{ key: seedKey }] }));
+}
+
+/** Resolves to `{ key, ... }` of the new list. */
+export function createList(userKey, name, seedKey) {
+    return request(`${userKey}/lists.json`, json({ name, description: '', seeds: seedKey ? [{ key: seedKey }] : [] }));
+}
+
+/**
+ * Mirror of js/utils.js `queueAction` (that bundle can't be imported here):
+ * remember what the visitor was doing, then send them to log in.
+ */
+export function redirectToLogin({ action, title, type = 'book', resumeUrl } = {}) {
+    const target = resumeUrl || window.location.pathname + window.location.search;
+    if (action && title) {
+        const data = encodeURIComponent(JSON.stringify({ name: title, url: target, action, type }));
+        document.cookie = `pending_action=${data}; path=/; max-age=129600; samesite=lax`;
+    }
+    window.location.href = `/account/login?redirect=${encodeURIComponent(target)}`;
+}

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -610,7 +610,7 @@ class Bookshelves(db.CommonExtras):
         return user_read_status == cls.PRESET_BOOKSHELVES["Already Read"]
 
     @classmethod
-    def get_users_read_status_of_works(cls, username: str, work_ids: list[str]) -> list:
+    def get_users_read_status_of_works(cls, username: str, work_ids: list[str] | list[int]) -> list:
         oldb = db.get_db()
         data = {
             "username": username,

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -151,6 +151,15 @@ class Ratings(db.CommonExtras):
         return rating
 
     @classmethod
+    def get_users_ratings_of_works(cls, username: str, work_ids: list[int]) -> dict[int, int]:
+        """Map work_id -> rating for the subset of `work_ids` this user has rated."""
+        if not work_ids:
+            return {}
+        oldb = db.get_db()
+        query = "SELECT work_id, rating FROM ratings WHERE username=$username AND work_id IN $work_ids"
+        return {row.work_id: row.rating for row in oldb.query(query, vars={"username": username, "work_ids": work_ids})}
+
+    @classmethod
     def remove(cls, username, work_id):
         oldb = db.get_db()
         where = {"username": username, "work_id": int(work_id)}

--- a/openlibrary/fastapi/books_display.py
+++ b/openlibrary/fastapi/books_display.py
@@ -1,0 +1,66 @@
+"""Endpoints backing the `<ol-books-display>` component.
+
+- `GET /books-display.json` — the (cacheable, user-agnostic) book cards for a
+  Solr query, paginated by offset.
+- `GET /books-display/user-state.json` — the current user's shelf + rating for
+  a batch of works, so the public payload above stays cacheable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BeforeValidator
+
+from openlibrary import accounts
+from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.ratings import Ratings
+from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_user
+from openlibrary.fastapi.models import parse_comma_separated_list
+from openlibrary.fastapi.services.books_display import BooksDisplayResponse, fetch_books_display
+from openlibrary.utils import extract_numeric_id_from_olid
+
+router = APIRouter(tags=["internal"], include_in_schema=os.getenv("LOCAL_DEV") is not None)
+
+MAX_LIMIT = 50
+MAX_STATE_WORKS = 100
+
+
+@router.get("/books-display.json")
+async def books_display(
+    q: Annotated[str, Query(description="Solr work query")],
+    sort: Annotated[str, Query()] = "new",
+    limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    has_fulltext_only: Annotated[bool, Query()] = True,
+    safe_mode: Annotated[bool, Query()] = True,
+) -> BooksDisplayResponse:
+    return await fetch_books_display(
+        q=q,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+        has_fulltext_only=has_fulltext_only,
+        safe_mode=safe_mode,
+        user=accounts.get_current_user(),
+    )
+
+
+@router.get("/books-display/user-state.json")
+async def books_display_user_state(
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    work_ids: Annotated[
+        list[str],
+        BeforeValidator(parse_comma_separated_list),
+        Query(description="Comma-separated work OLIDs, e.g. OL1W,OL2W", max_length=MAX_STATE_WORKS),
+    ],
+) -> dict[str, dict[str, int]]:
+    """`{"shelves": {"OL1W": 1}, "ratings": {"OL1W": 4}}` — only works with state are present."""
+    numeric_ids = [int(extract_numeric_id_from_olid(olid)) for olid in work_ids if olid]
+    if not numeric_ids:
+        return {"shelves": {}, "ratings": {}}
+    shelves = {f"OL{row.work_id}W": row.bookshelf_id for row in Bookshelves.get_users_read_status_of_works(user.username, numeric_ids)}
+    ratings = {f"OL{work_id}W": rating for work_id, rating in Ratings.get_users_ratings_of_works(user.username, numeric_ids).items()}
+    return {"shelves": shelves, "ratings": ratings}

--- a/openlibrary/fastapi/services/books_display.py
+++ b/openlibrary/fastapi/services/books_display.py
@@ -107,7 +107,8 @@ def _target_edition(work: dict) -> dict:
 
 def _cover_url(work: dict, edition: dict) -> str | None:
     host = get_coverstore_public_url()
-    cover_id = edition.get("cover_i") or work.get("cover_i")
+    # Prefer the work's cover: which child edition Solr returns varies per query.
+    cover_id = work.get("cover_i") or edition.get("cover_i")
     if cover_id and cover_id != -1:
         return f"{host}/b/id/{cover_id}-M.jpg"
     if ia := edition.get("ia") or work.get("ia"):

--- a/openlibrary/fastapi/services/books_display.py
+++ b/openlibrary/fastapi/services/books_display.py
@@ -1,0 +1,265 @@
+"""Service layer for `<ol-books-display>`: fetches a book query from Solr and
+normalizes each doc into the flat card model the component renders.
+
+The card model is deliberately label-free: the server returns a `cta` kind
+(read / borrow / preview / ...) and the template supplies translated labels
+via component attributes, matching how the other Lit components handle i18n.
+"""
+
+from __future__ import annotations
+
+from hashlib import md5
+from typing import Literal, TypedDict
+
+from openlibrary.book_providers import EbookAccess, get_book_provider
+from openlibrary.core import cache
+from openlibrary.core.lending import get_lending_state
+from openlibrary.plugins.upstream.utils import get_coverstore_public_url
+from openlibrary.plugins.worksearch.code import work_search_async
+
+# Same filter the legacy carousel applies (plugins/openlibrary/partials.py).
+_SAFE_MODE_FILTER = '-subject:"content_warning:cover"'
+
+# Superset of the legacy _CAROUSEL_FIELDS: adds author keys, ratings and the
+# first-publish year for the list view, and ebook_access for partner CTAs.
+BOOKS_DISPLAY_FIELDS = [
+    "key",
+    "title",
+    "subtitle",
+    "editions",
+    "author_name",
+    "author_key",
+    "availability",
+    "cover_i",
+    "cover_edition_key",
+    "ia",
+    "ebook_access",
+    "first_publish_year",
+    "ratings_average",
+    "ratings_count",
+    "id_project_gutenberg",
+    "id_project_runeberg",
+    "id_librivox",
+    "id_standard_ebooks",
+    "id_openstax",
+    "providers",
+]
+
+CtaKind = Literal[
+    "read",
+    "audiobook",
+    "borrow",
+    "special_access",
+    "preview",
+    "join_waitlist",
+    "checked_out",
+    "find_in_library",
+    "not_in_library",
+]
+
+
+class BookAccess(TypedDict):
+    state: str
+    cta: CtaKind
+    url: str | None
+    external: bool
+    method: Literal["get", "post"]
+    badge: Literal["not_online", "preview"] | None
+    login_intent: bool
+    ocaid: str | None
+
+
+class BookAuthor(TypedDict):
+    key: str | None
+    name: str
+
+
+class BookCard(TypedDict):
+    key: str
+    title: str
+    subtitle: str | None
+    authors: list[BookAuthor]
+    cover_url: str | None
+    edition_key: str | None
+    first_publish_year: int | None
+    ratings_average: float | None
+    ratings_count: int
+    access: BookAccess
+
+
+class BooksDisplayResponse(TypedDict):
+    docs: list[BookCard]
+    num_found: int
+    offset: int
+    limit: int
+
+
+def _target_edition(work: dict) -> dict:
+    """The doc the CTA is computed from: the `{!child}` edition when Solr
+    returned one (availability is attached there), else the work itself."""
+    editions = work.get("editions")
+    if isinstance(editions, list) and editions:
+        return editions[0]
+    if isinstance(editions, dict) and editions.get("docs"):
+        return editions["docs"][0]
+    return work
+
+
+def _cover_url(work: dict, edition: dict) -> str | None:
+    host = get_coverstore_public_url()
+    cover_id = edition.get("cover_i") or work.get("cover_i")
+    if cover_id and cover_id != -1:
+        return f"{host}/b/id/{cover_id}-M.jpg"
+    if ia := edition.get("ia") or work.get("ia"):
+        return f"{host}/b/ia/{ia[0]}-M.jpg?default=false"
+    if olid := edition.get("cover_edition_key") or work.get("cover_edition_key"):
+        return f"{host}/b/olid/{olid}-M.jpg"
+    return None
+
+
+def _authors(work: dict) -> list[BookAuthor]:
+    names = work.get("author_name") or []
+    keys = work.get("author_key") or []
+    return [{"key": f"/authors/{keys[i]}" if i < len(keys) else None, "name": name} for i, name in enumerate(names)]
+
+
+def _partner_access(edition: dict, edition_key: str | None) -> BookAccess | None:
+    provider = get_book_provider(edition)
+    if not provider or provider.short_name == "ia" or not edition_key:
+        return None
+    acquisitions = sorted(
+        (a for a in provider.get_acquisitions(edition) if a.ebook_access >= EbookAccess.PRINTDISABLED),
+        key=lambda a: a.ebook_access,
+        reverse=True,
+    )
+    if not acquisitions:
+        return None
+    acq = acquisitions[0]
+    cta: CtaKind
+    badge: Literal["preview"] | None
+    if acq.access == "open-access":
+        cta, badge = ("audiobook" if acq.format == "audio" else "read"), None
+    else:
+        cta, badge = "preview", "preview"
+    return BookAccess(
+        state="partner",
+        cta=cta,
+        url=f"/books/{edition_key}/-/borrow?action=read",
+        external=True,
+        method="get",
+        badge=badge,
+        login_intent=False,
+        ocaid=None,
+    )
+
+
+def build_access(edition: dict, user=None) -> BookAccess:
+    """Collapse `get_lending_state()` + the LoanStatus macro's branches into a
+    CTA the client can render without knowing lending rules."""
+    availability = edition.get("availability") or {}
+    ocaid = edition.get("ocaid") or availability.get("identifier")
+    key = edition.get("key") or ""
+    edition_key = key.split("/")[2] if key.startswith("/books/") else None
+    state = get_lending_state(edition, user=user)
+    stream_url = f"/borrow/ia/{ocaid}?ref=ol" if ocaid else None
+
+    base: BookAccess = {
+        "state": state,
+        "cta": "not_in_library",
+        "url": None,
+        "external": False,
+        "method": "get",
+        "badge": None,
+        "login_intent": False,
+        "ocaid": ocaid,
+    }
+
+    if state == "partner":
+        if partner := _partner_access(edition, edition_key):
+            return partner
+        state = "locate"
+        base["state"] = state
+
+    if state in ("borrowed", "open"):
+        return {**base, "cta": "read", "url": stream_url}
+    if state == "printdisabled":
+        std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
+        return {**base, "cta": "borrow" if std_borrow else "special_access", "url": stream_url, "login_intent": bool(std_borrow)}
+    if state == "borrowable":
+        return {**base, "cta": "borrow", "url": stream_url, "login_intent": True}
+    if state == "waitlist":
+        return {**base, "cta": "join_waitlist", "url": f"/borrow/ia/{ocaid}", "method": "post", "login_intent": True}
+    if state == "checkedout":
+        return {**base, "cta": "checked_out", "url": None}
+    if state == "preview_only":
+        return {**base, "cta": "preview", "url": f"https://archive.org/details/{ocaid}", "external": True, "badge": "preview"}
+    # locate
+    if edition_key:
+        return {**base, "cta": "find_in_library", "url": f"/books/{edition_key}/-/borrow?action=locate", "external": True, "badge": "not_online"}
+    return {**base, "badge": "not_online"}
+
+
+def to_book_card(work: dict, user=None) -> BookCard:
+    edition = _target_edition(work)
+    key = edition.get("key") or ""
+    return {
+        "key": work.get("key") or "",
+        "title": work.get("title") or edition.get("title") or "",
+        "subtitle": work.get("subtitle") or None,
+        "authors": _authors(work),
+        "cover_url": _cover_url(work, edition),
+        "edition_key": key.split("/")[2] if key.startswith("/books/") else None,
+        "first_publish_year": work.get("first_publish_year"),
+        "ratings_average": work.get("ratings_average"),
+        "ratings_count": work.get("ratings_count") or 0,
+        "access": build_access(edition, user=user),
+    }
+
+
+@cache.memoize(
+    engine="memcache",
+    key=lambda q, sort, limit, offset, has_fulltext_only, safe_mode: (
+        "BooksDisplayData-" + md5(f"{q}-{sort}-{limit}-{offset}-{has_fulltext_only}-{safe_mode}".encode()).hexdigest()
+    ),
+    expires=300,
+    cacheable=lambda key, value: "error" not in value,
+)
+async def _fetch_raw_docs(q: str, sort: str, limit: int, offset: int, has_fulltext_only: bool, safe_mode: bool) -> dict:
+    """The Solr + availability round trip, cached like the legacy carousel.
+    Per-user shaping happens outside the cache in `to_book_card`."""
+    query = f"{q} {_SAFE_MODE_FILTER}".strip() if safe_mode and _SAFE_MODE_FILTER not in q else q
+    params: dict = {"q": query}
+    if has_fulltext_only:
+        params["has_fulltext"] = "true"
+    results = await work_search_async(
+        params,
+        sort=sort,
+        fields=",".join(BOOKS_DISPLAY_FIELDS),
+        limit=limit,
+        offset=offset,
+        facet=False,
+        request_label="BOOK_CAROUSEL",
+    )
+    out = {"docs": results.get("docs", []), "num_found": results.get("num_found", 0)}
+    if "error" in results:
+        out["error"] = results["error"]
+    return out
+
+
+async def fetch_books_display(
+    *,
+    q: str,
+    sort: str,
+    limit: int,
+    offset: int,
+    has_fulltext_only: bool,
+    safe_mode: bool,
+    user=None,
+) -> BooksDisplayResponse:
+    raw = await _fetch_raw_docs(q, sort, limit, offset, has_fulltext_only, safe_mode)
+    return {
+        "docs": [to_book_card(work, user=user) for work in raw["docs"]],
+        "num_found": raw["num_found"],
+        "offset": offset,
+        "limit": limit,
+    }

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7335,11 +7335,6 @@ msgstr ""
 
 #: BooksDisplay.html
 #, python-format
-msgid "Your rating: %(rating)s of 5"
-msgstr ""
-
-#: BooksDisplay.html
-#, python-format
 msgid "Rate %(rating)s of 5"
 msgstr ""
 
@@ -7378,6 +7373,11 @@ msgstr ""
 #: BooksDisplay.html
 #, python-format
 msgid "%(count)s items"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "In %(count)s of your lists"
 msgstr ""
 
 #: BooksDisplay.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -296,7 +296,7 @@ msgstr ""
 msgid "YAML Representation:"
 msgstr ""
 
-#: BookPreview.html PreviewSearchInside.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
+#: BookPreview.html BooksDisplay.html PreviewSearchInside.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
 msgstr ""
 
@@ -815,6 +815,10 @@ msgstr ""
 msgid "Disambiguations"
 msgstr ""
 
+#: home/index.html openlibrary/plugins/openlibrary/api.py subjects.html trending.html
+msgid "Trending Books"
+msgstr ""
+
 #: trending.html
 msgid "Now"
 msgstr ""
@@ -839,10 +843,6 @@ msgstr ""
 msgid "All Time"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
-msgid "Trending Books"
-msgstr ""
-
 #: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
 msgstr ""
@@ -852,24 +852,24 @@ msgid "Earliest trending data is from October 2017"
 msgstr ""
 
 #. Label for the reading log shelf for books the user plans to read in the future (bookshelf ID 1). Used as a button label and shelf name.
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: BooksDisplay.html account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr ""
 
 #. Display name for the "currently-reading" reading log shelf used in page headings and breadcrumbs.
 #. Label for the reading log shelf for books the user is actively reading (bookshelf ID 2). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: BooksDisplay.html account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr ""
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
+#: BooksDisplay.html LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
 msgid "Read"
 msgstr ""
 
 #. Display name for the "stopped-reading" reading log shelf used in page headings and breadcrumbs.
 #. Label for the reading log shelf for books the user stopped reading before finishing (bookshelf ID 4). Used as a button label and shelf name.
 #. Label for the reading log shelf for books the user stopped reading (bookshelf ID 4). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: BooksDisplay.html account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Stopped Reading"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+#: BooksDisplay.html ReadButton.html books/edit/edition.html type/list/embed.html widget.html
 msgid "Borrow"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Join waitlist for \"%(title)s\""
 msgstr ""
 
-#: LoanStatus.html widget.html
+#: BooksDisplay.html LoanStatus.html widget.html
 msgid "Join Waitlist"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 
 #. Display name for the "already-read" reading log shelf used in page headings and breadcrumbs.
 #. Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#: BooksDisplay.html account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "See All"
 msgstr ""
 
-#: account/sidebar.html type/list/edit.html type/series/edit.html
+#: BooksDisplay.html account/sidebar.html type/list/edit.html type/series/edit.html
 msgid "Create a list"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "Listen to a reading from %s"
 msgstr ""
 
-#: book_providers/read_button.html
+#: BooksDisplay.html book_providers/read_button.html
 msgid "Audiobook"
 msgstr ""
 
@@ -3319,7 +3319,7 @@ msgstr ""
 msgid " by %(name)s"
 msgstr ""
 
-#: books/daisy.html
+#: BooksDisplay.html books/daisy.html
 msgid "Back"
 msgstr ""
 
@@ -4979,7 +4979,7 @@ msgstr ""
 msgid "Quality Criteria"
 msgstr ""
 
-#: lists/carousel.html lists/home.html lists/showcase.html
+#: BooksDisplay.html lists/carousel.html lists/home.html lists/showcase.html
 msgid "See all"
 msgstr ""
 
@@ -5953,11 +5953,11 @@ msgid_plural "in %(seconds)s seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: search/layout_options.html
+#: BooksDisplay.html search/layout_options.html
 msgid "View as"
 msgstr ""
 
-#: search/layout_options.html
+#: BooksDisplay.html search/layout_options.html
 msgid "List"
 msgstr ""
 
@@ -6816,7 +6816,7 @@ msgstr ""
 msgid "Protected DAISY"
 msgstr ""
 
-#: BookByline.html type/list/embed.html
+#: BookByline.html BooksDisplay.html type/list/embed.html
 #, python-format
 msgid "by %(name)s"
 msgstr ""
@@ -7240,6 +7240,150 @@ msgstr ""
 msgid "See more about this book on Archive.org"
 msgstr ""
 
+#: BooksDisplay.html
+msgid "Covers"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Save %(title)s to your reading log"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "%(title)s is on your reading log"
+msgstr ""
+
+#: BooksDisplay.html ReadButton.html
+msgid "Special Access"
+msgstr ""
+
+#: BooksDisplay.html LoanStatus.html
+msgid "Checked Out"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Find in a library"
+msgstr ""
+
+#: BooksDisplay.html NotInLibrary.html
+msgid "Not in Library"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Not online"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "%(count)s rating"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "%(count)s ratings"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Rated %(average)s out of 5"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "First published %(year)s"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "More options for %(title)s"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Show %(count)s more"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Collapse"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Loading…"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Couldn’t load these books."
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Retry"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "No books found."
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Actions for %(title)s"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Rate this book"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Your rating: %(rating)s of 5"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "Rate %(rating)s of 5"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Clear rating"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Add to list"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "List name"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Create"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Filter lists…"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "You have no lists yet."
+msgstr ""
+
+#: BooksDisplay.html
+msgid "No lists match."
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Loading lists…"
+msgstr ""
+
+#: BooksDisplay.html
+#, python-format
+msgid "%(count)s items"
+msgstr ""
+
+#: BooksDisplay.html
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #: DisplayCode.html
 msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
 msgstr ""
@@ -7357,10 +7501,6 @@ msgstr ""
 msgid "This book is currently checked out, please check back later."
 msgstr ""
 
-#: LoanStatus.html
-msgid "Checked Out"
-msgstr ""
-
 #: LocateButton.html
 msgid "Locate"
 msgstr ""
@@ -7378,10 +7518,6 @@ msgid "You have %(count)d more hour to borrow it."
 msgid_plural "You have %(count)d more hours to borrow it."
 msgstr[0] ""
 msgstr[1] ""
-
-#: NotInLibrary.html
-msgid "Not in Library"
-msgstr ""
 
 #: NotesModal.html
 msgid "My Book Notes"
@@ -7460,10 +7596,6 @@ msgstr ""
 
 #: RawQueryCarousel.html
 msgid "Search collection"
-msgstr ""
-
-#: ReadButton.html
-msgid "Special Access"
 msgstr ""
 
 #: ReadButton.html

--- a/openlibrary/macros/BooksDisplay.html
+++ b/openlibrary/macros/BooksDisplay.html
@@ -13,12 +13,14 @@ $# * limit (int) -- page size
 $# * has_fulltext_only (bool) -- only readable books
 $# * url (str) -- "See all" link (defaults to the search page for `query`)
 $# * view (str) -- initial view: 'covers' or 'list'
-$# * user_lang_only (bool) -- restrict to the user's language
+$# * user_lang_only (bool) -- restrict to the user's language, falling back to all languages when that finds nothing
 $# * safe_mode (bool) -- hide covers of books with a content_warning tag
 
+$ fallback_query = ''
 $if user_lang_only:
   $ user_lang = convert_iso_to_marc(get_lang() or 'en')
   $if user_lang and user_lang in get_populated_languages():
+    $ fallback_query = query
     $ query = query + ' language:' + user_lang
 
 $if url is None:
@@ -84,6 +86,7 @@ $code:
 
 <ol-books-display
   query="$query"
+  fallback-query="$fallback_query"
   sort="$sort"
   limit="$limit"
   title="$title"

--- a/openlibrary/macros/BooksDisplay.html
+++ b/openlibrary/macros/BooksDisplay.html
@@ -68,7 +68,6 @@ $code:
         "alreadyRead": _("Already Read"),
         "stoppedReading": _("Stopped Reading"),
         "rateThisBook": _("Rate this book"),
-        "yourRating": _("Your rating: %(rating)s of 5"),
         "rateStar": _("Rate %(rating)s of 5"),
         "clearRating": _("Clear rating"),
         "addToList": _("Add to list"),
@@ -81,6 +80,7 @@ $code:
         "noMatchingLists": _("No lists match."),
         "loadingLists": _("Loading lists…"),
         "itemsInList": _("%(count)s items"),
+        "inLists": _("In %(count)s of your lists"),
         "errorGeneric": _("Something went wrong. Please try again."),
     }
 

--- a/openlibrary/macros/BooksDisplay.html
+++ b/openlibrary/macros/BooksDisplay.html
@@ -1,0 +1,98 @@
+$def with(query, title='', sort='new', key='', limit=20, has_fulltext_only=True, url=None, view='covers', user_lang_only=False, safe_mode=True)
+
+$# Renders an <ol-books-display> for a Solr query: a titled set of books
+$# switchable between the covers carousel and the list view, with per-book
+$# shelf/rating/list actions. Data is fetched client-side from
+$# /books-display.json, so this macro only emits config + translated labels.
+$#
+$# * query (str) -- Any Open Library search query, e.g. subject:"Textbooks"
+$# * title (str) -- Section heading
+$# * sort (str) -- work_search sort param
+$# * key (str) -- analytics key for this section
+$# * limit (int) -- page size
+$# * has_fulltext_only (bool) -- only readable books
+$# * url (str) -- "See all" link (defaults to the search page for `query`)
+$# * view (str) -- initial view: 'covers' or 'list'
+$# * user_lang_only (bool) -- restrict to the user's language
+$# * safe_mode (bool) -- hide covers of books with a content_warning tag
+
+$if user_lang_only:
+  $ user_lang = convert_iso_to_marc(get_lang() or 'en')
+  $if user_lang and user_lang in get_populated_languages():
+    $ query = query + ' language:' + user_lang
+
+$if url is None:
+  $ url = '/search?' + urlencode({'q': query, 'sort': sort})
+
+$ user = get_current_user()
+
+$code:
+    labels = {
+        # views
+        "viewAs": _("View as"),
+        "covers": _("Covers"),
+        "list": _("List"),
+        # cards
+        "by": _("by %(name)s"),
+        "save": _("Save %(title)s to your reading log"),
+        "saved": _("%(title)s is on your reading log"),
+        "read": _("Read"),
+        "audiobook": _("Audiobook"),
+        "borrow": _("Borrow"),
+        "specialAccess": _("Special Access"),
+        "preview": _("Preview"),
+        "joinWaitlist": _("Join Waitlist"),
+        "checkedOut": _("Checked Out"),
+        "findInLibrary": _("Find in a library"),
+        "notInLibrary": _("Not in Library"),
+        "notOnline": _("Not online"),
+        "previewBadge": _("Preview"),
+        "ratingsOne": _("%(count)s rating"),
+        "ratingsMany": _("%(count)s ratings"),
+        "ratingsAverage": _("Rated %(average)s out of 5"),
+        "firstPublished": _("First published %(year)s"),
+        "shelfMenu": _("More options for %(title)s"),
+        "showMore": _("Show %(count)s more"),
+        "collapse": _("Collapse"),
+        "seeAll": _("See all"),
+        "loading": _("Loading…"),
+        "loadError": _("Couldn’t load these books."),
+        "retry": _("Retry"),
+        "empty": _("No books found."),
+        # actions popover
+        "actionsFor": _("Actions for %(title)s"),
+        "wantToRead": _("Want to Read"),
+        "currentlyReading": _("Currently Reading"),
+        "alreadyRead": _("Already Read"),
+        "stoppedReading": _("Stopped Reading"),
+        "rateThisBook": _("Rate this book"),
+        "yourRating": _("Your rating: %(rating)s of 5"),
+        "rateStar": _("Rate %(rating)s of 5"),
+        "clearRating": _("Clear rating"),
+        "addToList": _("Add to list"),
+        "back": _("Back"),
+        "createList": _("Create a list"),
+        "listName": _("List name"),
+        "create": _("Create"),
+        "filterLists": _("Filter lists…"),
+        "noLists": _("You have no lists yet."),
+        "noMatchingLists": _("No lists match."),
+        "loadingLists": _("Loading lists…"),
+        "itemsInList": _("%(count)s items"),
+        "errorGeneric": _("Something went wrong. Please try again."),
+    }
+
+<ol-books-display
+  query="$query"
+  sort="$sort"
+  limit="$limit"
+  title="$title"
+  url="$url"
+  view="$view"
+  has-fulltext-only="$('true' if has_fulltext_only else 'false')"
+  safe-mode="$('true' if safe_mode else 'false')"
+  analytics-key="$key"
+  $if user:
+    user-key="$user.key"
+  labels="$json_encode(labels)"
+></ol-books-display>

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -94,6 +94,8 @@ DEPRECATED_PATHS: list[tuple[str, str | None]] = [
     (r"(/subjects/[^/]+)", "json"),
     (r"(/publishers/[^/]+)", "json"),
     (r"(/partials/[^/]+)", "json"),
+    (r"/books-display", "json"),
+    (r"/books-display/user-state", "json"),
     (r"/api/books", "json"),
     (r"/api/books", None),
     # Simplified regex

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -96,6 +96,7 @@ DEPRECATED_PATHS: list[tuple[str, str | None]] = [
     (r"(/partials/[^/]+)", "json"),
     (r"/books-display", "json"),
     (r"/books-display/user-state", "json"),
+    (r"/works/OL\d+W/ratings", "json"),
     (r"/api/books", "json"),
     (r"/api/books", None),
     # Simplified regex

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -223,6 +223,23 @@ COMPONENTS = (
         tag="ol-carousel",
     ),
     Component(
+        "books-display",
+        "Books Display",
+        "A titled set of books for a query, switchable between a covers carousel and a list.",
+        "design/components/books-display.html.jinja",
+        group="Content",
+        tag="ol-books-display",
+        css_files=("ol-books-display",),
+    ),
+    Component(
+        "book-actions",
+        "Book Actions",
+        "Per-book shelf, rating and add-to-list actions in a popover.",
+        "design/components/book-actions.html.jinja",
+        group="Content",
+        tag="ol-book-actions",
+    ),
+    Component(
         "read-more",
         "Read More",
         "Truncating long prose to a fixed height or line count, expandable in place.",

--- a/openlibrary/templates/design/components/book-actions.html.jinja
+++ b/openlibrary/templates/design/components/book-actions.html.jinja
@@ -1,0 +1,32 @@
+{% import "design/_example.html.jinja" as ex %}
+{% macro demos() %}
+    <p class="ds-lead">
+        The per-book action popover: the four reading-log shelves, a star rating, and an "Add to list" pane that slides in from the right with a filter and inline list creation. It composes <a href="#popover">Popover</a> for the shell; you supply the trigger. State is optimistic — the UI updates first and an error toast rolls back — and every accepted change fires <code>ol-book-state-change</code> so the surrounding card can update. Only render it for signed-in readers; send everyone else to log in.
+    </p>
+    {% call ex.example("Standalone", "Give it a book, the current shelf/rating, and the reader's key (needed to create lists). The trigger is whatever you slot in.",
+        code='<ol-book-actions user-key="/people/you">\n  <button slot="trigger">Save</button>\n</ol-book-actions>\n\n<script>\n  el.book = { key: "/works/OL27448W", title: "The Lord of the Rings",\n              authors: [{ name: "J.R.R. Tolkien" }] };\n  el.shelf = 1; // Want to Read\n</script>') %}
+        <ol-book-actions id="demo-book-actions" user-key="/people/openlibrary">
+            <ol-button slot="trigger">
+                Save
+            </ol-button>
+        </ol-book-actions>
+        <p>Last change: <strong id="demo-book-actions-out">—</strong></p>
+        <script>
+            (function () {
+                const el = document.getElementById('demo-book-actions');
+                el.book = { key: '/works/OL27448W', title: 'The Lord of the Rings', authors: [{ name: 'J.R.R. Tolkien' }] };
+                el.addEventListener('ol-book-state-change', (e) => {
+                    document.getElementById('demo-book-actions-out').textContent = JSON.stringify(e.detail);
+                });
+            })();
+        </script>
+{% endcall %}
+<div class="ds-notes">
+    <p>
+        <b>Requests.</b> Shelves post to <code>/works/OL…W/bookshelves.json</code>, ratings to <code>/works/OL…W/ratings.json</code>, lists through <code>/partials/MyBooksDropperLists.json</code> (read) and the lists/seeds endpoints (write). A 401 on any of them redirects to login.
+    </p>
+    <p>
+        <b>Escape.</b> In the lists pane, Escape goes back to the main pane; a second Escape closes the popover.
+    </p>
+</div>
+{% endmacro %}

--- a/openlibrary/templates/design/components/books-display.html.jinja
+++ b/openlibrary/templates/design/components/books-display.html.jinja
@@ -1,0 +1,27 @@
+{% import "design/_example.html.jinja" as ex %}
+{% macro demos() %}
+    <p class="ds-lead">
+        A titled set of books for a Solr query, switchable between views. It fetches <code>/books-display.json</code> itself, overlays the signed-in reader's shelf and rating from <code>/books-display/user-state.json</code>, and hands each book's actions to <a href="#book-actions">Book Actions</a>. <code>view</code> is an open enum — <code>covers</code> (an <code>ol-carousel</code> of cover cards) and <code>list</code> (full-width rows) today, more layouts later without changing the data path. Templates should go through the <code>BooksDisplay</code> macro, which fills in the translated <code>labels</code>.
+    </p>
+    {% call ex.example("Covers view", "The default. Cards show the cover, a corner save button, title, author and the access CTA (Read / Borrow / Preview / Find in a library) the server derived from lending state. Nearing the end of the carousel loads the next page.",
+        code='$:macros.BooksDisplay(query=\'subject_key:"fiction"\', title=_("Trending Books"), sort="trending", key="Demo")') %}
+        <ol-books-display query='subject_key:"fiction"' title="Trending Books" sort="trending" limit="12" url="/search?q=subject_key:fiction" analytics-key="DesignDemo">
+        </ol-books-display>
+    {% endcall %}
+    {% call ex.example("List view", "Rows add stars, rating count and first-publish year, plus a split shelf button: the main part toggles the shown shelf, the chevron opens the actions popover. The footer pages with Show more / Collapse / See all.",
+        code='<ol-books-display view="list" query=\'subject_key:"fiction"\' title="Trending Books" sort="trending"></ol-books-display>') %}
+        <ol-books-display view="list" query='subject_key:"fiction"' title="Trending Books" sort="trending" limit="4" url="/search?q=subject_key:fiction" analytics-key="DesignDemo">
+        </ol-books-display>
+    {% endcall %}
+    <div class="ds-notes">
+        <p>
+            <b>Light DOM.</b> Like <code>ol-button</code>, this renders into the light DOM: <code>ol-carousel</code> needs the cards as real children, sitewide handlers (<code>.js-login-intent</code>, analytics) keep working, and its styles live in <code>static/css/components/ol-books-display.css</code> (class prefix <code>obd-</code>).
+        </p>
+        <p>
+            <b>Signed out.</b> Without <code>user-key</code> the corner button and shelf controls send the visitor to log in (remembering the intent), and Borrow CTAs carry the standard login-intent hook. No user-state request is made.
+        </p>
+        <p>
+            <b>Labels.</b> Every string is a key in the <code>labels</code> JSON attribute with an English default; <code>%(name)s</code>-style placeholders match the server-side i18n strings.
+        </p>
+    </div>
+{% endmacro %}

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -57,7 +57,7 @@ $ q = query_param('q')
       $:format(sanitize(page.tag.body))
     $else:
       $# Only show default carousel if subject doesn't have an associated Tag
-      $:macros.QueryCarousel(query=page.solr_query, sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
+      $:macros.BooksDisplay(query=page.solr_query, title=_("Trending Books"), sort='trending,trending_score_hourly_sum', key='SubjectTrending', user_lang_only=True)
     $:macros.PublishingHistory(page.publishing_history)
 
     <div class="clearfix"></div>

--- a/openlibrary/tests/fastapi/test_books_display.py
+++ b/openlibrary/tests/fastapi/test_books_display.py
@@ -1,0 +1,149 @@
+"""Tests for the `<ol-books-display>` endpoints and card normalization."""
+
+from unittest.mock import patch
+
+import pytest
+import web
+
+from openlibrary.fastapi.services import books_display as svc
+
+SERVICE = "openlibrary.fastapi.services.books_display"
+
+
+def solr_work(**overrides):
+    work = {
+        "key": "/works/OL1W",
+        "title": "Project Hail Mary",
+        "author_name": ["Andy Weir"],
+        "author_key": ["OL7W1A"],
+        "cover_i": 123,
+        "first_publish_year": 2021,
+        "ratings_average": 4.3,
+        "ratings_count": 3662,
+        "editions": {"docs": [{"key": "/books/OL9M", "cover_i": 456, "ia": ["projecthailmary"], "ebook_access": "borrowable"}]},
+    }
+    work.update(overrides)
+    return work
+
+
+@pytest.fixture(autouse=True)
+def _cover_host():
+    with patch(f"{SERVICE}.get_coverstore_public_url", return_value="https://covers.test"):
+        yield
+
+
+class TestToBookCard:
+    def test_flattens_work_and_edition(self):
+        card = svc.to_book_card(solr_work())
+        assert card["key"] == "/works/OL1W"
+        assert card["title"] == "Project Hail Mary"
+        assert card["authors"] == [{"key": "/authors/OL7W1A", "name": "Andy Weir"}]
+        assert card["cover_url"] == "https://covers.test/b/id/456-M.jpg"  # edition cover wins
+        assert card["edition_key"] == "OL9M"
+        assert card["first_publish_year"] == 2021
+        assert card["ratings_average"] == 4.3
+        assert card["ratings_count"] == 3662
+
+    def test_author_without_key(self):
+        card = svc.to_book_card(solr_work(author_key=[]))
+        assert card["authors"] == [{"key": None, "name": "Andy Weir"}]
+
+    def test_cover_falls_back_to_ia_then_olid(self):
+        assert svc._cover_url({"ia": ["abc"]}, {}) == "https://covers.test/b/ia/abc-M.jpg?default=false"
+        assert svc._cover_url({"cover_edition_key": "OL5M"}, {}) == "https://covers.test/b/olid/OL5M-M.jpg"
+        assert svc._cover_url({"cover_i": -1}, {}) is None
+
+
+class TestBuildAccess:
+    """`build_access` mirrors LoanStatus.html branch by branch."""
+
+    def edition(self, availability=None, **extra):
+        return {"key": "/books/OL9M", "ia": ["x"], "availability": availability, **extra}
+
+    def access(self, state, availability=None, **extra):
+        with patch(f"{SERVICE}.get_lending_state", return_value=state):
+            return svc.build_access(self.edition(availability, **extra))
+
+    def test_open(self):
+        a = self.access("open", {"identifier": "x"})
+        assert (a["cta"], a["url"], a["badge"], a["login_intent"]) == ("read", "/borrow/ia/x?ref=ol", None, False)
+
+    def test_borrowable_requires_login_intent(self):
+        a = self.access("borrowable", {"identifier": "x"})
+        assert (a["cta"], a["url"], a["login_intent"]) == ("borrow", "/borrow/ia/x?ref=ol", True)
+
+    def test_waitlist_is_a_post(self):
+        a = self.access("waitlist", {"identifier": "x"})
+        assert (a["cta"], a["url"], a["method"]) == ("join_waitlist", "/borrow/ia/x", "post")
+
+    def test_preview_only_badge_and_external(self):
+        a = self.access("preview_only", {"identifier": "x"})
+        assert (a["cta"], a["badge"], a["external"]) == ("preview", "preview", True)
+        assert a["url"] == "https://archive.org/details/x"
+
+    def test_printdisabled_with_standard_borrow(self):
+        a = self.access("printdisabled", {"identifier": "x", "available_to_borrow": True})
+        assert a["cta"] == "borrow"
+        a = self.access("printdisabled", {"identifier": "x"})
+        assert a["cta"] == "special_access"
+
+    def test_checked_out_has_no_url(self):
+        a = self.access("checkedout", {"identifier": "x"})
+        assert (a["cta"], a["url"]) == ("checked_out", None)
+
+    def test_locate(self):
+        a = self.access("locate")
+        assert (a["cta"], a["badge"], a["external"]) == ("find_in_library", "not_online", True)
+        assert a["url"] == "/books/OL9M/-/borrow?action=locate"
+
+    def test_locate_without_edition_key_is_not_in_library(self):
+        with patch(f"{SERVICE}.get_lending_state", return_value="locate"):
+            a = svc.build_access({"key": "/works/OL1W"})
+        assert (a["cta"], a["url"], a["badge"]) == ("not_in_library", None, "not_online")
+
+    def test_partner_open_access(self):
+        edition = {"key": "/books/OL9M", "id_standard_ebooks": ["foo/bar"], "ebook_access": "public"}
+        with patch(f"{SERVICE}.get_lending_state", return_value="partner"):
+            a = svc.build_access(edition)
+        assert (a["state"], a["cta"], a["external"]) == ("partner", "read", True)
+        assert a["url"] == "/books/OL9M/-/borrow?action=read"
+
+
+class TestBooksDisplayEndpoint:
+    def test_returns_cards(self, fastapi_client):
+        raw = {"docs": [solr_work()], "num_found": 1}
+        with (
+            patch(f"{SERVICE}._fetch_raw_docs", return_value=raw) as fetch,
+            patch(f"{SERVICE}.get_lending_state", return_value="locate"),
+            patch("openlibrary.fastapi.books_display.accounts.get_current_user", return_value=None),
+        ):
+            response = fastapi_client.get("/books-display.json", params={"q": "subject:fiction", "sort": "trending", "limit": 5, "offset": 10})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["num_found"] == 1
+        assert (body["offset"], body["limit"]) == (10, 5)
+        assert body["docs"][0]["title"] == "Project Hail Mary"
+        assert body["docs"][0]["access"]["cta"] == "find_in_library"
+        fetch.assert_called_once_with("subject:fiction", "trending", 5, 10, True, True)
+
+    def test_limit_is_capped(self, fastapi_client):
+        response = fastapi_client.get("/books-display.json", params={"q": "x", "limit": 500})
+        assert response.status_code == 422
+
+
+class TestUserStateEndpoint:
+    def test_requires_login(self, fastapi_client):
+        response = fastapi_client.get("/books-display/user-state.json", params={"work_ids": "OL1W"})
+        assert response.status_code == 401
+
+    def test_returns_shelves_and_ratings(self, fastapi_client, mock_authenticated_user):
+        rows = [web.storage(work_id=1, bookshelf_id=2)]
+        with (
+            patch("openlibrary.fastapi.books_display.Bookshelves.get_users_read_status_of_works", return_value=rows) as shelves,
+            patch("openlibrary.fastapi.books_display.Ratings.get_users_ratings_of_works", return_value={2: 5}) as ratings,
+        ):
+            response = fastapi_client.get("/books-display/user-state.json", params={"work_ids": "OL1W,OL2W"})
+        assert response.status_code == 200
+        assert response.json() == {"shelves": {"OL1W": 2}, "ratings": {"OL2W": 5}}
+        shelves.assert_called_once_with("testuser", [1, 2])
+        ratings.assert_called_once_with("testuser", [1, 2])

--- a/openlibrary/tests/fastapi/test_books_display.py
+++ b/openlibrary/tests/fastapi/test_books_display.py
@@ -38,7 +38,7 @@ class TestToBookCard:
         assert card["key"] == "/works/OL1W"
         assert card["title"] == "Project Hail Mary"
         assert card["authors"] == [{"key": "/authors/OL7W1A", "name": "Andy Weir"}]
-        assert card["cover_url"] == "https://covers.test/b/id/456-M.jpg"  # edition cover wins
+        assert card["cover_url"] == "https://covers.test/b/id/123-M.jpg"  # work cover wins
         assert card["edition_key"] == "OL9M"
         assert card["first_publish_year"] == 2021
         assert card["ratings_average"] == 4.3

--- a/static/css/components/ol-books-display.css
+++ b/static/css/components/ol-books-display.css
@@ -1,0 +1,531 @@
+/**
+ * ol-books-display — light-DOM styles for the books-display component and
+ * its cover cards / list rows. Lives here (not in the component's JS) because
+ * the component renders into the light DOM so <ol-carousel> can slot the
+ * cards. Class prefix: obd-.
+ */
+
+ol-books-display {
+  display: block;
+  /* Hold to the container even inside flex/grid parents: the carousel's
+     track is wide, and must never set this element's width. */
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  font-family: var(--font-family-body);
+  color: var(--color-text);
+}
+
+/* Reserve a little height pre-upgrade so the page doesn't jump. */
+ol-books-display:not(:defined) {
+  min-height: 320px;
+}
+
+.obd__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-inline-md);
+  margin-bottom: var(--spacing-stack-sm);
+}
+
+.obd__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-title-large);
+  line-height: var(--line-height-heading);
+}
+
+/* Links. Two classes so these beat the page-level `a:link` rules. */
+.obd .obd-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.obd .obd-row__author .obd-link {
+  color: var(--color-link);
+}
+
+.obd .obd-link:hover {
+  text-decoration: underline;
+}
+
+.obd__toggle .obd-icon {
+  width: 14px;
+  height: 14px;
+  vertical-align: -2px;
+  margin-right: 4px;
+}
+
+.obd__status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-inline-md);
+  padding: var(--spacing-inset-lg);
+  color: var(--color-text-secondary);
+}
+
+.obd .obd__link-btn {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--color-link);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.obd .obd__link-btn:hover {
+  text-decoration: underline;
+}
+
+.obd .obd__link-btn:disabled {
+  color: var(--color-text-muted);
+  cursor: default;
+  text-decoration: none;
+}
+
+.obd .obd__link-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm);
+}
+
+/* ── Shared: covers, badges, CTAs ─────────────────────────── */
+
+.obd-cover {
+  position: relative;
+  display: block;
+  aspect-ratio: 2 / 3;
+  border-radius: var(--border-radius-thumbnail);
+  overflow: hidden;
+  background: var(--color-surface-sunken);
+  box-shadow: 0 1px 3px var(--book-cover-shadow-color);
+}
+
+.obd-cover__link {
+  display: block;
+  height: 100%;
+}
+
+.obd-cover__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.obd-cover__blank {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-inset-md);
+  background: linear-gradient(160deg, var(--neutral-600), var(--neutral-800));
+  color: var(--color-text-inverse);
+  text-align: center;
+}
+
+.obd-cover__blank-title {
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-title-medium);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.obd-cover__blank-author {
+  font-size: var(--font-size-label-small);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.obd-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 2px 6px;
+  border-radius: var(--border-radius-badge);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-size-label-small);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow: 0 1px 2px var(--book-cover-shadow-color);
+  pointer-events: none;
+}
+
+.obd .obd-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-inline-xs);
+  box-sizing: border-box;
+  height: var(--control-height-medium);
+  padding: 0 var(--spacing-md);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--border-radius-button);
+  font-family: var(--font-family-button);
+  font-size: var(--font-size-body-medium);
+  font-weight: 600;
+  line-height: var(--line-height-control);
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  background-color: var(--white);
+  color: var(--color-link);
+  transition: transform 0.08s;
+}
+
+.obd .obd-cta:active {
+  transform: scale(0.97);
+}
+
+.obd .obd-cta--primary {
+  background-color: var(--primary-blue);
+  border-color: var(--primary-blue);
+  color: var(--white);
+}
+
+.obd .obd-cta--primary:hover {
+  background-color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.obd .obd-cta--secondary:hover {
+  background-color: var(--color-hover-overlay);
+}
+
+.obd .obd-cta--static {
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.obd .obd-cta:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.obd-cta__ext {
+  width: 14px;
+  height: 14px;
+}
+
+.obd-cta-form {
+  margin: 0;
+}
+
+/* ── Covers view (carousel cards) ─────────────────────────── */
+
+.obd__carousel {
+  --ol-carousel-viewport-padding: 6px;
+
+  min-width: 0;
+}
+
+.obd-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-stack-xs);
+  min-width: 0;
+}
+
+.obd-card .obd-cover {
+  margin-bottom: var(--spacing-stack-xs);
+}
+
+.obd .obd-card__title {
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-title-medium);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  color: var(--color-text);
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.obd .obd-card__title:hover {
+  text-decoration: underline;
+}
+
+.obd-card__author {
+  font-size: var(--font-size-body-medium);
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.obd-card__cta {
+  width: 100%;
+  margin-top: auto;
+}
+
+/* Corner save button: "+" until the book is on a shelf, then a filled check.
+   Signed in, the button is slotted into <ol-book-actions>, whose popover host
+   is position: relative — so the wrapper takes the corner and the button
+   goes static inside it. */
+.obd-save,
+.obd-cover > ol-book-actions {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.obd-save {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--border-radius-circle);
+  background: var(--white);
+  color: var(--color-text);
+  box-shadow: 0 1px 4px var(--boxshadow-black);
+  cursor: pointer;
+  transition: transform 0.08s;
+}
+
+.obd-save .obd-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.obd-save:hover {
+  transform: scale(1.06);
+}
+
+.obd-save:active {
+  transform: scale(0.95);
+}
+
+.obd-save:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.obd-save--on {
+  background: var(--primary-blue);
+  color: var(--white);
+}
+
+.obd-cover > ol-book-actions .obd-save {
+  position: static;
+}
+
+/* ── List view (rows) ─────────────────────────────────────── */
+
+.obd__list-wrap {
+  border: var(--border-card);
+  border-radius: var(--border-radius-card);
+  background: var(--color-surface);
+}
+
+.obd__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.obd-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+  gap: var(--spacing-inline-lg);
+  align-items: start;
+  padding: var(--spacing-inset-md);
+  border-bottom: var(--border-divider);
+}
+
+.obd-row:last-child {
+  border-bottom: 0;
+}
+
+.obd-row__cover {
+  width: 72px;
+}
+
+.obd-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.obd .obd-row__title {
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-title-large);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.obd .obd-row__title:hover {
+  text-decoration: underline;
+}
+
+.obd-row__author,
+.obd-row__meta {
+  font-size: var(--font-size-body-medium);
+  color: var(--color-text-secondary);
+}
+
+.obd-row__rating {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-inline-xs);
+  font-size: var(--font-size-body-medium);
+  color: var(--color-text-secondary);
+}
+
+.obd-stars {
+  display: inline-flex;
+  color: var(--gold);
+}
+
+.obd-stars .obd-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.obd-row__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--spacing-stack-xs);
+  width: 200px;
+}
+
+.obd-row__cta {
+  width: 100%;
+}
+
+/* Split shelf button: main toggles the shown shelf, chevron opens the menu. */
+.obd-shelf {
+  display: flex;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--border-radius-button);
+  overflow: hidden;
+  background: var(--white);
+}
+
+.obd-shelf--on {
+  border-color: var(--color-control-selected-border);
+  background: var(--color-control-selected-bg);
+}
+
+.obd-shelf__main,
+.obd-shelf__more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: calc(var(--control-height-medium) - 2px);
+  border: 0;
+  background: none;
+  color: var(--color-text);
+  font-family: var(--font-family-button);
+  font-size: var(--font-size-body-medium);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.obd-shelf__main {
+  flex: 1;
+  min-width: 0;
+  padding: 0 var(--spacing-sm);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.obd-shelf__main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.obd-shelf__main--on {
+  color: var(--color-link);
+}
+
+.obd-shelf > ol-book-actions {
+  display: flex;
+}
+
+.obd-shelf__more {
+  width: 40px;
+  border-left: 1px solid var(--color-border-subtle);
+}
+
+.obd-shelf--on .obd-shelf__more {
+  border-left-color: var(--color-control-selected-border);
+  color: var(--color-link);
+}
+
+.obd-shelf__main:hover,
+.obd-shelf__more:hover {
+  background: var(--color-hover-overlay);
+}
+
+.obd-shelf__main:focus-visible,
+.obd-shelf__more:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+.obd-shelf .obd-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+
+.obd__list-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-inline-md);
+  padding: var(--spacing-inset-md);
+  border-top: var(--border-divider);
+  font-size: var(--font-size-body-medium);
+}
+
+.obd__dot {
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 600px) {
+  .obd-row {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  .obd-row__cover {
+    width: 56px;
+  }
+
+  .obd-row__actions {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    width: auto;
+  }
+
+  .obd-row__actions > * {
+    flex: 1;
+  }
+
+  .obd-row__title {
+    font-size: var(--font-size-title-medium);
+  }
+}

--- a/static/css/components/ol-books-display.css
+++ b/static/css/components/ol-books-display.css
@@ -50,13 +50,6 @@ ol-books-display:not(:defined) {
   text-decoration: underline;
 }
 
-.obd__toggle .obd-icon {
-  width: 14px;
-  height: 14px;
-  vertical-align: -2px;
-  margin-right: 4px;
-}
-
 .obd__status {
   display: flex;
   align-items: center;
@@ -100,7 +93,6 @@ ol-books-display:not(:defined) {
   border-radius: var(--border-radius-thumbnail);
   overflow: hidden;
   background: var(--color-surface-sunken);
-  box-shadow: 0 1px 3px var(--book-cover-shadow-color);
 }
 
 .obd-cover__link {
@@ -164,7 +156,10 @@ ol-books-display:not(:defined) {
   pointer-events: none;
 }
 
+/* Mirrors ol-button (see ol-button.css): raised shadow + inset specular
+   edge, primary lightens on hover, secondary darkens. */
 .obd .obd-cta {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -176,13 +171,22 @@ ol-books-display:not(:defined) {
   border-radius: var(--border-radius-button);
   font-family: var(--font-family-button);
   font-size: var(--font-size-body-medium);
-  font-weight: 600;
   line-height: var(--line-height-control);
   white-space: nowrap;
   text-decoration: none;
   cursor: pointer;
+  user-select: none;
   background-color: var(--white);
-  color: var(--color-link);
+  color: var(--dark-grey);
+  --control-highlight-strength: 35%;
+  box-shadow:
+    var(--box-shadow-raised),
+    inset 0 1px 0
+      color-mix(
+        in srgb,
+        var(--white) var(--control-highlight-strength),
+        var(--control-surface)
+      );
   transition: transform 0.08s;
 }
 
@@ -194,15 +198,20 @@ ol-books-display:not(:defined) {
   background-color: var(--primary-blue);
   border-color: var(--primary-blue);
   color: var(--white);
+  --control-surface: var(--primary-blue);
+  --control-highlight-strength: 18%;
 }
 
-.obd .obd-cta--primary:hover {
-  background-color: var(--color-primary-hover);
-  border-color: var(--color-primary-hover);
-}
+@media (hover: hover) and (pointer: fine) {
+  .obd .obd-cta--primary:hover {
+    filter: brightness(1.1);
+  }
 
-.obd .obd-cta--secondary:hover {
-  background-color: var(--color-hover-overlay);
+  .obd .obd-cta--secondary:hover {
+    background-color: var(--color-control-hover);
+    border-color: var(--light-grey);
+    --control-surface: var(--color-control-hover);
+  }
 }
 
 .obd .obd-cta--static {
@@ -212,7 +221,7 @@ ol-books-display:not(:defined) {
 
 .obd .obd-cta:focus-visible {
   outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline-offset: var(--spacing-3xs);
 }
 
 .obd-cta__ext {
@@ -245,8 +254,8 @@ ol-books-display:not(:defined) {
 
 .obd .obd-card__title {
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-title-medium);
-  font-weight: 700;
+  font-size: var(--font-size-title-small);
+  font-weight: 600;
   line-height: var(--line-height-tight);
   color: var(--color-text);
   text-decoration: none;
@@ -261,7 +270,7 @@ ol-books-display:not(:defined) {
 }
 
 .obd-card__author {
-  font-size: var(--font-size-body-medium);
+  font-size: var(--font-size-label-medium);
   color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -292,39 +301,69 @@ ol-books-display:not(:defined) {
   height: 32px;
   padding: 0;
   border: 0;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  --control-highlight-strength: 35%;
+}
+
+/* The visible circle is smaller than the 32px hit target. Same inset
+   specular edge as ol-button; the drop shadow is heavier since it floats
+   over cover art. */
+.obd-save::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
   border-radius: var(--border-radius-circle);
   background: var(--white);
-  color: var(--color-text);
-  box-shadow: 0 1px 4px var(--boxshadow-black);
-  cursor: pointer;
+  box-shadow:
+    0 1px 4px var(--boxshadow-black),
+    inset 0 1px 0
+      color-mix(
+        in srgb,
+        var(--white) var(--control-highlight-strength),
+        var(--control-surface)
+      );
   transition: transform 0.08s;
 }
 
 .obd-save .obd-icon {
-  width: 18px;
-  height: 18px;
+  position: relative;
+  width: 14px;
+  height: 14px;
 }
 
-.obd-save:hover {
-  transform: scale(1.06);
+.obd-save:hover::before {
+  transform: scale(1.08);
 }
 
-.obd-save:active {
+.obd-save:active::before {
   transform: scale(0.95);
 }
 
 .obd-save:focus-visible {
+  outline: none;
+}
+
+.obd-save:focus-visible::before {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
 .obd-save--on {
-  background: var(--primary-blue);
   color: var(--white);
+  --control-surface: var(--primary-blue);
+  --control-highlight-strength: 18%;
+}
+
+.obd-save--on::before {
+  background: var(--primary-blue);
 }
 
 .obd-cover > ol-book-actions .obd-save {
-  position: static;
+  position: relative;
+  top: auto;
+  right: auto;
 }
 
 /* ── List view (rows) ─────────────────────────────────────── */
@@ -367,8 +406,8 @@ ol-books-display:not(:defined) {
 
 .obd .obd-row__title {
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-title-large);
-  font-weight: 700;
+  font-size: var(--font-size-title-medium);
+  font-weight: 600;
   line-height: var(--line-height-tight);
   color: var(--color-text);
   text-decoration: none;
@@ -380,7 +419,7 @@ ol-books-display:not(:defined) {
 
 .obd-row__author,
 .obd-row__meta {
-  font-size: var(--font-size-body-medium);
+  font-size: var(--font-size-label-medium);
   color: var(--color-text-secondary);
 }
 
@@ -526,6 +565,6 @@ ol-books-display:not(:defined) {
   }
 
   .obd-row__title {
-    font-size: var(--font-size-title-medium);
+    font-size: var(--font-size-title-small);
   }
 }

--- a/static/css/ol-components.css
+++ b/static/css/ol-components.css
@@ -16,6 +16,7 @@
 
 @import "components/ol-button.css";
 @import "components/ol-banner.css";
+@import "components/ol-books-display.css";
 
 /* Pre-hydration sizing for shadow-DOM web components. These rules apply
    only until the component upgrades and renders its own shadow root. */

--- a/tests/unit/js/OlBookActions.test.js
+++ b/tests/unit/js/OlBookActions.test.js
@@ -128,7 +128,7 @@ describe('ol-book-actions rating', () => {
         await tick(el);
         const post = calls.find(c => c.url === '/works/OL1W/ratings.json');
         expect(post.init.body.get('rating')).toBe('4');
-        expect(q(el, '.stars .caption').textContent).toBe('Your rating: 4 of 5');
+        expect(q(el, '.stars .caption').textContent).toBe('Clear rating');
     });
 
     test('clicking the current star clears the rating', async() => {

--- a/tests/unit/js/OlBookActions.test.js
+++ b/tests/unit/js/OlBookActions.test.js
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for <ol-book-actions>: shelf/rating requests and their optimistic
+ * updates, the state-change event, and the add-to-list pane (load, filter,
+ * toggle, create). Network is stubbed at `fetch`.
+ */
+import { OlBookActions, resetListsCache, fmt } from '../../../openlibrary/components/lit/OlBookActions.js';
+import { SHELF } from '../../../openlibrary/components/lit/utils/books-api.js';
+
+const BOOK = { key: '/works/OL1W', title: 'Project Hail Mary', authors: [{ name: 'Andy Weir' }], editionKey: 'OL9M' };
+
+let calls;
+let listData;
+
+function stubFetch({ failWith } = {}) {
+    calls = [];
+    listData = {
+        '/people/tester/lists/OL1L': { listName: 'Summer 2026', members: ['/works/OL7W'] },
+        '/people/tester/lists/OL2L': { listName: 'Sci-fi to reread', members: ['/works/OL1W'] },
+    };
+    global.fetch = jest.fn(async(url, init) => {
+        calls.push({ url, init });
+        if (failWith) return { ok: false, status: failWith, json: async() => ({}) };
+        let body = {};
+        if (url.endsWith('/partials/MyBooksDropperLists.json')) body = { dropper: '', listData };
+        if (url.endsWith('/lists.json') && init?.method === 'POST') body = { key: '/people/tester/lists/OL3L', revision: 1 };
+        return { ok: true, status: 200, json: async() => body };
+    });
+}
+
+beforeAll(() => {
+    global.ResizeObserver = class { observe() {} disconnect() {} };
+    window.matchMedia = query => ({
+        matches: false, media: query, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {},
+    });
+});
+
+beforeEach(() => {
+    resetListsCache();
+});
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+async function tick(el) {
+    await new Promise(r => setTimeout(r, 0));
+    await el.updateComplete;
+}
+
+async function mount(props = {}) {
+    const el = new OlBookActions();
+    el.book = BOOK;
+    el.userKey = '/people/tester';
+    Object.assign(el, props);
+    const trigger = document.createElement('button');
+    trigger.slot = 'trigger';
+    el.appendChild(trigger);
+    document.body.appendChild(el);
+    await el.updateComplete;
+    // Open the popover so the panel exists.
+    el.shadowRoot.querySelector('ol-popover').open = true;
+    await tick(el);
+    return el;
+}
+
+const q = (el, sel) => el.shadowRoot.querySelector(sel);
+const qa = (el, sel) => [...el.shadowRoot.querySelectorAll(sel)];
+
+describe('fmt', () => {
+    test('interpolates %(name)s placeholders', () => {
+        expect(fmt('by %(name)s', { name: 'Andy' })).toBe('by Andy');
+        expect(fmt('%(count)s items', { count: 3 })).toBe('3 items');
+    });
+});
+
+describe('ol-book-actions shelves', () => {
+    test('renders header and four shelf rows with the current one checked', async() => {
+        stubFetch();
+        const el = await mount({ shelf: SHELF.CURRENTLY_READING });
+        expect(q(el, '.header').textContent.replace(/\s+/g, ' ').trim()).toBe('Project Hail Mary by Andy Weir');
+        const rows = qa(el, '.row[role="menuitemradio"]');
+        expect(rows.map(r => r.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false', 'false']);
+    });
+
+    test('clicking a shelf posts it, updates optimistically, and emits state', async() => {
+        stubFetch();
+        const el = await mount();
+        const events = [];
+        el.addEventListener('ol-book-state-change', e => events.push(e.detail));
+        qa(el, '.row[role="menuitemradio"]')[0].click();
+        expect(el.shelf).toBe(SHELF.WANT_TO_READ);
+        await tick(el);
+        const post = calls.find(c => c.url === '/works/OL1W/bookshelves.json');
+        expect(post.init.method).toBe('POST');
+        expect(post.init.body.get('bookshelf_id')).toBe('1');
+        expect(post.init.body.get('edition_id')).toBe('OL9M');
+        expect(events).toEqual([{ key: '/works/OL1W', shelf: SHELF.WANT_TO_READ, rating: null }]);
+    });
+
+    test('clicking the current shelf removes it', async() => {
+        stubFetch();
+        const el = await mount({ shelf: SHELF.WANT_TO_READ });
+        qa(el, '.row[role="menuitemradio"]')[0].click();
+        expect(el.shelf).toBeNull();
+        await tick(el);
+        // Server toggles off when it receives the current shelf id.
+        expect(calls[0].init.body.get('bookshelf_id')).toBe('1');
+    });
+
+    test('rolls back and toasts on failure', async() => {
+        stubFetch({ failWith: 500 });
+        const el = await mount();
+        qa(el, '.row[role="menuitemradio"]')[2].click();
+        expect(el.shelf).toBe(SHELF.ALREADY_READ);
+        await tick(el);
+        expect(el.shelf).toBeNull();
+        expect(document.querySelector('ol-toast')).not.toBeNull();
+    });
+});
+
+describe('ol-book-actions rating', () => {
+    test('rating posts and moves the book to Already Read', async() => {
+        stubFetch();
+        const el = await mount();
+        qa(el, '.star')[3].click();
+        expect(el.rating).toBe(4);
+        expect(el.shelf).toBe(SHELF.ALREADY_READ);
+        await tick(el);
+        const post = calls.find(c => c.url === '/works/OL1W/ratings.json');
+        expect(post.init.body.get('rating')).toBe('4');
+        expect(q(el, '.stars .caption').textContent).toBe('Your rating: 4 of 5');
+    });
+
+    test('clicking the current star clears the rating', async() => {
+        stubFetch();
+        const el = await mount({ rating: 2, shelf: SHELF.ALREADY_READ });
+        qa(el, '.star')[1].click();
+        expect(el.rating).toBeNull();
+        await tick(el);
+        expect(calls[0].init.body.has('rating')).toBe(false);
+    });
+});
+
+describe('ol-book-actions lists pane', () => {
+    test('opens the pane, loads lists with membership and counts', async() => {
+        stubFetch();
+        const el = await mount();
+        q(el, '.group:last-child .row').click();
+        await tick(el);
+        expect(el._pane).toBe('lists');
+        expect(q(el, '.track').classList.contains('pane-lists')).toBe(true);
+        expect(calls.some(c => c.url.endsWith('/partials/MyBooksDropperLists.json'))).toBe(true);
+        const rows = qa(el, '.list-row');
+        expect(rows.map(r => r.querySelector('.name').textContent)).toEqual(['Summer 2026', 'Sci-fi to reread']);
+        expect(rows.map(r => r.querySelector('input').checked)).toEqual([false, true]);
+        expect(rows.map(r => r.querySelector('.count').textContent)).toEqual(['1', '1']);
+    });
+
+    test('filter narrows the rows', async() => {
+        stubFetch();
+        const el = await mount();
+        q(el, '.group:last-child .row').click();
+        await tick(el);
+        const input = q(el, '.pane:nth-child(2) .input');
+        input.value = 'sci';
+        input.dispatchEvent(new Event('input'));
+        await el.updateComplete;
+        expect(qa(el, '.list-row')).toHaveLength(1);
+        input.value = 'zzz';
+        input.dispatchEvent(new Event('input'));
+        await el.updateComplete;
+        expect(q(el, '.empty').textContent).toBe('No lists match.');
+    });
+
+    test('toggling a checkbox adds/removes the seed', async() => {
+        stubFetch();
+        const el = await mount();
+        q(el, '.group:last-child .row').click();
+        await tick(el);
+        const [first, second] = qa(el, '.list-row input');
+        first.checked = true;
+        first.dispatchEvent(new Event('change'));
+        second.checked = false;
+        second.dispatchEvent(new Event('change'));
+        await tick(el);
+        const add = calls.find(c => c.url === '/people/tester/lists/OL1L/seeds.json');
+        const remove = calls.find(c => c.url === '/people/tester/lists/OL2L/seeds.json');
+        expect(JSON.parse(add.init.body)).toEqual({ add: [{ key: '/works/OL1W' }] });
+        expect(JSON.parse(remove.init.body)).toEqual({ remove: [{ key: '/works/OL1W' }] });
+        expect(qa(el, '.list-row .count').map(c => c.textContent)).toEqual(['2', '0']);
+    });
+
+    test('create list inlines an input, posts, and prepends the new list', async() => {
+        stubFetch();
+        const el = await mount();
+        q(el, '.group:last-child .row').click();
+        await tick(el);
+        q(el, '.lists-header .btn').click();
+        await el.updateComplete;
+        const form = q(el, 'form.field');
+        expect(form).not.toBeNull();
+        form.querySelector('input').value = 'Gothic autumn';
+        form.dispatchEvent(new Event('submit', { cancelable: true }));
+        await tick(el);
+        const post = calls.find(c => c.url === '/people/tester/lists.json');
+        expect(JSON.parse(post.init.body)).toEqual({ name: 'Gothic autumn', description: '', seeds: [{ key: '/works/OL1W' }] });
+        expect(el._creating).toBe(false);
+        const rows = qa(el, '.list-row');
+        expect(rows[0].querySelector('.name').textContent).toBe('Gothic autumn');
+        expect(rows[0].querySelector('input').checked).toBe(true);
+    });
+
+    test('Escape in the lists pane goes back instead of closing', async() => {
+        stubFetch();
+        const el = await mount();
+        q(el, '.group:last-child .row').click();
+        await tick(el);
+        const popover = q(el, 'ol-popover');
+        popover._requestClose('escape');
+        await tick(el);
+        expect(popover.open).toBe(true);
+        expect(el._pane).toBe('main');
+        popover._requestClose('escape');
+        await tick(el);
+        expect(popover.open).toBe(false);
+    });
+});

--- a/tests/unit/js/OlBooksDisplay.test.js
+++ b/tests/unit/js/OlBooksDisplay.test.js
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for <ol-books-display>: data flow (fetch → cards → user-state
+ * overlay), the view toggle, list-view paging, and the logged-in/out branches
+ * of the per-book controls. Network is stubbed at `fetch`.
+ */
+import '../../../openlibrary/components/lit/OlBooksDisplay.js';
+import { SHELF } from '../../../openlibrary/components/lit/utils/books-api.js';
+
+function doc(i, overrides = {}) {
+    return {
+        key: `/works/OL${i}W`,
+        title: `Book ${i}`,
+        subtitle: null,
+        authors: [{ key: `/authors/OL${i}A`, name: `Author ${i}` }],
+        cover_url: `https://covers.test/b/id/${i}-M.jpg`,
+        edition_key: `OL${i}M`,
+        first_publish_year: 2000 + i,
+        ratings_average: 4.2,
+        ratings_count: 3,
+        access: { state: 'borrowable', cta: 'borrow', url: `/borrow/ia/x${i}?ref=ol`, external: false, method: 'get', badge: null, login_intent: true, ocaid: `x${i}` },
+        ...overrides,
+    };
+}
+
+function page(offset, limit, total) {
+    const docs = [];
+    for (let i = offset; i < Math.min(offset + limit, total); i++) docs.push(doc(i));
+    return { docs, num_found: total, offset, limit };
+}
+
+let fetchCalls;
+
+function stubFetch({ total = 45, userState = { shelves: {}, ratings: {} } } = {}) {
+    fetchCalls = [];
+    global.fetch = jest.fn(async(url, init) => {
+        fetchCalls.push({ url, init });
+        const u = new URL(url, 'http://localhost');
+        let body;
+        if (u.pathname === '/books-display.json') {
+            body = page(Number(u.searchParams.get('offset')), Number(u.searchParams.get('limit')), total);
+        } else if (u.pathname === '/books-display/user-state.json') {
+            body = userState;
+        } else if (u.pathname.endsWith('/bookshelves.json')) {
+            body = { bookshelves_affected: 1 };
+        } else {
+            body = {};
+        }
+        return { ok: true, status: 200, json: async() => body };
+    });
+}
+
+beforeAll(() => {
+    // jsdom has no IntersectionObserver; the component falls back to start().
+    delete window.IntersectionObserver;
+    global.ResizeObserver = class { observe() {} disconnect() {} };
+    // jsdom's ElementInternals lacks the form-association API the segmented
+    // control calls; give it inert stand-ins.
+    const proto = window.ElementInternals?.prototype;
+    if (proto && !proto.setFormValue) {
+        proto.setFormValue = () => {};
+        proto.setValidity = () => {};
+    }
+});
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+async function mount(attrs = {}) {
+    const el = document.createElement('ol-books-display');
+    el.query = 'subject:fiction';
+    el.limit = 20;
+    el.title = 'Trending';
+    el.url = '/search?q=x';
+    Object.assign(el, attrs);
+    document.body.appendChild(el);
+    await el.updateComplete;
+    // Let the first fetch + render settle.
+    await new Promise(r => setTimeout(r, 0));
+    await el.updateComplete;
+    await new Promise(r => setTimeout(r, 0));
+    await el.updateComplete;
+    return el;
+}
+
+describe('ol-books-display data flow', () => {
+    test('fetches the first page and renders cover cards', async() => {
+        stubFetch();
+        const el = await mount();
+        expect(el.docs).toHaveLength(20);
+        expect(el.querySelectorAll('.obd-card')).toHaveLength(20);
+        const first = fetchCalls[0].url;
+        expect(first).toContain('/books-display.json?');
+        expect(first).toContain('q=subject%3Afiction');
+        expect(first).toContain('offset=0');
+        expect(first).toContain('has_fulltext_only=true');
+    });
+
+    test('renders label-free CTA kinds with translated labels', async() => {
+        stubFetch();
+        const el = await mount({ labels: { borrow: 'Emprunter' } });
+        const cta = el.querySelector('.obd-card .obd-cta');
+        expect(cta.textContent.trim()).toBe('Emprunter');
+        expect(cta.classList.contains('obd-cta--primary')).toBe(true);
+        expect(cta.getAttribute('href')).toBe('/borrow/ia/x0?ref=ol');
+    });
+
+    test('logged out: borrow CTAs carry the login-intent hook and "+" has no popover', async() => {
+        stubFetch();
+        const el = await mount();
+        expect(el.querySelector('.obd-card .obd-cta').classList.contains('js-login-intent')).toBe(true);
+        expect(el.querySelector('ol-book-actions')).toBeNull();
+        expect(el.querySelector('.obd-save')).not.toBeNull();
+        // No user-state request without a user
+        expect(fetchCalls.some(c => c.url.includes('user-state'))).toBe(false);
+    });
+
+    test('logged in: overlays shelf state and wraps "+" in ol-book-actions', async() => {
+        stubFetch({ userState: { shelves: { OL1W: SHELF.ALREADY_READ }, ratings: { OL1W: 5 } } });
+        const el = await mount({ userKey: '/people/tester' });
+        const stateCall = fetchCalls.find(c => c.url.includes('user-state'));
+        expect(stateCall.url).toContain('work_ids=OL0W%2COL1W');
+        const actions = el.querySelectorAll('ol-book-actions');
+        expect(actions).toHaveLength(20);
+        expect(actions[1].shelf).toBe(SHELF.ALREADY_READ);
+        expect(actions[1].rating).toBe(5);
+        expect(actions[1].querySelector('.obd-save').classList.contains('obd-save--on')).toBe(true);
+        expect(actions[0].querySelector('.obd-save').classList.contains('obd-save--on')).toBe(false);
+        expect(el.querySelector('.obd-card .obd-cta').classList.contains('js-login-intent')).toBe(false);
+    });
+
+    test('ol-book-state-change updates the card', async() => {
+        stubFetch();
+        const el = await mount({ userKey: '/people/tester' });
+        const actions = el.querySelector('ol-book-actions');
+        actions.dispatchEvent(new CustomEvent('ol-book-state-change', {
+            bubbles: true, composed: true,
+            detail: { key: '/works/OL0W', shelf: SHELF.WANT_TO_READ, rating: null },
+        }));
+        await el.updateComplete;
+        expect(el.querySelector('ol-book-actions .obd-save').classList.contains('obd-save--on')).toBe(true);
+    });
+
+    test('carousel nearing its end loads the next page', async() => {
+        stubFetch({ total: 45 });
+        const el = await mount();
+        const carousel = el.querySelector('ol-carousel');
+        carousel.dispatchEvent(new CustomEvent('ol-carousel-page-change', { detail: { page: 2, totalPages: 3 }, bubbles: true }));
+        await new Promise(r => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(el.docs).toHaveLength(40);
+        expect(fetchCalls.filter(c => c.url.includes('/books-display.json'))[1].url).toContain('offset=20');
+    });
+
+    test('stops paging once every result is loaded', async() => {
+        stubFetch({ total: 5 });
+        const el = await mount();
+        expect(el.hasMore).toBe(false);
+        await el.loadMore();
+        expect(fetchCalls.filter(c => c.url.includes('/books-display.json'))).toHaveLength(1);
+    });
+
+    test('shows the error state with a retry on failure', async() => {
+        global.fetch = jest.fn(async() => ({ ok: false, status: 500, json: async() => ({}) }));
+        const el = await mount();
+        expect(el.querySelector('[role="alert"]').textContent).toContain('load these books');
+        expect(el.querySelector('.obd-card')).toBeNull();
+    });
+});
+
+describe('ol-books-display views', () => {
+    test('toggle switches to the list view and back', async() => {
+        stubFetch();
+        const el = await mount();
+        const events = [];
+        el.addEventListener('ol-books-display-view-change', e => events.push(e.detail.view));
+        el.querySelector('ol-segmented-control').dispatchEvent(new CustomEvent('ol-segmented-control-change', { detail: { value: 'list' } }));
+        await el.updateComplete;
+        expect(el.view).toBe('list');
+        expect(el.getAttribute('view')).toBe('list');
+        expect(el.querySelectorAll('.obd-row')).toHaveLength(20);
+        expect(el.querySelector('ol-carousel')).toBeNull();
+        expect(events).toEqual(['list']);
+    });
+
+    test('list rows show byline links, stars, and first-publish year', async() => {
+        stubFetch();
+        const el = await mount({ view: 'list' });
+        const row = el.querySelector('.obd-row');
+        expect(row.querySelector('.obd-row__author a').getAttribute('href')).toBe('/authors/OL0A');
+        expect(row.querySelector('.obd-row__author').textContent.replace(/\s+/g, ' ').trim()).toBe('by Author 0');
+        expect(row.querySelector('.obd-row__rating-text').textContent).toContain('4.2');
+        expect(row.querySelector('.obd-row__meta').textContent).toBe('First published 2000');
+    });
+
+    test('list footer: show more fetches and reveals, collapse hides', async() => {
+        stubFetch({ total: 45 });
+        const el = await mount({ view: 'list' });
+        const footerText = () => el.querySelector('.obd__list-footer').textContent.replace(/\s+/g, ' ').trim();
+        expect(footerText()).toBe('Show 20 more · See all →');
+        el.querySelector('.obd__list-footer .obd__link-btn').click();
+        await new Promise(r => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(el.querySelectorAll('.obd-row')).toHaveLength(40);
+        expect(footerText()).toBe('Show 5 more · Collapse · See all →');
+        el.scrollIntoView = () => {};
+        [...el.querySelectorAll('.obd__list-footer .obd__link-btn')].find(b => b.textContent === 'Collapse').click();
+        await el.updateComplete;
+        expect(el.querySelectorAll('.obd-row')).toHaveLength(20);
+    });
+
+    test('split button main click toggles Want to Read for a signed-in user', async() => {
+        stubFetch();
+        const el = await mount({ view: 'list', userKey: '/people/tester' });
+        const main = el.querySelector('.obd-shelf__main');
+        expect(main.textContent.trim()).toBe('Want to Read');
+        main.click();
+        await new Promise(r => setTimeout(r, 0));
+        await el.updateComplete;
+        const post = fetchCalls.find(c => c.url.endsWith('/works/OL0W/bookshelves.json'));
+        expect(post.init.method).toBe('POST');
+        expect(post.init.body.get('bookshelf_id')).toBe(String(SHELF.WANT_TO_READ));
+        expect(el.querySelector('.obd-shelf').classList.contains('obd-shelf--on')).toBe(true);
+    });
+});

--- a/tests/unit/js/OlBooksDisplay.test.js
+++ b/tests/unit/js/OlBooksDisplay.test.js
@@ -202,7 +202,7 @@ describe('ol-books-display views', () => {
         const el = await mount({ view: 'list' });
         const row = el.querySelector('.obd-row');
         expect(row.querySelector('.obd-row__author a').getAttribute('href')).toBe('/authors/OL0A');
-        expect(row.querySelector('.obd-row__author').textContent.replace(/\s+/g, ' ').trim()).toBe('by Author 0');
+        expect(row.querySelector('.obd-row__author').textContent.replace(/\s+/g, ' ').trim()).toBe('Author 0');
         expect(row.querySelector('.obd-row__rating-text').textContent).toContain('4.2');
         expect(row.querySelector('.obd-row__meta').textContent).toBe('First published 2000');
     });

--- a/tests/unit/js/OlBooksDisplay.test.js
+++ b/tests/unit/js/OlBooksDisplay.test.js
@@ -160,6 +160,20 @@ describe('ol-books-display data flow', () => {
         expect(fetchCalls.filter(c => c.url.includes('/books-display.json'))).toHaveLength(1);
     });
 
+    test('falls back to the wider query when the first is empty', async() => {
+        stubFetch({ total: 45 });
+        const original = global.fetch;
+        global.fetch = jest.fn(async(url, init) => {
+            if (url.includes('q=narrow')) return { ok: true, status: 200, json: async() => ({ docs: [], num_found: 0, offset: 0, limit: 20 }) };
+            return original(url, init);
+        });
+        const el = await mount({ query: 'narrow', fallbackQuery: 'subject:fiction' });
+        await new Promise(r => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(el.query).toBe('subject:fiction');
+        expect(el.docs).toHaveLength(20);
+    });
+
     test('shows the error state with a retry on failure', async() => {
         global.fetch = jest.fn(async() => ({ ok: false, status: 500, json: async() => ({}) }));
         const el = await mount();


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #


https://github.com/user-attachments/assets/05dec290-bbc7-4d34-9ab4-6eeaf9198845



**Draft / WIP.** Feature: rebuilds the subject-page carousel on `<ol-carousel>` as a new `<ol-books-display>` component, adds a Covers ⇄ List view toggle, and gives every book a "+" popover (`<ol-book-actions>`) for shelves, star rating, and add-to-list — without leaving the page.

Design notes and status live in `CAROUSEL-ACTIONS-PLAN.md` (will be removed before this leaves draft).

### Why

- **Act on a book where you find it.** Today a carousel card is a link; shelving, rating, or listing a book means a page load. Now it's one click, optimistic, with a toast on failure, and logged-out users are routed to login with their intent queued.
- **Same books, more than one shape.** The list view surfaces author, rating, and first-publish year from the same docs — a real "browse" mode rather than a strip of covers.
- **One controller, many surfaces.** `view` is an open enum (`covers`, `list`, later `grid`), so home page and other `QueryCarousel` callers can move over one at a time with a one-line template change.

### Technical

- **Data — JSON, split public / per-user.** `GET /books-display.json` (FastAPI) returns normalized book cards, Solr + availability memcached exactly like the legacy carousel; the CTA is decided server-side by `get_lending_state()` so no lending logic is duplicated in JS. `GET /books-display/user-state.json` is a small, uncached, per-user overlay (shelf + rating for a batch of works). Everything else reuses the existing shelf / rating / list endpoints. Because the public payload never depends on the user, it can be shared/edge-cached later; the per-user call is the only thing that can't.
- **Components** — `<ol-books-display>` (light DOM; owns fetch, pagination, toggle, user-state overlay; renders `<ol-carousel>` or rows from the same docs) and `<ol-book-actions>` (shadow DOM popover on `<ol-popover>`; two-pane shelves+rating → lists). Labels are passed in from the template so strings stay in the normal i18n flow.
- **Templates** — `macros/BooksDisplay.html` emits the element; `subjects.html` opts in. Everything else stays on slick.
- Design-docs pages for both components; jest + FastAPI tests included.

### Testing

1. `/subjects/fiction` — carousel renders, arrows page and lazy-load more; toggle to List → "Show more / Collapse / See all".
2. Signed in: "+" on a cover → set a shelf, rate, add to a list (create one inline); ✓ state and list-row split button stay in sync. Signed out: "+" redirects to login.
3. `npm run test:js -- OlBooksDisplay OlBookActions`, `make test-py-uv PYTEST_ARGS="openlibrary/tests/fastapi/test_books_display.py"`.

Note: dev availability mock returns `{}`, so every card is "Find in a library" locally.

### Risks / gotchas

- **Two extra requests per carousel** vs. one HTML partial today: docs JSON + user-state (signed in only). Docs are memcached like the legacy path, so Solr load is unchanged; user-state is a cheap batched DB read but is *new* traffic proportional to signed-in carousel views.
- **Lists still come from `/partials/MyBooksDropperLists.json`**, which renders dropper HTML we discard. Fine at one carousel per page; a JSON-only lists endpoint should land before rolling out to the home page.
- **Icons are inline Lucide paths** for now; swap to `<ol-icon>` when #12955 lands.
- **Client-rendered cards** — no book HTML in the initial subject-page response for this section (the legacy lazy path already behaved this way, but worth stating).
- Waitlist / preview-modal branches of the CTA are unverified in dev (mock never yields those states).
- Only the subject page changes; no user preference is persisted for the view.

### Screenshot

_TODO_

### Stakeholders

_WIP — will tag when ready for review._


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

https://claude.ai/code/session_015eSzBTqC8crz1V6BbUJxF5
