### PR TITLE
New PORT_PREFIX environment variable to allow easy multiple instances of local open library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,20 @@ repos:
     hooks:
       - id: check-toml
       - id: check-yaml
+        exclude: ^compose\.port-prefix\.yaml$
+      - id: check-yaml
+        name: check-yaml (compose.port-prefix.yaml)
+        # compose.port-prefix.yaml uses Compose's `!override` merge tag, which
+        # plain safe_load has no constructor for. --unsafe switches this file's
+        # check from full load (safe_load) to parse-only (syntax check via
+        # yaml.parse), so it still catches malformed YAML but no longer verifies
+        # that every tag is one of the safe, portable, constructible set -- e.g.
+        # it would not flag an errant `!!python/object/apply:...` tag the way
+        # the unscoped check-yaml above does for every other YAML file in the
+        # repo. check-yaml has no allow-list-one-tag option, only this
+        # all-or-nothing switch, so we scope it to just this file.
+        args: [--unsafe]
+        files: ^compose\.port-prefix\.yaml$
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: ^.*\.(po|pot|type|svg|ini|mr|mrc|pg_dump)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,17 +91,17 @@ cat /tmp/cookies.txt
 2. **Use the session cookie in subsequent requests:**
 ```bash
 # Just use -b to send the cookie automatically (no manual extraction needed)
-curl -X POST "http://localhost:18080/people/openlibrary/lists/OL1L/delete.json" -b /tmp/cookies.txt
-curl "http://localhost:18080/people/openlibrary/lists/OL1L.json" -b /tmp/cookies.txt
+curl -X POST "http://localhost:8081/people/openlibrary/lists/OL1L/delete.json" -b /tmp/cookies.txt
+curl "http://localhost:8081/people/openlibrary/lists/OL1L.json" -b /tmp/cookies.txt
 ```
 
-**Note:** Sessions expire — always login fresh before testing. Both web.py (port 8080) and FastAPI (port 18080) share the same auth system.
+**Note:** Sessions expire — always login fresh before testing. Both web.py (port 8080) and FastAPI (port 8081) share the same auth system.
 
 ### FastAPI and web.py Interaction
 
 Open Library runs two web servers in parallel:
 - **web.py** (port 8080) — **Legacy** (web.py / Infogami) — no new endpoints here, use FastAPI
-- **FastAPI** (port 18080) — New async endpoints via nginx proxy
+- **FastAPI** (port 8081) — New async endpoints via nginx proxy
 
 When testing:
 - Both servers share the same database

--- a/compose.port-prefix.yaml
+++ b/compose.port-prefix.yaml
@@ -2,7 +2,7 @@
 ## Helper docker compose file for running multiple OL dev instances on one machine
 ## without port collisions: prefixes every host port with ${PORT_PREFIX}, eg
 ## PORT_PREFIX=2 turns web's 8080 into 28080. You probably want to run something like:
-## PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up -d
+## PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port-prefix.yaml up -d
 ##
 
 services:

--- a/compose.port_prefix.yaml
+++ b/compose.port_prefix.yaml
@@ -1,32 +1,28 @@
-# Overlay for running multiple OpenLibrary dev instances on the same machine without
-# port collisions. Each host port becomes ${PORT_PREFIX} prepended to a fixed 4-digit
-# port, so eg PORT_PREFIX=2 turns the main web port 8080 into 28080 (localhost:28080).
-# Pick a different PORT_PREFIX per checkout (2, 3, 4, ...) to run several instances at once.
-#
-# Usage (compose.override.yaml must be listed explicitly once -f is used at all):
-#   PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up
-#
-# fast_web's normal default port (18080) doesn't fit the "prefix + 4 digits" scheme, so
-# it's remapped here to 8081 instead, alongside web's 8080.
+##
+## Helper docker compose file for running multiple Open Library dev instances on the
+## same machine without host port collisions. Each host port becomes ${PORT_PREFIX}
+## prepended to the service's normal port, eg with PORT_PREFIX=2 web's port 8080
+## becomes 28080 (visit http://localhost:28080). Pick a different PORT_PREFIX per
+## checkout (2, 3, 4, ...) to run several instances at once. You probably want to run
+## something like:
+## PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up -d
+##
+
 services:
   web:
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8080:8080"
       - "127.0.0.1:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}3000:3000"
-
   fast_web:
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8081:8080"
       - "127.0.0.1:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}3001:3000"
-
   solr:
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8983:8983"
-
   covers:
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}7075:7075"
-
   mockservices:
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8025:8025"

--- a/compose.port_prefix.yaml
+++ b/compose.port_prefix.yaml
@@ -1,0 +1,32 @@
+# Overlay for running multiple OpenLibrary dev instances on the same machine without
+# port collisions. Each host port becomes ${PORT_PREFIX} prepended to a fixed 4-digit
+# port, so eg PORT_PREFIX=2 turns the main web port 8080 into 28080 (localhost:28080).
+# Pick a different PORT_PREFIX per checkout (2, 3, 4, ...) to run several instances at once.
+#
+# Usage (compose.override.yaml must be listed explicitly once -f is used at all):
+#   PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up
+#
+# fast_web's normal default port (18080) doesn't fit the "prefix + 4 digits" scheme, so
+# it's remapped here to 8081 instead, alongside web's 8080.
+services:
+  web:
+    ports: !override
+      - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8080:8080"
+      - "127.0.0.1:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}3000:3000"
+
+  fast_web:
+    ports: !override
+      - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8081:8080"
+      - "127.0.0.1:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}3001:3000"
+
+  solr:
+    ports: !override
+      - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8983:8983"
+
+  covers:
+    ports: !override
+      - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}7075:7075"
+
+  mockservices:
+    ports: !override
+      - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8025:8025"

--- a/compose.port_prefix.yaml
+++ b/compose.port_prefix.yaml
@@ -1,15 +1,14 @@
 ##
-## Helper docker compose file for running multiple Open Library dev instances on the
-## same machine without host port collisions. Each host port becomes ${PORT_PREFIX}
-## prepended to the service's normal port, eg with PORT_PREFIX=2 web's port 8080
-## becomes 28080 (visit http://localhost:28080). Pick a different PORT_PREFIX per
-## checkout (2, 3, 4, ...) to run several instances at once. You probably want to run
-## something like:
+## Helper docker compose file for running multiple OL dev instances on one machine
+## without port collisions: prefixes every host port with ${PORT_PREFIX}, eg
+## PORT_PREFIX=2 turns web's 8080 into 28080. You probably want to run something like:
 ## PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up -d
 ##
 
 services:
   web:
+    environment:
+      - OL_COVERSTORE_PUBLIC_URL=http://localhost:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}7075
     ports: !override
       - "${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}8080:8080"
       - "127.0.0.1:${PORT_PREFIX:?Set PORT_PREFIX, e.g. PORT_PREFIX=2}3000:3000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --timeout 180 --max-requests 500}
     command: docker/ol-web-fastapi-start.sh
     ports:
-      - ${FAST_WEB_PORT:-18080}:8080
+      - ${FAST_WEB_PORT:-8081}:8080
     networks:
       - webnet
       - dbnet

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -8,7 +8,7 @@ Open Library (openlibrary.org) is an open, editable library catalog by the Inter
 
 ## Development Setup
 
-Run `make git` to initialize the Infogami submodule, then `docker compose up` and visit http://localhost:8080. The FastAPI server runs on port 18080.
+Run `make git` to initialize the Infogami submodule, then `docker compose up` and visit http://localhost:8080. The FastAPI server runs on port 8081.
 
 ## Build Commands
 
@@ -91,7 +91,7 @@ matches the app's configured `http_ext_header_uri`. The dev app sets this to
   `X-12-action: merge-authors`, `X-12-comment: ...`, `X-12-data: {...}`.
 - **Prefer FastAPI endpoints instead:** they share the session auth and need
   no custom headers — e.g. author merges via
-  `POST http://localhost:18080/authors/merge.json`.
+  `POST http://localhost:8081/authors/merge.json`.
 
 ### Scripts must log in via the JSON endpoint
 

--- a/docs/ai/solr/index.md
+++ b/docs/ai/solr/index.md
@@ -224,7 +224,7 @@ Notable dynamic field patterns:
 
 ## Search Endpoints
 
-All `*.json` endpoints are defined in `openlibrary/fastapi/search.py`, served by FastAPI (port 18080, proxied from 8080).
+All `*.json` endpoints are defined in `openlibrary/fastapi/search.py`, served by FastAPI (port 8081, proxied from 8080).
 
 | Endpoint | Handler | Purpose |
 |----------|---------|---------|

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -105,11 +105,11 @@ async def check_authentication(
 
     Example:
         # With valid session cookie
-        curl http://localhost:18080/account/test.json \\
+        curl http://localhost:8081/account/test.json \\
             -b "session=/people/openlibrary%2C2026-01-18T17%3A25%3A46%2C7897f%24841a3bd2f8e9a5ca46f505fa557d57bd"
 
         # Without cookie
-        curl http://localhost:18080/account/test.json
+        curl http://localhost:8081/account/test.json
     """
 
     cookie_name = config.get("login_cookie_name", "session")

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -1,6 +1,6 @@
 """Handler for deprecated web.py endpoints.
 
-Redirects deprecated endpoints to port 18080 in dev environment,
+Redirects deprecated endpoints to the FastAPI container in dev environment,
 or raises a loud error in production.
 This is temporary while we migrate to fastapi and have two containers running.
 """

--- a/tests/integration/test_fastapi_auth.py
+++ b/tests/integration/test_fastapi_auth.py
@@ -9,7 +9,7 @@
 """Integration tests for FastAPI authentication endpoints.
 
 These tests are marked as "integration" and are skipped by default.
-They require a running FastAPI server on localhost:18080.
+They require a running FastAPI server on localhost:8081.
 
 Run explicitly with:
     uv run pytest -m integration tests/integration/test_fastapi_auth.py -v
@@ -18,7 +18,7 @@ Run explicitly with:
 import pytest
 import requests
 
-BASE_URL = "http://localhost:18080"
+BASE_URL = "http://localhost:8081"
 USERNAME = "openlibrary@example.com"
 PASSWORD = "admin123"
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -13,9 +13,7 @@ class _PortPrefixLoader(yaml.SafeLoader):
     which plain yaml.safe_load doesn't know how to construct."""
 
 
-_PortPrefixLoader.add_constructor(
-    "!override", lambda loader, node: loader.construct_sequence(node)
-)
+_PortPrefixLoader.add_constructor("!override", lambda loader, node: loader.construct_sequence(node))
 
 
 class TestDockerCompose:
@@ -58,12 +56,7 @@ class TestDockerCompose:
         with open(p("..", "compose.port-prefix.yaml")) as f:
             port_prefix_dc: dict = yaml.load(f, Loader=_PortPrefixLoader)
 
-        ported_services = {
-            serv
-            for dc in (root_dc, override_dc)
-            for serv, opts in dc["services"].items()
-            if opts.get("ports")
-        }
+        ported_services = {serv for dc in (root_dc, override_dc) for serv, opts in dc["services"].items() if opts.get("ports")}
         port_prefix_services = set(port_prefix_dc["services"])
         missing = ported_services - port_prefix_services
         assert missing == set(), "compose.port-prefix.yaml missing services with ports"

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -13,7 +13,12 @@ class _PortPrefixLoader(yaml.SafeLoader):
     which plain yaml.safe_load doesn't know how to construct."""
 
 
-_PortPrefixLoader.add_constructor("!override", lambda loader, node: loader.construct_sequence(node))
+def _construct_override(loader: yaml.SafeLoader, node: yaml.Node) -> list:
+    assert isinstance(node, yaml.SequenceNode)
+    return loader.construct_sequence(node)
+
+
+_PortPrefixLoader.add_constructor("!override", _construct_override)
 
 
 class TestDockerCompose:

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -8,6 +8,16 @@ def p(*paths):
     return os.path.join(os.path.dirname(__file__), *paths)
 
 
+class _PortPrefixLoader(yaml.SafeLoader):
+    """compose.port-prefix.yaml uses the compose-spec `!override` merge tag,
+    which plain yaml.safe_load doesn't know how to construct."""
+
+
+_PortPrefixLoader.add_constructor(
+    "!override", lambda loader, node: loader.construct_sequence(node)
+)
+
+
 class TestDockerCompose:
     def test_all_root_services_must_be_in_prod(self):
         """
@@ -34,3 +44,26 @@ class TestDockerCompose:
             prod_dc: dict = yaml.safe_load(f)
         for serv, opts in prod_dc["services"].items():
             assert "profiles" in opts, f"{serv} is missing 'profiles' field"
+
+    def test_all_ported_services_are_in_port_prefix(self):
+        """
+        Each service in compose.yaml/compose.override.yaml that publishes a port
+        should also appear in compose.port-prefix.yaml, so it gets a collision-free
+        port when running multiple instances side by side.
+        """
+        with open(p("..", "compose.yaml")) as f:
+            root_dc: dict = yaml.safe_load(f)
+        with open(p("..", "compose.override.yaml")) as f:
+            override_dc: dict = yaml.safe_load(f)
+        with open(p("..", "compose.port-prefix.yaml")) as f:
+            port_prefix_dc: dict = yaml.load(f, Loader=_PortPrefixLoader)
+
+        ported_services = {
+            serv
+            for dc in (root_dc, override_dc)
+            for serv, opts in dc["services"].items()
+            if opts.get("ports")
+        }
+        port_prefix_services = set(port_prefix_dc["services"])
+        missing = ported_services - port_prefix_services
+        assert missing == set(), "compose.port-prefix.yaml missing services with ports"


### PR DESCRIPTION
With AI, I've been finding the need to run multiple instances of the full docker compose stack, and keep hitting port conflicts. This flow creates a new compose file for overriding the ports by exposing a PORT_PREFIX parameter. This means to spin up a fresh copy of all of open library, all you need to run is:

```sh
cd my-worktree-2
PORT_PREFIX=2 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up -d
```

And you'll have openlibrary running at http://localhost:28080 .

Want more?


```sh
cd my-worktree-3
PORT_PREFIX=3 docker compose -f compose.yaml -f compose.override.yaml -f compose.port_prefix.yaml up -d
```

Up at http://localhost:38080 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
