### PR TITLE
fix: don't rewrite local-params fq (e.g. {!terms}) into editions query

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/tests/test_works.py
+++ b/openlibrary/plugins/worksearch/schemes/tests/test_works.py
@@ -149,18 +149,12 @@ def test_q_to_solr_params_edition_key(query, edQuery):
 
 
 def test_q_to_solr_params_local_params_fq_not_rewritten_for_editions():
-    """
-    A {!terms f=key}... fq (local-params syntax, used to filter to a specific
-    set of work keys) isn't a plain field:value facet filter, and shouldn't be
-    parsed as one when building the editions block-join subquery.
-    """
+    """A local-params fq (e.g. {!terms f=key}...) isn't a field:value facet filter and shouldn't be parsed as one for the editions subquery."""
     web.ctx.lang = "en"
     s = WorkSearchScheme()
 
     with patch("openlibrary.plugins.worksearch.schemes.works.convert_iso_to_marc") as mock_fn:
         mock_fn.return_value = "eng"
-        # Regression test: this used to raise
-        # ValueError: not enough values to unpack (expected 2, got 1)
         params = s.q_to_solr_params(
             "*:*",
             {"editions:[subquery]"},

--- a/openlibrary/plugins/worksearch/schemes/tests/test_works.py
+++ b/openlibrary/plugins/worksearch/schemes/tests/test_works.py
@@ -146,3 +146,25 @@ def test_q_to_solr_params_edition_key(query, edQuery):
     params_d = dict(params)
     assert params_d["userWorkQuery"] == query
     assert params_d["userEdQuery"] == edQuery
+
+
+def test_q_to_solr_params_local_params_fq_not_rewritten_for_editions():
+    """
+    A {!terms f=key}... fq (local-params syntax, used to filter to a specific
+    set of work keys) isn't a plain field:value facet filter, and shouldn't be
+    parsed as one when building the editions block-join subquery.
+    """
+    web.ctx.lang = "en"
+    s = WorkSearchScheme()
+
+    with patch("openlibrary.plugins.worksearch.schemes.works.convert_iso_to_marc") as mock_fn:
+        mock_fn.return_value = "eng"
+        # Regression test: this used to raise
+        # ValueError: not enough values to unpack (expected 2, got 1)
+        params = s.q_to_solr_params(
+            "*:*",
+            {"editions:[subquery]"},
+            [("fq", "{!terms f=key}/works/OL192489W")],
+        )
+    editions_fq_values = [v for k, v in params if k == "editions.fq"]
+    assert not any("OL192489W" in v for v in editions_fq_values)

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -498,9 +498,7 @@ class WorkSearchScheme(SearchScheme):
                 if param_name != "fq" or param_value.startswith("type:"):
                     continue
                 if param_value.startswith("{!"):
-                    # Solr local-params syntax (e.g. {!terms f=key}...) isn't a
-                    # plain field:value facet filter, so it can't be translated
-                    # to an equivalent edition-level filter below.
+                    # Local-params syntax (e.g. {!terms f=key}...) isn't a plain field:value pair.
                     continue
                 field_name, field_val = param_value.split(":", 1)
                 # facet_rewrites can produce negated fq values like

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -497,6 +497,11 @@ class WorkSearchScheme(SearchScheme):
             for param_name, param_value in cur_solr_params:
                 if param_name != "fq" or param_value.startswith("type:"):
                     continue
+                if param_value.startswith("{!"):
+                    # Solr local-params syntax (e.g. {!terms f=key}...) isn't a
+                    # plain field:value facet filter, so it can't be translated
+                    # to an equivalent edition-level filter below.
+                    continue
                 field_name, field_val = param_value.split(":", 1)
                 # facet_rewrites can produce negated fq values like
                 # '-ebook_access:public' (from public_scan=false). The leading


### PR DESCRIPTION
/series and /lists pages crashed with "not enough values to unpack" because the editions.fq rewriter in q_to_solr_params assumed every non-type: fq is a plain field:value facet filter and split it on ':'. The {!terms f=key}... filter added in get_solr_works_async's editions=True path uses Solr local-params syntax instead, which has no colon to split on.

Addendum to #12874

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
