### PR TITLE
ol-button: href links, ghost variant, icon/circle shapes, floating elevation

### DIFF
--- a/openlibrary/components/lit/OLButton.js
+++ b/openlibrary/components/lit/OLButton.js
@@ -7,6 +7,10 @@ import { LitElement, html, nothing } from 'lit';
  * it both before and after hydration. Handles variants, sizes, loading,
  * disabled, and form submission for type="submit" / type="reset".
  *
+ * Links: set `href` and it renders an <a> instead, styled identically, so a
+ * button-shaped navigation CTA ("Read", "Borrow") needs no separate recipe.
+ * `disabled` / `loading` on a link drop the href and set aria-disabled.
+ *
  * Contains no application-specific logic, copy, or translations. The
  * consuming page owns what the button *does* — this component only owns
  * how it looks and basic interaction semantics.
@@ -23,9 +27,18 @@ import { LitElement, html, nothing } from 'lit';
  *
  * @element ol-button
  *
- * @prop {"primary" | "secondary" | "destructive"} variant - Default: "secondary"
+ * @prop {"primary" | "secondary" | "destructive" | "ghost"} variant - Default: "secondary".
+ *   Ghost is transparent with no border or lift; it fills on hover.
  * @prop {"small" | "medium" | "large"}            size    - Default: "medium"
+ * @prop {"icon" | "circle"} shape - Icon-only: width equals the size's height,
+ *   no horizontal padding. "circle" additionally rounds it. Give it an aria-label.
+ * @prop {"floating"} elevation - Heavier drop shadow for a control that sits
+ *   over content (e.g. a save button on cover art) rather than on the page.
  * @prop {"button" | "submit" | "reset"}           type    - Default: "button"
+ * @prop {String} href      - Renders an <a> instead of a <button>.
+ * @prop {String} target    - Link target (only with href).
+ * @prop {String} rel       - Link rel (only with href).
+ * @prop {String} download  - Link download attribute (only with href).
  * @prop {Boolean} loading    - Shows a spinner and disables interaction.
  * @prop {Boolean} disabled   - Disables interaction.
  * @prop {Boolean} fullWidth  - Button expands to fill its container.
@@ -41,12 +54,20 @@ import { LitElement, html, nothing } from 'lit';
  * @example
  *   <ol-button variant="destructive" size="medium">Delete</ol-button>
  *   <ol-button type="submit" loading>Saving…</ol-button>
+ *   <ol-button variant="primary" href="/borrow/OL1M">Borrow</ol-button>
+ *   <ol-button shape="circle" elevation="floating" aria-label="Save">+</ol-button>
  */
 export class OLButton extends LitElement {
     static properties = {
         variant: { type: String, reflect: true },
         size: { type: String, reflect: true },
+        shape: { type: String, reflect: true },
+        elevation: { type: String, reflect: true },
         type: { type: String, reflect: true },
+        href: { type: String, reflect: true },
+        target: { type: String },
+        rel: { type: String },
+        download: { type: String },
         loading: { type: Boolean, reflect: true },
         disabled: { type: Boolean, reflect: true },
         fullWidth: { type: Boolean, reflect: true, attribute: 'full-width' },
@@ -109,15 +130,37 @@ export class OLButton extends LitElement {
         // The chevron is always rendered but hidden by CSS unless the button is
         // a disclosure trigger (ol-popover / ol-select-popover set aria-haspopup
         // on it). That keeps the trigger affordance automatic — no consumer markup.
+        const inert = this.loading || this.disabled;
+        const content = html`${this._label}<span class="ol-btn-spinner" aria-hidden="true"></span><span class="ol-btn-chevron" aria-hidden="true"></span>`;
+
+        if (this.href !== undefined && this.href !== null) {
+            // A link can't be disabled natively: drop the href (no navigation,
+            // no tab stop) and say so via aria-disabled. The host's
+            // pointer-events: none handles clicks.
+            return html`
+                <a
+                    href=${inert ? nothing : this.href}
+                    target=${this.target ?? nothing}
+                    rel=${this.rel ?? nothing}
+                    download=${this.download ?? nothing}
+                    aria-disabled=${inert ? 'true' : nothing}
+                    aria-busy=${this.loading ? 'true' : 'false'}
+                    aria-label=${this.a11yLabel ?? nothing}
+                    aria-haspopup=${this.a11yHasPopup ?? nothing}
+                    aria-expanded=${this.a11yExpanded ?? nothing}
+                >${content}</a>
+            `;
+        }
+
         return html`
             <button
                 type=${this.type}
-                ?disabled=${this.loading || this.disabled}
+                ?disabled=${inert}
                 aria-busy=${this.loading ? 'true' : 'false'}
                 aria-label=${this.a11yLabel ?? nothing}
                 aria-haspopup=${this.a11yHasPopup ?? nothing}
                 aria-expanded=${this.a11yExpanded ?? nothing}
-            >${this._label}<span class="ol-btn-spinner" aria-hidden="true"></span><span class="ol-btn-chevron" aria-hidden="true"></span></button>
+            >${content}</button>
         `;
     }
 }

--- a/openlibrary/templates/design/components/button.html.jinja
+++ b/openlibrary/templates/design/components/button.html.jinja
@@ -10,6 +10,112 @@
         <ol-button variant="destructive">
             Destructive
         </ol-button>
+        <ol-button variant="ghost">
+            Ghost
+        </ol-button>
+    {% endcall %}
+    {% call ex.example("Links", "Set href and the component renders an <a> with the same styling — for button-shaped navigation like Read, Borrow, or Find in a library. disabled and loading drop the href and set aria-disabled.") %}
+        <ol-button variant="primary" href="/search?q=hobbit">
+            Read
+        </ol-button>
+        <ol-button href="/search?q=hobbit">
+            Borrow
+        </ol-button>
+        <ol-button href="/search?q=hobbit" target="_blank" rel="noopener">
+            Find in a library
+        </ol-button>
+        <ol-button href="/search?q=hobbit" disabled>
+            Unavailable
+        </ol-button>
+    {% endcall %}
+    {% call ex.example("Icon-only shapes", "shape=\"icon\" makes a square whose side matches the size's control height; shape=\"circle\" rounds it. Always give these an aria-label.",
+        code='<ol-button shape="icon" aria-label="Search">\n  <svg ...></svg>\n</ol-button>\n<ol-button shape="circle" size="small" aria-label="Save">\n  <svg ...></svg>\n</ol-button>') %}
+        <ol-button shape="icon" size="small" aria-label="Search">
+            <svg width="14"
+                 height="14"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" />
+            </svg>
+        </ol-button>
+        <ol-button shape="icon" aria-label="Search">
+            <svg width="16"
+                 height="16"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" />
+            </svg>
+        </ol-button>
+        <ol-button shape="icon" size="large" aria-label="Search">
+            <svg width="18"
+                 height="18"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" />
+            </svg>
+        </ol-button>
+        <ol-button shape="circle" aria-label="Save">
+            <svg width="16"
+                 height="16"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <path d="M12 5v14M5 12h14" />
+            </svg>
+        </ol-button>
+        <ol-button shape="circle" variant="ghost" aria-label="Close">
+            <svg width="16"
+                 height="16"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+        </ol-button>
+    {% endcall %}
+    {% call ex.example("Floating", "elevation=\"floating\" swaps in a heavier drop shadow for a control that sits over content — a save button on cover art, a scroll-to-top button — instead of on the page surface.") %}
+        <ol-button shape="circle" elevation="floating" aria-label="Save">
+            <svg width="16"
+                 height="16"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2"
+                 stroke-linecap="round"
+                 stroke-linejoin="round"
+                 aria-hidden="true">
+                <path d="M12 5v14M5 12h14" />
+            </svg>
+        </ol-button>
+        <ol-button elevation="floating">
+            Back to top
+        </ol-button>
     {% endcall %}
     {% call ex.example("Sizes", "Heights come from the shared --control-height-* tokens, so each size lines up with the same-size segmented control and input.") %}
         <ol-button size="small">

--- a/static/css/components/ol-button.css
+++ b/static/css/components/ol-button.css
@@ -21,7 +21,7 @@
  * the component sets on itself after it inserts the inner <button>.
  * Every style rule below either targets:
  *   - `ol-button:not([hydrated])` (phase 1 — style the outer tag), or
- *   - `ol-button > button`        (phase 2 — style the inner button).
+ *   - `ol-button > :is(button, a)`        (phase 2 — style the inner button).
  *
  * We use a custom `hydrated` attribute instead of the built-in
  * `:defined` pseudo-class because `:defined` flips the moment the JS
@@ -41,7 +41,8 @@ ol-button[full-width] {
   width: 100%;
 }
 
-/* Once hydrated, the host is just a wrapper — the inner <button> paints. */
+/* Once hydrated, the host is just a wrapper — the inner <button> (or <a>,
+   when `href` is set) paints. */
 ol-button[hydrated] {
   padding: 0;
   border: 0;
@@ -58,14 +59,16 @@ ol-button[loading] {
 
 /* Shared appearance: host pre-upgrade, inner button post-upgrade. */
 ol-button:not([hydrated]),
-ol-button > button {
+ol-button > :is(button, a) {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--spacing-inline-md);
   box-sizing: border-box;
-  height: var(--control-height-medium);
+  /* Height is a custom property so the icon-only shapes can square up on it. */
+  --ol-button-height: var(--control-height-medium);
+  height: var(--ol-button-height);
   padding: 0 var(--spacing-md);
   font-family: var(--font-family-button);
   font-size: var(--font-size-body-medium);
@@ -89,40 +92,84 @@ ol-button > button {
       );
   cursor: pointer;
   user-select: none;
+  text-decoration: none;
   /* Hover color changes are instant (see docs/ai/design.md); only the
      :active press-scale animates. */
   transition: transform 0.08s;
 }
 
+/* The link form must out-rank the global a:link / a:visited / a:hover rules
+   (0,1,1) — variant colors already do (0,1,2), but the underline needs help. */
+ol-button > a:is(:link, :visited, :hover, :active) {
+  text-decoration: none;
+}
+
 /* Press feedback — tactile scale on activation. The raised shadow and
    specular highlight stay put through the press. */
-ol-button > button:active {
+ol-button > :is(button, a):active {
   transform: scale(0.97);
 }
 
+/* Icon-only shapes are small enough that 3% is sub-pixel; press harder so
+   the feedback registers. */
+ol-button[shape] > :is(button, a):active {
+  transform: scale(0.93);
+}
+
 ol-button[full-width]:not([hydrated]),
-ol-button[full-width] > button {
+ol-button[full-width] > :is(button, a) {
   width: 100%;
 }
 
 /* Sizes */
 ol-button[size="small"]:not([hydrated]),
-ol-button[size="small"] > button {
-  height: var(--control-height-small);
+ol-button[size="small"] > :is(button, a) {
+  --ol-button-height: var(--control-height-small);
   padding: 0 var(--spacing-sm);
   font-size: var(--font-size-label-medium);
 }
 
 ol-button[size="large"]:not([hydrated]),
-ol-button[size="large"] > button {
-  height: var(--control-height-large);
+ol-button[size="large"] > :is(button, a) {
+  --ol-button-height: var(--control-height-large);
   padding: 0 var(--spacing-lg);
   font-size: var(--font-size-body-large);
 }
 
+/* Icon-only shapes: a square whose side is the size's control height, so it
+   sits flush with a same-size text button. The slot holds just the glyph;
+   consumers must supply aria-label. */
+ol-button[shape="icon"]:not([hydrated]),
+ol-button[shape="icon"] > :is(button, a),
+ol-button[shape="circle"]:not([hydrated]),
+ol-button[shape="circle"] > :is(button, a) {
+  width: var(--ol-button-height);
+  padding: 0;
+}
+
+ol-button[shape="circle"]:not([hydrated]),
+ol-button[shape="circle"] > :is(button, a) {
+  border-radius: var(--border-radius-circle);
+}
+
+/* Floating — the control sits over content (cover art, a sticky bar) rather
+   than on the page surface, so it carries a heavier drop shadow. The inset
+   specular edge is unchanged. */
+ol-button[elevation="floating"]:not([hydrated]),
+ol-button[elevation="floating"] > :is(button, a) {
+  box-shadow:
+    var(--box-shadow-floating),
+    inset 0 1px 0
+      color-mix(
+        in srgb,
+        var(--white) var(--control-highlight-strength),
+        var(--control-surface)
+      );
+}
+
 /* Primary — opt-in via variant="primary". */
 ol-button[variant="primary"]:not([hydrated]),
-ol-button[variant="primary"] > button {
+ol-button[variant="primary"] > :is(button, a) {
   background-color: var(--primary-blue);
   border-color: var(--primary-blue);
   color: var(--white);
@@ -134,7 +181,7 @@ ol-button[variant="primary"] > button {
 
 /* Secondary is the default (already set above). Explicit selector for clarity. */
 ol-button[variant="secondary"]:not([hydrated]),
-ol-button[variant="secondary"] > button {
+ol-button[variant="secondary"] > :is(button, a) {
   background-color: var(--white);
   border-color: var(--color-border-subtle);
   color: var(--dark-grey);
@@ -142,7 +189,7 @@ ol-button[variant="secondary"] > button {
 
 /* Destructive — solid red fill, mirroring primary but in the danger hue. */
 ol-button[variant="destructive"]:not([hydrated]),
-ol-button[variant="destructive"] > button {
+ol-button[variant="destructive"] > :is(button, a) {
   background-color: var(--red);
   border-color: var(--red);
   color: var(--white);
@@ -151,11 +198,23 @@ ol-button[variant="destructive"] > button {
   --control-highlight-strength: 18%;
 }
 
+/* Ghost — text and icon only, no fill, border, or lift at rest; picks up the
+   neutral hover fill. For low-emphasis actions ("Show more", toolbar icons).
+   The border stays (transparent) so ghost lines up pixel-for-pixel with
+   secondary. */
+ol-button[variant="ghost"]:not([hydrated]),
+ol-button[variant="ghost"] > :is(button, a) {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--dark-grey);
+  box-shadow: none;
+}
+
 /* Selected — a neutral button carrying a selection, e.g. ol-select-popover's
    trigger once a language is picked. Must stay after the variant fills, which
    it ties on specificity. */
 ol-button[selected]:not([hydrated]),
-ol-button[selected] > button {
+ol-button[selected] > :is(button, a) {
   background-color: var(--color-control-selected-bg);
   border-color: var(--color-control-selected-border);
   color: var(--link-blue);
@@ -169,7 +228,7 @@ ol-button[selected] > button {
    specular highlight stays toned to the resting color (e.g. a blown-out white
    edge once destructive fills red). Keep --control-surface == background-color. */
 @media (hover: hover) and (pointer: fine) {
-  ol-button[variant="secondary"] > button:hover {
+  ol-button[variant="secondary"] > :is(button, a):hover {
     background-color: var(--color-control-hover);
     /* Nudge the border a touch darker in step with the fill (both drop ~7%
        in lightness) so the whole button reads as one shape on hover, rather
@@ -178,9 +237,13 @@ ol-button[selected] > button {
     --control-surface: var(--color-control-hover);
   }
 
+  ol-button[variant="ghost"] > :is(button, a):hover {
+    background-color: var(--color-control-hover);
+  }
+
   /* Deepens its tint rather than going grey. After the secondary hover rule,
      which it ties on specificity. */
-  ol-button[selected] > button:hover {
+  ol-button[selected] > :is(button, a):hover {
     background-color: var(--color-control-selected-bg-hover);
     border-color: var(--color-control-selected-border-hover);
     --control-surface: var(--color-control-selected-surface-hover);
@@ -191,33 +254,35 @@ ol-button[selected] > button {
      brightness() carries the fill, border, and inset specular edge together, so
      there's no per-property override or --control-surface retoning to keep in
      sync. The press-scale on :active still reads as the "down" step. */
-  ol-button[variant="primary"] > button:hover,
-  ol-button[variant="destructive"] > button:hover {
+  ol-button[variant="primary"] > :is(button, a):hover,
+  ol-button[variant="destructive"] > :is(button, a):hover {
     filter: brightness(1.1);
   }
 }
 
 /* Focus ring */
-ol-button > button:focus-visible {
+ol-button > :is(button, a):focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: var(--spacing-3xs);
 }
 
 /* Loading: the label and spinner crossfade. Both are always in the DOM so
    the button width stays stable and we can animate between states. */
-ol-button[loading] > button {
+ol-button[loading] > :is(button, a) {
   cursor: progress;
 }
 
 /* Disabled — scoped away from [loading] so the loading state keeps
-   full-strength colors while still being non-interactive. */
-ol-button:not([loading]) > button:disabled {
+   full-strength colors while still being non-interactive. Links have no
+   :disabled; the component sets aria-disabled and drops the href instead. */
+ol-button:not([loading]) > button:disabled,
+ol-button:not([loading]) > a[aria-disabled="true"] {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
 /* Label: visible by default; shrinks, blurs, and fades out on loading. */
-ol-button > button > .ol-btn-label {
+ol-button > :is(button, a) > .ol-btn-label {
   display: inline-block;
   transition:
     opacity 0.24s ease,
@@ -225,7 +290,16 @@ ol-button > button > .ol-btn-label {
     filter 0.24s ease;
 }
 
-ol-button[loading] > button > .ol-btn-label {
+/* An inline SVG sits on the text baseline, leaving descender space under it
+   that pushes the glyph off-center. Flex the label so the icon centers on
+   the box, not the baseline. */
+ol-button[shape] > :is(button, a) > .ol-btn-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+ol-button[loading] > :is(button, a) > .ol-btn-label {
   opacity: 0;
   transform: scale(0.8);
   filter: blur(2px);
@@ -234,7 +308,7 @@ ol-button[loading] > button > .ol-btn-label {
 /* Spinner wrapper: hidden by default; grows, sharpens, and fades in on
    loading. Absolute so it doesn't affect layout. The rotation lives on
    the inner ::before so it doesn't conflict with the scale transition. */
-ol-button > button > .ol-btn-spinner {
+ol-button > :is(button, a) > .ol-btn-spinner {
   position: absolute;
   inset: 0;
   display: flex;
@@ -250,7 +324,7 @@ ol-button > button > .ol-btn-spinner {
     filter 0.24s ease;
 }
 
-ol-button > button > .ol-btn-spinner::before {
+ol-button > :is(button, a) > .ol-btn-spinner::before {
   content: "";
   display: block;
   box-sizing: border-box;
@@ -261,13 +335,13 @@ ol-button > button > .ol-btn-spinner::before {
   border-radius: 50%;
 }
 
-ol-button[loading] > button > .ol-btn-spinner {
+ol-button[loading] > :is(button, a) > .ol-btn-spinner {
   opacity: 1;
   transform: scale(1);
   filter: blur(0);
 }
 
-ol-button[loading] > button > .ol-btn-spinner::before {
+ol-button[loading] > :is(button, a) > .ol-btn-spinner::before {
   animation: ol-button-spin 0.7s linear infinite;
 }
 
@@ -282,11 +356,11 @@ ol-button[loading] > button > .ol-btn-spinner::before {
    and aria-expanded directly on the trigger element, so the affordance is
    automatic with no consumer markup. Opt out with the `no-chevron` attribute.
    The glyph is a mask painted with currentcolor so it matches the label color. */
-ol-button > button > .ol-btn-chevron {
+ol-button > :is(button, a) > .ol-btn-chevron {
   display: none;
 }
 
-ol-button[aria-haspopup] > button > .ol-btn-chevron {
+ol-button[aria-haspopup] > :is(button, a) > .ol-btn-chevron {
   /* Reference an external SVG file rather than an inline data URI: an unquoted
      url() to a static path has no `+` or spaces for the CSS formatter to tokenize
      and mangle (a data URI repeatedly got split on `image/svg+xml`). Mirrors the
@@ -309,31 +383,31 @@ ol-button[aria-haspopup] > button > .ol-btn-chevron {
 
 /* Opt out — stays hidden even when wired as a trigger. Comes after the show
    rule (equal specificity) so it wins. */
-ol-button[no-chevron] > button > .ol-btn-chevron {
+ol-button[no-chevron] > :is(button, a) > .ol-btn-chevron {
   display: none;
 }
 
 /* Rotate 180° while the popover is open. aria-expanded="true" only appears on
    disclosure triggers, so [aria-haspopup] is redundant here. */
-ol-button[aria-expanded="true"] > button > .ol-btn-chevron {
+ol-button[aria-expanded="true"] > :is(button, a) > .ol-btn-chevron {
   transform: rotate(180deg);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  ol-button > button > .ol-btn-label,
-  ol-button > button > .ol-btn-spinner,
-  ol-button[loading] > button > .ol-btn-label,
-  ol-button[loading] > button > .ol-btn-spinner {
+  ol-button > :is(button, a) > .ol-btn-label,
+  ol-button > :is(button, a) > .ol-btn-spinner,
+  ol-button[loading] > :is(button, a) > .ol-btn-label,
+  ol-button[loading] > :is(button, a) > .ol-btn-spinner {
     transform: none;
     filter: none;
     transition-property: opacity;
   }
 
-  ol-button[loading] > button > .ol-btn-spinner::before {
+  ol-button[loading] > :is(button, a) > .ol-btn-spinner::before {
     animation-duration: 2s;
   }
 
-  ol-button[aria-haspopup] > button > .ol-btn-chevron {
+  ol-button[aria-haspopup] > :is(button, a) > .ol-btn-chevron {
     transition: none;
   }
 }

--- a/static/css/tokens/borders.css
+++ b/static/css/tokens/borders.css
@@ -63,4 +63,9 @@
      color-mix is unsupported on very old Safari/Android in our browserslist;
      there the highlight is dropped and the control keeps just this drop shadow. */
   --box-shadow-raised: 0 1px 1px hsla(0, 0%, 0%, 0.05);
+
+  /* Floating-control drop shadow — a control that sits over content (a save
+     button on cover art) rather than on the page. Pair with the same inline
+     specular highlight as above; see ol-button[elevation="floating"]. */
+  --box-shadow-floating: 0 1px 4px hsla(0, 0%, 0%, 0.15);
 }

--- a/tests/unit/js/OLButton.test.js
+++ b/tests/unit/js/OLButton.test.js
@@ -1,0 +1,73 @@
+/**
+ * <ol-button> rendering contract: which inner element it produces and how
+ * disabled/loading map onto it. jsdom has no layout, so appearance (variants,
+ * shapes, elevation) is CSS-only and verified in the browser / design page.
+ */
+import '../../../openlibrary/components/lit/OLButton.js';
+
+async function mount(attrs = {}, label = 'Label') {
+    const el = document.createElement('ol-button');
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    el.textContent = label;
+    document.body.appendChild(el);
+    await el.updateComplete;
+    return el;
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('OLButton', () => {
+    test('renders a <button> by default and moves the label inside it', async() => {
+        const el = await mount();
+        const btn = el.querySelector(':scope > button');
+        expect(btn).not.toBeNull();
+        expect(btn.type).toBe('button');
+        expect(btn.querySelector('.ol-btn-label').textContent).toBe('Label');
+        expect(el.hasAttribute('hydrated')).toBe(true);
+    });
+
+    test('renders an <a> when href is set, passing link attributes through', async() => {
+        const el = await mount({ href: '/borrow/OL1M', target: '_blank', rel: 'noopener', download: 'x.pdf' });
+        expect(el.querySelector(':scope > button')).toBeNull();
+        const a = el.querySelector(':scope > a');
+        expect(a.getAttribute('href')).toBe('/borrow/OL1M');
+        expect(a.getAttribute('target')).toBe('_blank');
+        expect(a.getAttribute('rel')).toBe('noopener');
+        expect(a.getAttribute('download')).toBe('x.pdf');
+        expect(a.hasAttribute('aria-disabled')).toBe(false);
+        expect(a.querySelector('.ol-btn-label').textContent).toBe('Label');
+    });
+
+    test('a disabled link drops its href and sets aria-disabled', async() => {
+        const el = await mount({ href: '/x', disabled: '' });
+        const a = el.querySelector(':scope > a');
+        expect(a.hasAttribute('href')).toBe(false);
+        expect(a.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    test('a loading link is also inert and reports aria-busy', async() => {
+        const el = await mount({ href: '/x', loading: '' });
+        const a = el.querySelector(':scope > a');
+        expect(a.hasAttribute('href')).toBe(false);
+        expect(a.getAttribute('aria-disabled')).toBe('true');
+        expect(a.getAttribute('aria-busy')).toBe('true');
+    });
+
+    test('toggling href swaps between <a> and <button> and keeps the label', async() => {
+        const el = await mount();
+        el.href = '/x';
+        await el.updateComplete;
+        expect(el.querySelector(':scope > a .ol-btn-label').textContent).toBe('Label');
+        el.href = undefined;
+        await el.updateComplete;
+        expect(el.querySelector(':scope > a')).toBeNull();
+        expect(el.querySelector(':scope > button .ol-btn-label').textContent).toBe('Label');
+    });
+
+    test('mirrors aria-label onto the link', async() => {
+        const el = await mount({ href: '/x', 'aria-label': 'Save' });
+        expect(el.querySelector(':scope > a').getAttribute('aria-label')).toBe('Save');
+    });
+});


### PR DESCRIPTION
feature — extends `<ol-button>` with what the in-progress book actions popover work (#13346) needs, so those surfaces stop hand-rolling button features.

All four are standard button-component conventions (link buttons, ghost, icon-only, elevation) rather than anything novel to OL, so nothing here should be contentious.

<img width="983" height="523" alt="Screenshot 2026-08-17 at 10 13 09 AM" src="https://github.com/user-attachments/assets/21e404c9-644b-4804-b7ff-6eecc4a65a69" />
<img width="986" height="391" alt="Screenshot 2026-08-17 at 10 13 14 AM" src="https://github.com/user-attachments/assets/15197f7a-150a-4de4-bba1-08e87b696b7c" />


- **Links** — `href` renders an `<a>` with identical styling (`target`/`rel`/`download` pass through). For button-shaped navigation like Read / Borrow.
- **`variant="ghost"`** — no fill, border, or lift at rest; neutral hover fill.
- **`shape="icon"` / `shape="circle"`** — icon-only, square on the size's control height.
- **`elevation="floating"`** — heavier drop shadow (new `--box-shadow-floating` token) for controls sitting over content, e.g. a save button on cover art.

> [!NOTE]  
> Low risk: nothing in the codebase uses these yet — this only adds attributes and CSS rules to the existing component.

### Screenshots

See above.

Also, here is a scenario where these features can be utilized:

https://github.com/user-attachments/assets/685ba7b5-c0e3-4a9b-82ab-f8efcd04b7f7



### Testing
- `/developers/design/components#button` has examples for each addition.
- `npx jest tests/unit/js/OLButton.test.js` covers the button ↔ link rendering contract.

### Stakeholders
@cdrini @mekarpeles 


