### PR TITLE
Seed dev environment with full /languages/* records from prod

### DIFF
--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -21,7 +21,14 @@ latest_language_timestamp() {
 
 seed_languages() {
     echo "Waiting for web container..."
+    local wait_timeout=60
+    local waited=0
     until curl -sf -o /dev/null http://web:8080/; do
+        if [ "$waited" -ge "$wait_timeout" ]; then
+            echo "Warning: web container not reachable after ${wait_timeout}s - skipping /languages/* seed."
+            return
+        fi
+        waited=$((waited + 1))
         sleep 1
     done
 

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -13,6 +13,19 @@ else
 fi
 cd /openlibrary
 
+# Polls a URL every second until it responds successfully. Meant to be run under `timeout`.
+_poll_until_up() {
+    until curl -sf -o /dev/null "$1"; do
+        sleep 1
+    done
+}
+export -f _poll_until_up
+
+# Waits up to $2 seconds for $1 to respond successfully; returns non-zero on timeout.
+wait_for_url() {
+    timeout "$2" bash -c '_poll_until_up "$0"' "$1"
+}
+
 # Latest last_modified among /type/language docs on the given OL instance, or empty if unknown.
 latest_language_timestamp() {
     curl -sf "$1/query.json?type=/type/language&sort=-last_modified&limit=1&last_modified=" \
@@ -22,15 +35,10 @@ latest_language_timestamp() {
 seed_languages() {
     echo "Waiting for web container..."
     local wait_timeout=60
-    local waited=0
-    until curl -sf -o /dev/null http://web:8080/; do
-        if [ "$waited" -ge "$wait_timeout" ]; then
-            echo "Warning: web container not reachable after ${wait_timeout}s - skipping /languages/* seed."
-            return
-        fi
-        waited=$((waited + 1))
-        sleep 1
-    done
+    if ! wait_for_url http://web:8080/ "$wait_timeout"; then
+        echo "Warning: web container not reachable after ${wait_timeout}s - skipping /languages/* seed."
+        return
+    fi
 
     local_ts=$(latest_language_timestamp http://web:8080)
     remote_ts=$(latest_language_timestamp https://openlibrary.org)

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -15,7 +15,7 @@ cd /openlibrary
 
 # Latest last_modified among /type/language docs on the given OL instance, or empty if unknown.
 latest_language_timestamp() {
-    curl -sf "$1/query.json?type=/type/language&sort=-last_modified&limit=1" \
+    curl -sf "$1/query.json?type=/type/language&sort=-last_modified&limit=1&last_modified=" \
         | python -c "import json, sys; d = json.load(sys.stdin); print(d[0]['last_modified']['value'] if d else '')" 2>/dev/null
 }
 

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -14,3 +14,7 @@ fi
 cd /openlibrary
 
 make reindex-solr
+
+echo "Seeding /languages/* records from openlibrary.org..."
+python scripts/copydocs.py "/languages/*" --dest http://web:8080 \
+    || echo "Warning: failed to seed /languages/* from openlibrary.org (offline?) - continuing."

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -13,16 +13,32 @@ else
 fi
 cd /openlibrary
 
-(
+# Latest last_modified among /type/language docs on the given OL instance, or empty if unknown.
+latest_language_timestamp() {
+    curl -sf "$1/query.json?type=/type/language&sort=-last_modified&limit=1" \
+        | python -c "import json, sys; d = json.load(sys.stdin); print(d[0]['last_modified']['value'] if d else '')" 2>/dev/null
+}
+
+seed_languages() {
     echo "Waiting for web container..."
     until curl -sf -o /dev/null http://web:8080/; do
         sleep 1
     done
 
+    local_ts=$(latest_language_timestamp http://web:8080)
+    remote_ts=$(latest_language_timestamp https://openlibrary.org)
+
+    if [ -n "$local_ts" ] && [ -n "$remote_ts" ] && [[ ! "$local_ts" < "$remote_ts" ]]; then
+        echo "Local /languages/* already up to date with openlibrary.org - skipping seed."
+        return
+    fi
+
     echo "Seeding /languages/* records from openlibrary.org..."
     python scripts/copydocs.py "/languages/*" --dest http://web:8080 \
         || echo "Warning: failed to seed /languages/* from openlibrary.org (offline?) - continuing."
-) &
+}
+
+seed_languages &
 seed_languages_pid=$!
 
 make reindex-solr

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -15,6 +15,11 @@ cd /openlibrary
 
 make reindex-solr
 
+echo "Waiting for web container..."
+until curl -sf -o /dev/null http://web:8080/; do
+    sleep 1
+done
+
 echo "Seeding /languages/* records from openlibrary.org..."
 python scripts/copydocs.py "/languages/*" --dest http://web:8080 \
     || echo "Warning: failed to seed /languages/* from openlibrary.org (offline?) - continuing."

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -13,13 +13,18 @@ else
 fi
 cd /openlibrary
 
+(
+    echo "Waiting for web container..."
+    until curl -sf -o /dev/null http://web:8080/; do
+        sleep 1
+    done
+
+    echo "Seeding /languages/* records from openlibrary.org..."
+    python scripts/copydocs.py "/languages/*" --dest http://web:8080 \
+        || echo "Warning: failed to seed /languages/* from openlibrary.org (offline?) - continuing."
+) &
+seed_languages_pid=$!
+
 make reindex-solr
 
-echo "Waiting for web container..."
-until curl -sf -o /dev/null http://web:8080/; do
-    sleep 1
-done
-
-echo "Seeding /languages/* records from openlibrary.org..."
-python scripts/copydocs.py "/languages/*" --dest http://web:8080 \
-    || echo "Warning: failed to seed /languages/* from openlibrary.org (offline?) - continuing."
+wait "$seed_languages_pid"


### PR DESCRIPTION
Local dev's seeded language records are missing iso codes and translated names, which language-boosted search needs to rank non-English editions.

Small tweak while hitting issues testing #12966

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
