### PR TITLE
vite build: readyState guards for analytics/SW init + hashed CSS filenames

### DIFF
--- a/docs/ai/js-vite-migration-progress.md
+++ b/docs/ai/js-vite-migration-progress.md
@@ -83,6 +83,12 @@ non-render-blocking, exact `style-loader` semantics with zero plugins.
 `publicDir: '.'` + `copyPublicDir: false` keeps root-absolute `url(/static/...)`
 unprocessed — zero data URIs, zero emitted image assets.
 
+Extracted CSS is emitted as `[name].[hash].css` (e.g. `carousel.Xk3f9a2b.css`):
+`/static/build` is served with `expires max` and these files aren't routed
+through `static_url()`'s `?v=` cache-buster, so an unhashed name would be cached
+by browsers forever across deploys. Vite rewrites the injected `<link>` URLs to
+match, so nothing else needs to know the hash.
+
 ### NEW: real-app bugs the browser caught
 Earlier verification served the build at the site *root*, which masked three
 issues that only show up at the real path `/static/build/js/`:

--- a/openlibrary/plugins/openlibrary/js/ol.analytics.js
+++ b/openlibrary/plugins/openlibrary/js/ol.analytics.js
@@ -76,8 +76,13 @@ export default function initAnalytics() {
     }
     window.vs = vs;
 
-    // NOTE: This might cause issues if this script is made async #4474
-    window.addEventListener('DOMContentLoaded', function send_analytics_pageview() {
+    // The bundle loads asynchronously, so DOMContentLoaded may already have fired (#4474)
+    function sendPageview() {
         window.archive_analytics.send_pageview({});
-    });
+    }
+    if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', sendPageview);
+    } else {
+        sendPageview();
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/service-worker-init.js
+++ b/openlibrary/plugins/openlibrary/js/service-worker-init.js
@@ -1,13 +1,19 @@
 export default function initServiceWorker(){
     if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
+        const register = () => {
             navigator.serviceWorker.register('/sw.js')
                 .then(() => { })
                 .catch(error => {
                     // eslint-disable-next-line no-console
                     console.error(`Service worker registration failed: ${error}`);
                 });
-        });
+        };
+        // The bundle loads asynchronously, so the load event may already have fired
+        if (document.readyState === 'complete') {
+            register();
+        } else {
+            window.addEventListener('load', register);
+        }
     }
 
     window.addEventListener('beforeinstallprompt', (e) => {

--- a/vite-js.config.mjs
+++ b/vite-js.config.mjs
@@ -59,7 +59,7 @@ export default defineConfig(({ mode }) => ({
                 postFooter: AGPL_LICENSE_FOOTER,
                 entryFileNames: '[name].js',
                 chunkFileNames: (info) => `${chunkName(info)}.[hash].js`,
-                assetFileNames: '[name][extname]',
+                assetFileNames: '[name].[hash][extname]',
             },
         },
     },


### PR DESCRIPTION
Follow-up to #13331 — targets `feat/vite-js-build-v2`, not master. Two small fixes for issues introduced by switching `all.js` to `<script type="module">` + dynamic `import()`.

### 1. readyState guards (analytics + service worker)

`initAnalytics()` and `initServiceWorker()` both register listeners for lifecycle events (`DOMContentLoaded`, `load`). Previously `all.js` ran synchronously at the end of `<body>`, so those listeners were always registered in time. Now the bundle arrives via an async `import()`, so `DOMContentLoaded` has already fired (and `load` often has, on light/cached pages) by the time these run — `addEventListener` doesn't replay past events, so the pageview ping never sends and SW registration is skipped. The old comment in `ol.analytics.js` predicted exactly this (#4474).

Fix: check `document.readyState` and run immediately if the event already happened, otherwise wait for it as before.

### 2. Hashed `assetFileNames`

Vite extracts the six JS-imported CSS files (`js-all.css`, `carousel--js.css`, `toast.css`, …) to real files under `/static/build/js/`, which nginx serves with `expires max`. They were emitted as `[name][extname]` (`carousel.css`), and they don't go through `static_url()`'s `?v=` cache-buster, so returning users' browsers would hold stale CSS forever across deploys. Under webpack this never came up because style-loader inlined the CSS into the content-hashed JS chunk.

Fix: `assetFileNames: '[name].[hash][extname]'` in `vite-js.config.mjs` (the IIFE builds emit no CSS). Vite rewrites the injected `<link>` URLs to match. Verified locally: `carousel.--3cROC-.css`, `js.BbvC2MFs.css`, etc. Added a short note in the progress doc.

Not touched here: the browser-floor / browserslist / `partnerLib` polyfill decision — that's a product call for the team rather than a code fix.

Checks: `npx jest tests/unit/js` (566 passed), `npx vite build -c vite-js.config.mjs` builds clean, pre-commit passes.

https://claude.ai/code/session_0181hgjqkv2tyxa8XJi3v78y
