### PR TITLE
Add static-analysis test for unused templates and macros

### DIFF
--- a/openlibrary/tests/test_unused_templates.py
+++ b/openlibrary/tests/test_unused_templates.py
@@ -1,20 +1,10 @@
 """Fail on templates and macros that no code references.
 
-This is the pytest wrapper around ``openlibrary/utils/template_usage.py``,
-which inventories every Templetor template (``openlibrary/templates/**/*.html``),
-Templetor macro (``openlibrary/macros/*.html``), Jinja template
-(``*.html.jinja``), and Jinja ``{% macro %}`` definition, then searches every
-git-tracked source file for references.  Templates only reachable through
-runtime name construction (``templates/type/``, ``recentchanges/``,
-``book_providers/``, ``design/``) are documented in the analyzer's
-``DYNAMIC_DISPATCH_RULES`` and never flagged.
-
-The main test fails and lists every unused template/macro.  Fix it by
-deleting the template, or -- if it is used only from database content -- by
-adding it to ``DB_USED_EXCLUSIONS`` below with a justification.
+Wraps openlibrary/utils/template_usage.py (see its docstring for the matching
+rules and DYNAMIC_DISPATCH_RULES).  Fix a failure by deleting the template,
+or -- if it is used only from database content -- by adding it to
+DB_USED_EXCLUSIONS with a one-line justification.
 """
-
-from collections import Counter
 
 import pytest
 
@@ -28,57 +18,24 @@ from openlibrary.utils.template_usage import (
     analyze,
 )
 
-# Templates/macros that are used only from *database* content: wiki-stored
-# templates (/upstream/templates/*), wiki-stored macros (/upstream/macros/*),
-# or {{Macro(...)}} markdown in any page body.  None of these are visible to
-# static analysis.
-#
-# To check a candidate, search the "other" dump -- it contains every dump
-# document that is not an edition/work/author/redirect/delete/list, i.e. all
-# wiki templates, macros, and page bodies:
-#
+# Templates/macros used only from *database* content (wiki templates/macros,
+# or {{Macro(...)}} in page bodies) -- invisible to static analysis.  Verify
+# candidates against the "other" dump:
 #   curl -sO https://openlibrary.org/data/ol_dump_other_latest.txt.gz
 #   zcat ol_dump_other_latest.txt.gz | grep -F 'TheName'
-#
-# Interpreting what you find (verified 2026-08-17): production renders the
-# repo's file templates -- db copies under /upstream/templates/ and
-# /templates/ are generally stale shadows, and a reference *from* such a db
-# template (e.g. $:macros.RecentChangesUsers in /upstream/templates/type/
-# user/view.tmpl) does NOT count unless you can confirm the macro's output on
-# a live page.  What does count is invocation from db page content: markdown
-# like {{ListCarousel("...")}} in a /type/page doc that renders publicly.
-#
-# ONLY add an entry if you are totally confident it is used on the frontend
-# but not visible in the code base.  Otherwise do NOT add it -- leaving it
-# out just keeps the test failing, which is the safe failure mode.  Stale
-# entries (renamed/deleted templates, or ones that later become referenced in
-# code) fail test_exclusion_lists_are_not_stale.
+# Only db-page invocations that render publicly count; db copies under
+# /upstream/* are stale shadows.  When in doubt leave it out -- a missing
+# entry just keeps the test failing (safe).  Stale entries fail the staleness
+# test below.
 DB_USED_EXCLUSIONS: dict[str, str] = {
-    "ListCarousel": (
-        'invoked via {{ListCarousel("/people/digital_s/lists/OL238301L", ...)}} '
-        "markdown in live /type/page docs under /collections/the_haunted_library/*; "
-        "verified rendering on production (carousel markup with that list ID "
-        "present in the page HTML)"
-    ),
-    "SubjectSearch": (
-        "created (f7b9ae436, 2026-08-03) to be embedded as {{SubjectSearch()}} "
-        "in the /subjects wiki pages (/type/i18n_page docs stored in the "
-        "production db); verified rendering live on production /subjects "
-        "(form with id=searchSubjects). Note: the July dump predates the "
-        "macro, so dump greps miss this one"
-    ),
+    "ListCarousel": "{{ListCarousel(...)}} markdown in live /collections/* db pages (verified on prod)",
+    "SubjectSearch": "{{SubjectSearch()}} in db-stored /subjects wiki pages (f7b9ae436)",
 }
 
-# Exclusions that are NOT db-usage: the maintainer has reason to believe the
-# template is used even though static analysis and the db dump both come up
-# empty.  Each entry needs a justification and should be revisited.
+# Maintainer-verified without evidence; revisit periodically.
 MANUAL_EXCLUSIONS: dict[str, str] = {
-    "CodeBlock.html.jinja": (
-        "maintainer believes this is used on the frontend (2026-08-17); no "
-        "code, db, or design-registry reference found -- added per "
-        "maintainer's call, drop this entry if that turns out to be wrong"
-    ),
-    "code_block": ("the {% macro %} inside CodeBlock.html.jinja; excluded together with its file -- see that entry"),
+    "CodeBlock.html.jinja": "believed live on frontend (2026-08-17)",
+    "code_block": "the {% macro %} inside CodeBlock.html.jinja; excluded with its file",
 }
 
 ALL_EXCLUSIONS = {**DB_USED_EXCLUSIONS, **MANUAL_EXCLUSIONS}
@@ -91,12 +48,7 @@ def analysis() -> Analysis:
 
 def test_inventory_is_not_vacuous(analysis: Analysis):
     """Guard against silently broken discovery (moved roots, renamed globs)
-    that would make test_no_unused_templates_and_macros vacuously pass.
-
-    Every kind the analyzer can inventory must be present, and every
-    dynamic-dispatch rule must still match real files on disk.  Unlike count
-    floors, this survives any amount of legitimate template deletion.
-    """
+    that would make the main test vacuously pass."""
     kinds = {t.kind for t in analysis.templates}
     assert kinds == {KIND_TEMPLETOR_TEMPLATE, KIND_TEMPLETOR_MACRO, KIND_JINJA_TEMPLATE, KIND_JINJA_MACRO}, kinds
     for rule_dir in DYNAMIC_DISPATCH_RULES:
@@ -106,18 +58,15 @@ def test_inventory_is_not_vacuous(analysis: Analysis):
 
 
 def test_no_unused_templates_and_macros(analysis: Analysis):
-    counts = Counter(t.kind for t in analysis.templates)
-    assert sum(counts.values()) > 0, counts
-
     if not analysis.unused:
         return
     listing = "\n".join(f"  {t.kind}: {t.relpath}" for t in analysis.unused)
     pytest.fail(
         f"{len(analysis.unused)} templates/macros are not referenced in any Python, "
         "Templetor, Jinja, or JS source. For each one: verify against the "
-        "'other' dump as described in DB_USED_EXCLUSIONS and add it there with "
-        "a justification if (and only if) it is used from database content; "
-        f"otherwise delete it:\n{listing}"
+        "'other' dump and add it to DB_USED_EXCLUSIONS with a justification "
+        "if (and only if) it is used from database content; otherwise delete "
+        f"it:\n{listing}"
     )
 
 
@@ -126,7 +75,7 @@ def test_exclusion_lists_are_not_stale(analysis: Analysis):
         f"exclusion entries (DB_USED_EXCLUSIONS/MANUAL_EXCLUSIONS) matching no template/macro on disk (remove them): {sorted(analysis.missing_exclusions)}"
     )
     assert not analysis.used_exclusions, (
-        "exclusion entries (DB_USED_EXCLUSIONS/MANUAL_EXCLUSIONS) that are actually referenced in code "
+        "exclusion entries (DB_USED_EXCLUSIONS/MANUAL_EXCLUSIONS) that are referenced in code "
         "(remove them -- the exclusion hides real usage):\n"
         + "\n".join(f"  {name}: referenced in {evidence}" for name, evidence in sorted(analysis.used_exclusions.items()))
     )

--- a/openlibrary/tests/test_unused_templates.py
+++ b/openlibrary/tests/test_unused_templates.py
@@ -1,0 +1,108 @@
+"""Fail on templates and macros that no code references.
+
+This is the pytest wrapper around ``openlibrary/utils/template_usage.py``,
+which inventories every Templetor template (``openlibrary/templates/**/*.html``),
+Templetor macro (``openlibrary/macros/*.html``), Jinja template
+(``*.html.jinja``), and Jinja ``{% macro %}`` definition, then searches the
+whole code base for references.  Templates only reachable through runtime
+name construction (``templates/type/``, ``recentchanges/``,
+``book_providers/``, ``design/``) are documented in the analyzer's
+``DYNAMIC_DISPATCH_RULES`` and never flagged.
+
+The main test fails and lists every unused template/macro.  Fix it by
+deleting the template, or -- if it is used only from database content -- by
+adding it to ``DB_USED_EXCLUSIONS`` below with a justification.
+"""
+
+from collections import Counter
+
+import pytest
+
+from openlibrary.utils.template_usage import Analysis, analyze
+
+# Templates/macros that are used only from *database* content: wiki-stored
+# templates (/upstream/templates/*), wiki-stored macros (/upstream/macros/*),
+# or {{Macro(...)}} markdown in any page body.  None of these are visible to
+# static analysis.
+#
+# To check a candidate, search the "other" dump -- it contains every dump
+# document that is not an edition/work/author/redirect/delete/list, i.e. all
+# wiki templates, macros, and page bodies:
+#
+#   curl -sO https://openlibrary.org/data/ol_dump_other_latest.txt.gz
+#   zcat ol_dump_other_latest.txt.gz | grep -F 'TheName'
+#
+# Interpreting what you find (verified 2026-08-17): production renders the
+# repo's file templates -- db copies under /upstream/templates/ and
+# /templates/ are generally stale shadows, and a reference *from* such a db
+# template (e.g. $:macros.RecentChangesUsers in /upstream/templates/type/
+# user/view.tmpl) does NOT count unless you can confirm the macro's output on
+# a live page.  What does count is invocation from db page content: markdown
+# like {{ListCarousel("...")}} in a /type/page doc that renders publicly.
+#
+# ONLY add an entry if you are totally confident it is used on the frontend
+# but not visible in the code base.  Otherwise do NOT add it -- leaving it
+# out just keeps the test failing, which is the safe failure mode.  Stale
+# entries (renamed/deleted templates, or ones that later become referenced in
+# code) fail test_exclusion_list_is_not_stale.
+DB_USED_EXCLUSIONS: dict[str, str] = {
+    "ListCarousel": (
+        'invoked via {{ListCarousel("/people/digital_s/lists/OL238301L", ...)}} '
+        "markdown in live /type/page docs under /collections/the_haunted_library/*; "
+        "verified rendering on production (carousel markup with that list ID "
+        "present in the page HTML)"
+    ),
+    "SubjectSearch": (
+        "created (f7b9ae436, 2026-08-03) to be embedded as {{SubjectSearch()}} "
+        "in the /subjects wiki pages (/type/i18n_page docs stored in the "
+        "production db); verified rendering live on production /subjects "
+        "(form with id=searchSubjects). Note: the July dump predates the "
+        "macro, so dump greps miss this one"
+    ),
+}
+
+# Exclusions that are NOT db-usage: the maintainer has reason to believe the
+# template is used even though static analysis and the db dump both come up
+# empty.  Each entry needs a justification and should be revisited.
+MANUAL_EXCLUSIONS: dict[str, str] = {
+    "CodeBlock.html.jinja": (
+        "maintainer believes this is used on the frontend (2026-08-17); no "
+        "code, db, or design-registry reference found -- added per "
+        "maintainer's call, drop this entry if that turns out to be wrong"
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def analysis() -> Analysis:
+    return analyze({**DB_USED_EXCLUSIONS, **MANUAL_EXCLUSIONS})
+
+
+def test_no_unused_templates_and_macros(analysis: Analysis):
+    # Guard against a silently broken inventory (moved directories, renamed
+    # roots) that would make this test vacuously pass with an empty list.
+    counts = Counter(t.kind for t in analysis.templates)
+    assert counts["templetor template"] > 280, counts
+    assert counts["templetor macro"] > 75, counts
+    assert counts["jinja template"] >= 25, counts
+    assert counts["jinja macro"] >= 40, counts
+
+    if not analysis.unused:
+        return
+    listing = "\n".join(f"  {t.kind}: {t.relpath}" for t in analysis.unused)
+    pytest.fail(
+        f"{len(analysis.unused)} templates/macros are not referenced in any Python, "
+        "Templetor, Jinja, or JS source. For each one: verify against the "
+        "'other' dump as described in DB_USED_EXCLUSIONS and add it there with "
+        "a justification if (and only if) it is used from database content; "
+        f"otherwise delete it:\n{listing}"
+    )
+
+
+def test_exclusion_list_is_not_stale(analysis: Analysis):
+    assert not analysis.missing_exclusions, f"DB_USED_EXCLUSIONS entries matching no template/macro on disk (remove them): {sorted(analysis.missing_exclusions)}"
+    assert not analysis.used_exclusions, (
+        "DB_USED_EXCLUSIONS entries that are actually referenced in code "
+        "(remove them -- the exclusion hides real usage):\n"
+        + "\n".join(f"  {name}: referenced in {evidence}" for name, evidence in sorted(analysis.used_exclusions.items()))
+    )

--- a/openlibrary/tests/test_unused_templates.py
+++ b/openlibrary/tests/test_unused_templates.py
@@ -3,9 +3,9 @@
 This is the pytest wrapper around ``openlibrary/utils/template_usage.py``,
 which inventories every Templetor template (``openlibrary/templates/**/*.html``),
 Templetor macro (``openlibrary/macros/*.html``), Jinja template
-(``*.html.jinja``), and Jinja ``{% macro %}`` definition, then searches the
-whole code base for references.  Templates only reachable through runtime
-name construction (``templates/type/``, ``recentchanges/``,
+(``*.html.jinja``), and Jinja ``{% macro %}`` definition, then searches every
+git-tracked source file for references.  Templates only reachable through
+runtime name construction (``templates/type/``, ``recentchanges/``,
 ``book_providers/``, ``design/``) are documented in the analyzer's
 ``DYNAMIC_DISPATCH_RULES`` and never flagged.
 
@@ -18,7 +18,15 @@ from collections import Counter
 
 import pytest
 
-from openlibrary.utils.template_usage import Analysis, analyze
+from openlibrary.utils.template_usage import (
+    DYNAMIC_DISPATCH_RULES,
+    KIND_JINJA_MACRO,
+    KIND_JINJA_TEMPLATE,
+    KIND_TEMPLETOR_MACRO,
+    KIND_TEMPLETOR_TEMPLATE,
+    Analysis,
+    analyze,
+)
 
 # Templates/macros that are used only from *database* content: wiki-stored
 # templates (/upstream/templates/*), wiki-stored macros (/upstream/macros/*),
@@ -44,7 +52,7 @@ from openlibrary.utils.template_usage import Analysis, analyze
 # but not visible in the code base.  Otherwise do NOT add it -- leaving it
 # out just keeps the test failing, which is the safe failure mode.  Stale
 # entries (renamed/deleted templates, or ones that later become referenced in
-# code) fail test_exclusion_list_is_not_stale.
+# code) fail test_exclusion_lists_are_not_stale.
 DB_USED_EXCLUSIONS: dict[str, str] = {
     "ListCarousel": (
         'invoked via {{ListCarousel("/people/digital_s/lists/OL238301L", ...)}} '
@@ -70,22 +78,36 @@ MANUAL_EXCLUSIONS: dict[str, str] = {
         "code, db, or design-registry reference found -- added per "
         "maintainer's call, drop this entry if that turns out to be wrong"
     ),
+    "code_block": ("the {% macro %} inside CodeBlock.html.jinja; excluded together with its file -- see that entry"),
 }
+
+ALL_EXCLUSIONS = {**DB_USED_EXCLUSIONS, **MANUAL_EXCLUSIONS}
 
 
 @pytest.fixture(scope="module")
 def analysis() -> Analysis:
-    return analyze({**DB_USED_EXCLUSIONS, **MANUAL_EXCLUSIONS})
+    return analyze(ALL_EXCLUSIONS)
+
+
+def test_inventory_is_not_vacuous(analysis: Analysis):
+    """Guard against silently broken discovery (moved roots, renamed globs)
+    that would make test_no_unused_templates_and_macros vacuously pass.
+
+    Every kind the analyzer can inventory must be present, and every
+    dynamic-dispatch rule must still match real files on disk.  Unlike count
+    floors, this survives any amount of legitimate template deletion.
+    """
+    kinds = {t.kind for t in analysis.templates}
+    assert kinds == {KIND_TEMPLETOR_TEMPLATE, KIND_TEMPLETOR_MACRO, KIND_JINJA_TEMPLATE, KIND_JINJA_MACRO}, kinds
+    for rule_dir in DYNAMIC_DISPATCH_RULES:
+        assert any(t.rel_to_root.startswith(rule_dir) for t in analysis.templates), (
+            f"dynamic-dispatch rule {rule_dir!r} matches no template on disk (stale rule -- update or remove it)"
+        )
 
 
 def test_no_unused_templates_and_macros(analysis: Analysis):
-    # Guard against a silently broken inventory (moved directories, renamed
-    # roots) that would make this test vacuously pass with an empty list.
     counts = Counter(t.kind for t in analysis.templates)
-    assert counts["templetor template"] > 280, counts
-    assert counts["templetor macro"] > 75, counts
-    assert counts["jinja template"] >= 25, counts
-    assert counts["jinja macro"] >= 40, counts
+    assert sum(counts.values()) > 0, counts
 
     if not analysis.unused:
         return
@@ -99,10 +121,12 @@ def test_no_unused_templates_and_macros(analysis: Analysis):
     )
 
 
-def test_exclusion_list_is_not_stale(analysis: Analysis):
-    assert not analysis.missing_exclusions, f"DB_USED_EXCLUSIONS entries matching no template/macro on disk (remove them): {sorted(analysis.missing_exclusions)}"
+def test_exclusion_lists_are_not_stale(analysis: Analysis):
+    assert not analysis.missing_exclusions, (
+        f"exclusion entries (DB_USED_EXCLUSIONS/MANUAL_EXCLUSIONS) matching no template/macro on disk (remove them): {sorted(analysis.missing_exclusions)}"
+    )
     assert not analysis.used_exclusions, (
-        "DB_USED_EXCLUSIONS entries that are actually referenced in code "
+        "exclusion entries (DB_USED_EXCLUSIONS/MANUAL_EXCLUSIONS) that are actually referenced in code "
         "(remove them -- the exclusion hides real usage):\n"
         + "\n".join(f"  {name}: referenced in {evidence}" for name, evidence in sorted(analysis.used_exclusions.items()))
     )

--- a/openlibrary/utils/template_usage.py
+++ b/openlibrary/utils/template_usage.py
@@ -1,35 +1,16 @@
-"""Static analysis to find templates and macros that are never referenced.
+"""Find templates and macros that are never referenced.
 
-Open Library renders pages with two template systems side by side:
+Two template systems coexist:
+* Templetor (Infogami): ``.html`` files under ``openlibrary/templates/`` and
+  ``openlibrary/macros/``, referenced by root-relative name
+  (``render_template("account/mybooks")``) or bare macro name (``CoverImage``).
+* Jinja: ``*.html.jinja`` files by full path; ``{% macro %}`` defs are matched
+  by call/import sites.
 
-* Templetor (web.py/Infogami) -- ``openlibrary/templates/**/*.html`` page
-  templates (referenced as ``"account/mybooks"``) and
-  ``openlibrary/macros/*.html`` macros (referenced by bare file stem, e.g.
-  ``CoverImage``).
-* Jinja -- ``*.html.jinja`` files in both roots, referenced by their full path
-  relative to the Jinja loader roots (``openlibrary/macros`` then
-  ``openlibrary/templates``), e.g. ``"design/layout.html.jinja"``.
-
-This module inventories every template/macro file plus every Jinja
-``{% macro %}`` definition, then searches every git-tracked source file
-(Python, Templetor, Jinja, JS/TS/Vue, config) for references.  Anything with
-no reference is reported as unused.
-
-The analysis is deliberately conservative: it prefers to miss an unused
-template over flagging one that is actually used, because a false positive
-fails the build and invites deleting a template that is still live.
-References that cannot be seen statically are handled in two ways:
-
-* ``DYNAMIC_DISPATCH_RULES`` documents directories whose templates are
-  resolved at runtime by name construction (DB type keys, changeset kinds,
-  provider registries, design-system section ids) -- those are always
-  considered used, and so are the Jinja macros defined inside them (they are
-  imported under dynamic aliases such as ``page.nav()``).
-* Templates/macros that are used only from *database* content (wiki-stored
-  templates under ``/upstream/templates/*``, wiki-stored macros, or
-  ``{{Macro(...)}}`` markdown in any page body) are invisible to static
-  analysis.  The pytest wrapper keeps an explicit exclusion list for those;
-  see ``openlibrary/tests/test_unused_templates.py``.
+Every git-tracked source file is scanned; anything unreferenced is reported.
+The analysis errs conservative (a missed unused template beats a false
+positive).  Runtime name construction is covered by DYNAMIC_DISPATCH_RULES;
+database-only usage by the exclusion lists in the test file.
 """
 
 from __future__ import annotations
@@ -51,16 +32,13 @@ KIND_TEMPLETOR_MACRO = "templetor macro"
 KIND_JINJA_TEMPLATE = "jinja template"
 KIND_JINJA_MACRO = "jinja macro"
 
-# File types that may contain template references (Python code, both template
-# systems' files, front-end sources, and config).  Docs (*.md) are excluded:
-# a template mentioned in documentation is not used by it.  Test files are
-# included on purpose -- a template rendered only from a test is still alive.
+# Source files that may contain references.  Docs (*.md) are excluded (a
+# template mentioned in docs is not used by it); test files are included (a
+# template rendered only from a test is still alive).
 CORPUS_SUFFIXES = frozenset({".py", ".js", ".ts", ".tsx", ".vue", ".html", ".jinja", ".yml", ".yaml", ".json"})
 
-# Files never scanned for references.  This module and its test mention
-# template names verbatim (exclusion lists, rule tables), and package-lock.json
-# is generated noise whose dependency names could rescue a template by
-# coincidence.
+# Never scanned: this module and its test mention template names verbatim, and
+# package-lock.json dependency names could rescue a template by coincidence.
 CORPUS_SKIP_FILES = frozenset(
     {
         "openlibrary/utils/template_usage.py",
@@ -69,29 +47,13 @@ CORPUS_SKIP_FILES = frozenset(
     }
 )
 
-# Directories under openlibrary/templates/ whose files are never referenced by
-# a literal name: the runtime builds their names dynamically.  Mapped to the
-# code that does the dispatch, so the rule can be checked and updated.
+# Directories resolved by runtime name construction, never literal call sites.
+# Each rule cites the dispatching code so it can be audited.
 DYNAMIC_DISPATCH_RULES: dict[str, str] = {
-    "type/": (
-        "selected by infogami's typetemplate() as "
-        "render[<db type key> + '/' + name] -- the type keys live in the "
-        "database, not the code (infogami/utils/template.py)"
-    ),
-    "recentchanges/": (
-        "selected from DB changeset kinds via get_template('recentchanges/' + "
-        "kind + '/...') with recentchanges/default/... fallback "
-        "(openlibrary/plugins/upstream/recentchanges.py, "
-        "openlibrary/plugins/upstream/utils.py, "
-        "templates/recentchanges/render.html)"
-    ),
-    "book_providers/": ("filename constructed as f'book_providers/{short_name}_{typ}.html' from the provider registry (openlibrary/book_providers.py)"),
-    "design/": (
-        "imported dynamically by Jinja as 'design/' + section.id + "
-        "'.html.jinja' and via the component registry component.partial "
-        "(templates/design/layout.html.jinja, "
-        "openlibrary/plugins/openlibrary/design.py)"
-    ),
+    "type/": "infogami typetemplate(), keys from DB (infogami/utils/template.py)",
+    "recentchanges/": "changeset kinds (plugins/upstream/recentchanges.py)",
+    "book_providers/": "provider registry (openlibrary/book_providers.py)",
+    "design/": "Jinja dynamic imports + component registry (plugins/openlibrary/design.py)",
 }
 
 JINJA_MACRO_DEF_RE = re.compile(r"{%-?\s*macro\s+(\w+)\s*\(")
@@ -99,7 +61,7 @@ JINJA_MACRO_DEF_RE = re.compile(r"{%-?\s*macro\s+(\w+)\s*\(")
 
 @dataclass(frozen=True)
 class Template:
-    """A template/macros file, or a single {% macro %} definition in one."""
+    """A template file, or a single ``{% macro %}`` definition in one."""
 
     name: str
     path: Path
@@ -112,61 +74,48 @@ class Template:
     @property
     def rel_to_root(self) -> str:
         """Path relative to its template root (macros/ or templates/)."""
-        for root in TEMPLATE_ROOTS:
-            if self.path.is_relative_to(root):
-                return self.path.relative_to(root).as_posix()
-        return self.relpath
+        return next(self.path.relative_to(root).as_posix() for root in TEMPLATE_ROOTS if self.path.is_relative_to(root))
 
 
 @dataclass
 class Analysis:
-    """Result of the unused-template scan."""
+    """Result of the unused-template scan, plus the exclusion audit."""
 
     templates: list[Template]
     unused: list[Template]
-    # Exclusion-list entries that are actually referenced in code (so the
-    # entry hides real usage and must be removed), mapped to the evidence.
+    # Exclusion entries referenced in code (the entry hides real usage and
+    # must be removed), mapped to the evidence.
     used_exclusions: dict[str, str]
-    # Exclusion-list entries with no matching template/macro on disk.
+    # Exclusion entries matching no template/macro on disk.
     missing_exclusions: set[str]
 
 
-def iter_template_files() -> list[Template]:
-    templates = []
+def build_inventory() -> list[Template]:
+    """Every template file plus each ``{% macro %}`` definition under the roots."""
+    templates: list[Template] = []
     for root in TEMPLATE_ROOTS:
         is_macros_root = root.name == "macros"
         for path in sorted(root.rglob("*.html")):
-            # Templetor resolves names with any extension stripped, so the
-            # canonical name is the path relative to the root minus ".html".
-            name = path.relative_to(root).as_posix()[: -len(".html")]
+            # Templetor resolves names with any extension stripped: the
+            # canonical name is the root-relative path minus ".html".
+            name = path.relative_to(root).as_posix().removesuffix(".html")
             kind = KIND_TEMPLETOR_MACRO if is_macros_root else KIND_TEMPLETOR_TEMPLATE
             templates.append(Template(name, path, kind))
         for path in sorted(root.rglob("*.html.jinja")):
-            # Jinja resolves the full path relative to its loader roots.
-            name = path.relative_to(root).as_posix()
-            templates.append(Template(name, path, KIND_JINJA_TEMPLATE))
-    return templates
-
-
-def build_inventory() -> list[Template]:
-    templates = iter_template_files()
-    for t in templates:
+            # Jinja resolves the full root-relative path.
+            templates.append(Template(path.relative_to(root).as_posix(), path, KIND_JINJA_TEMPLATE))
+    for t in list(templates):  # snapshot: jinja macros are appended below
         if t.kind != KIND_JINJA_TEMPLATE:
             continue
-        text = t.path.read_text(encoding="utf-8", errors="replace")
-        for match in JINJA_MACRO_DEF_RE.finditer(text):
+        for match in JINJA_MACRO_DEF_RE.finditer(t.path.read_text(encoding="utf-8", errors="replace")):
             templates.append(Template(match.group(1), t.path, KIND_JINJA_MACRO))
     return sorted(set(templates), key=lambda t: (t.kind, t.relpath, t.name))
 
 
 def build_corpus() -> dict[str, str]:
-    """Read every git-tracked source file that may contain references.
-
-    Only tracked files are scanned, so the result is hermetic: untracked
-    scratch files, local config overrides, and nested checkouts cannot make
-    the verdict differ between machines or CI.  ``--recurse-submodules`` is
-    load-bearing -- references like ``render.viewpage`` live in the
-    ``vendor/infogami`` submodule (initialize it with ``make git``).
+    """Read every git-tracked source file (hermetic: untracked scratch files
+    can't change the verdict).  ``--recurse-submodules`` is load-bearing --
+    references like ``render.viewpage`` live in vendor/infogami (make git).
     """
     files = (
         subprocess.run(
@@ -201,45 +150,33 @@ RENDER_ATTR_RE = re.compile(r"\brender\.(\w+)")
 
 @dataclass(frozen=True)
 class FileIndex:
-    """Pre-extracted references from one corpus file.
+    """Pre-extracted references from one corpus file, for O(1) usage checks."""
 
-    Scanning every file with a regex per template name is O(names x files x
-    file size); extracting these sets once per file turns each usage check
-    into O(1) set lookups.
-    """
-
-    # String literals (pair-matched quotes, nested other-type quotes one
-    # level deep), each also stored with its last extension stripped:
-    # render_template()/get_template() strip extensions at resolve time, so
-    # "site/head.tmpl" and "lists/feed_updates.xml" both reference .html files.
+    # String literals, raw + extension-stripped: render_template() strips
+    # extensions at resolve time ("site/head.tmpl" references site/head).
     quoted: frozenset[str]
-    # All word tokens.  Templetor macros are referenced by bare name wherever
-    # they appear: $:macros.Name(...), render_macro("Name"),
-    # CacheableMacro("Name") indirection, JS component names.  Names are
-    # usually CamelCase but not always (i18n, iframe).
+    # Word tokens: Templetor macros are referenced by bare name everywhere
+    # ($:macros.X, render_macro("X"), CacheableMacro("X"), JS components).
     words: frozenset[str]
-    # Attributes accessed on `render` (render.notfound(...), render.site(...)).
+    # Attributes accessed on render (render.notfound(...)): root-level
+    # Templetor templates.
     render_attrs: frozenset[str]
-    # Words followed by "(" -- how Jinja macros are called (alias.name(...)).
-    # Only extracted for .jinja files, the only place non-exempt macros live.
+    # Words followed by "(" and words on import lines: how Jinja macros are
+    # called/imported (alias.name(...), {% from ... %}).  Only .jinja files.
     called_words: frozenset[str]
-    # Words on lines containing `import` ({% from "..." import a, b %}).
     import_words: frozenset[str]
 
 
 @dataclass(frozen=True)
 class SearchIndex:
-    """Per-file indexes sorted by path, so evidence reporting is stable."""
+    """Per-file indexes, sorted by path for stable evidence reporting."""
 
     entries: tuple[tuple[str, FileIndex], ...]
 
 
 def _add_quoted(text: str, quoted: set[str]) -> None:
-    """Add every quoted literal in text (raw + extension-stripped).
-
-    Recurses once into literals that themselves contain the other quote
-    type, e.g. data-i18n="$:render_template('search/availability_i18n')"
-    where the template name sits in single quotes inside an HTML attribute.
+    """Add every quoted literal in text (raw + extension-stripped), recursing
+    into literals that contain the other quote type ("a'b'c" nests).
     """
     for match in QUOTED_LITERAL_RE.finditer(text):
         literal = match.group(1) if match.group(1) is not None else match.group(2)
@@ -251,13 +188,16 @@ def _add_quoted(text: str, quoted: set[str]) -> None:
 
 
 def _index_file(text: str, suffix: str) -> FileIndex:
+    is_jinja = suffix == ".jinja"
+    if is_jinja:
+        # Mask macro-definition names: a {% macro foo %} line is not a use of
+        # foo; real calls elsewhere in the file still count.
+        text = JINJA_MACRO_DEF_RE.sub(lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), text)
     quoted: set[str] = set()
     _add_quoted(text, quoted)
     called_words: frozenset[str] = frozenset()
     import_words: frozenset[str] = frozenset()
-    if suffix == ".jinja":
-        # Jinja macro calls/imports only matter in .jinja files, so the
-        # costlier extractions below run there and nowhere else.
+    if is_jinja:
         called_words = frozenset(CALLED_WORD_RE.findall(text))
         import_words = frozenset(word for line in text.splitlines() if re.search(r"\bimport\b", line) for word in WORD_RE.findall(line))
     return FileIndex(
@@ -273,31 +213,12 @@ def build_search_index(corpus: dict[str, str]) -> SearchIndex:
     return SearchIndex(entries=tuple((rel, _index_file(text, Path(rel).suffix)) for rel, text in sorted(corpus.items())))
 
 
-def _macro_used_in_own_file(text: str, name: str) -> bool:
-    """Whether a Jinja macro is called inside its own defining file.
-
-    Self-use counts as usage (helper macros composing other macros in the
-    same file), but the ``{% macro name(`` definition lines do not.
-    """
-    for match in re.finditer(rf"\b{re.escape(name)}\s*\(", text):
-        if re.search(r"macro\s*$", text[: match.start()]):
-            continue
-        return True
-    return False
-
-
 def dynamic_dispatch_note(template: Template) -> str | None:
-    """Dispatch note if this template is only reachable via name construction.
-
-    Directories in ``DYNAMIC_DISPATCH_RULES`` never appear literally in call
-    sites: the runtime builds their names from DB type keys, changeset kinds,
-    provider registries, or design-system section ids.
-    """
+    """Why a template is reachable with no literal call site, if so."""
     rel_to_root = template.rel_to_root
     if template.kind == KIND_JINJA_MACRO:
         if rel_to_root.startswith(tuple(DYNAMIC_DISPATCH_RULES)):
-            # Macros inside dynamically-imported files are called through
-            # dynamic aliases (e.g. page.nav()), which no pattern can see.
+            # Imported under dynamic aliases (page.nav()), visible to no pattern.
             return "defined in a dynamically imported template"
         return None
     for prefix, why in DYNAMIC_DISPATCH_RULES.items():
@@ -307,11 +228,10 @@ def dynamic_dispatch_note(template: Template) -> str | None:
 
 
 def _reference_sets(template: Template, file_index: FileIndex) -> tuple[frozenset[str], ...]:
-    """The token sets of ``file_index`` a reference to ``template`` lives in."""
+    """Token sets of ``file_index`` that can reference ``template``."""
     if template.kind == KIND_TEMPLETOR_TEMPLATE:
-        # Named in string literals (render_template("account/login")); a
-        # root-level template is also reachable as render.name(...) attribute
-        # access on infogami's Render DictPile.
+        # Root-level templates are also reachable as render.name(...) on
+        # infogami's Render DictPile.
         if "/" not in template.name:
             return file_index.quoted, file_index.render_attrs
         return (file_index.quoted,)
@@ -319,9 +239,7 @@ def _reference_sets(template: Template, file_index: FileIndex) -> tuple[frozense
         return (file_index.words,)
     if template.kind == KIND_JINJA_TEMPLATE:
         return (file_index.quoted,)
-    # Jinja macros are called as name(...) or named by {%- import %} lines;
-    # aliased imports are covered because the name is its own word in
-    # alias.name(...).
+    # Jinja macros: calls (name(...)) and import lines.
     return file_index.called_words, file_index.import_words
 
 
@@ -332,26 +250,21 @@ def find_usage(template: Template, index: SearchIndex) -> str | None:
 
     self_rel = template.relpath
     for rel, file_index in index.entries:
-        # A file's own contents never count as a reference from elsewhere;
-        # self-referencing Jinja macros are handled separately below.
-        if rel == self_rel:
+        # A file's own contents never count as a reference -- except for
+        # Jinja macros, whose own file counts via def-masked call sites.
+        if rel == self_rel and template.kind != KIND_JINJA_MACRO:
             continue
         if any(template.name in tokens for tokens in _reference_sets(template, file_index)):
             return rel
-    if template.kind == KIND_JINJA_MACRO and _macro_used_in_own_file(
-        template.path.read_text(encoding="utf-8", errors="replace"),
-        template.name,
-    ):
-        return f"{self_rel} (self-referencing macro)"
     return None
 
 
 def analyze(exclusions: Iterable[str] = ()) -> Analysis:
     """Scan the code base and report unused templates/macros.
 
-    ``exclusions`` are names to skip (used only from database content); they
-    are also audited so stale entries -- ones actually referenced in code, or
-    matching nothing on disk -- surface as errors.
+    ``exclusions`` are names used only from database content; they are skipped
+    and audited so stale entries (referenced in code, or matching nothing on
+    disk) surface as errors.
     """
     corpus = build_corpus()
     inventory = build_inventory()

--- a/openlibrary/utils/template_usage.py
+++ b/openlibrary/utils/template_usage.py
@@ -11,14 +11,14 @@ Open Library renders pages with two template systems side by side:
   ``openlibrary/templates``), e.g. ``"design/layout.html.jinja"``.
 
 This module inventories every template/macro file plus every Jinja
-``{% macro %}`` definition, then searches the code base (Python, Templetor,
-Jinja, JS/TS/Vue, config files) for references.  Anything with no reference is
-reported as unused.
+``{% macro %}`` definition, then searches every git-tracked source file
+(Python, Templetor, Jinja, JS/TS/Vue, config) for references.  Anything with
+no reference is reported as unused.
 
 The analysis is deliberately conservative: it prefers to miss an unused
 template over flagging one that is actually used, because a false positive
-fails the build and invites deleting a template that is still live.  References that cannot be seen statically are
-handled in two ways:
+fails the build and invites deleting a template that is still live.
+References that cannot be seen statically are handled in two ways:
 
 * ``DYNAMIC_DISPATCH_RULES`` documents directories whose templates are
   resolved at runtime by name construction (DB type keys, changeset kinds,
@@ -34,9 +34,8 @@ handled in two ways:
 
 from __future__ import annotations
 
-import os
 import re
-import sys
+import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -58,30 +57,15 @@ KIND_JINJA_MACRO = "jinja macro"
 # included on purpose -- a template rendered only from a test is still alive.
 CORPUS_SUFFIXES = frozenset({".py", ".js", ".ts", ".tsx", ".vue", ".html", ".jinja", ".yml", ".yaml", ".json"})
 
-# Directories never scanned for references (third-party code, build output, VCS).
-CORPUS_SKIP_DIRS = frozenset(
-    {
-        "vendor",
-        "node_modules",
-        ".git",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".tox",
-        "dist",
-        "build",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-    }
-)
-
-# This module and its test must not count their own contents as references
-# (the exclusion list and rule tables mention template names verbatim).
+# Files never scanned for references.  This module and its test mention
+# template names verbatim (exclusion lists, rule tables), and package-lock.json
+# is generated noise whose dependency names could rescue a template by
+# coincidence.
 CORPUS_SKIP_FILES = frozenset(
     {
         "openlibrary/utils/template_usage.py",
         "openlibrary/tests/test_unused_templates.py",
+        "package-lock.json",
     }
 )
 
@@ -124,6 +108,14 @@ class Template:
     @property
     def relpath(self) -> str:
         return self.path.relative_to(REPO_ROOT).as_posix()
+
+    @property
+    def rel_to_root(self) -> str:
+        """Path relative to its template root (macros/ or templates/)."""
+        for root in TEMPLATE_ROOTS:
+            if self.path.is_relative_to(root):
+                return self.path.relative_to(root).as_posix()
+        return self.relpath
 
 
 @dataclass
@@ -168,21 +160,36 @@ def build_inventory() -> list[Template]:
 
 
 def build_corpus() -> dict[str, str]:
-    """Read every source file that may contain template references."""
+    """Read every git-tracked source file that may contain references.
+
+    Only tracked files are scanned, so the result is hermetic: untracked
+    scratch files, local config overrides, and nested checkouts cannot make
+    the verdict differ between machines or CI.  ``--recurse-submodules`` is
+    load-bearing -- references like ``render.viewpage`` live in the
+    ``vendor/infogami`` submodule (initialize it with ``make git``).
+    """
+    files = (
+        subprocess.run(
+            ["git", "ls-files", "--recurse-submodules", "-z"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        .stdout.decode()
+        .split("\0")
+    )
+    if not any(rel.startswith("vendor/infogami/") for rel in files):
+        raise RuntimeError(
+            "git ls-files returned no vendor/infogami files -- the submodule "
+            "is not initialized. Run `make git` (git submodule update --init) "
+            "so the scan can see infogami's template references."
+        )
     corpus: dict[str, str] = {}
-    # followlinks: the top-level infogami/ directory is a symlink to
-    # vendor/infogami/infogami, and references like render.viewpage live in
-    # there.  vendor/ itself is pruned, so it is only read via the symlink.
-    for dirpath, dirnames, filenames in os.walk(REPO_ROOT, followlinks=True):
-        dirnames[:] = sorted(d for d in dirnames if d not in CORPUS_SKIP_DIRS)
-        for filename in filenames:
-            path = Path(dirpath) / filename
-            if path.suffix not in CORPUS_SUFFIXES:
-                continue
-            rel = path.relative_to(REPO_ROOT).as_posix()
-            if rel in CORPUS_SKIP_FILES:
-                continue
-            corpus[rel] = path.read_text(encoding="utf-8", errors="replace")
+    for rel in files:
+        path = REPO_ROOT / rel
+        if not path.is_file() or Path(rel).suffix not in CORPUS_SUFFIXES or rel in CORPUS_SKIP_FILES:
+            continue
+        corpus[rel] = path.read_text(encoding="utf-8", errors="replace")
     return corpus
 
 
@@ -206,8 +213,8 @@ class FileIndex:
     # render_template()/get_template() strip extensions at resolve time, so
     # "site/head.tmpl" and "lists/feed_updates.xml" both reference .html files.
     quoted: frozenset[str]
-    # All word tokens, interned.  Templetor macros are referenced by bare
-    # name wherever they appear: $:macros.Name(...), render_macro("Name"),
+    # All word tokens.  Templetor macros are referenced by bare name wherever
+    # they appear: $:macros.Name(...), render_macro("Name"),
     # CacheableMacro("Name") indirection, JS component names.  Names are
     # usually CamelCase but not always (i18n, iframe).
     words: frozenset[str]
@@ -255,7 +262,7 @@ def _index_file(text: str, suffix: str) -> FileIndex:
         import_words = frozenset(word for line in text.splitlines() if re.search(r"\bimport\b", line) for word in WORD_RE.findall(line))
     return FileIndex(
         quoted=frozenset(quoted),
-        words=frozenset(map(sys.intern, WORD_RE.findall(text))),
+        words=frozenset(WORD_RE.findall(text)),
         render_attrs=frozenset(RENDER_ATTR_RE.findall(text)),
         called_words=called_words,
         import_words=import_words,
@@ -286,10 +293,7 @@ def dynamic_dispatch_note(template: Template) -> str | None:
     sites: the runtime builds their names from DB type keys, changeset kinds,
     provider registries, or design-system section ids.
     """
-    rel_to_root = next(
-        (template.path.relative_to(root).as_posix() for root in TEMPLATE_ROOTS if template.path.is_relative_to(root)),
-        template.relpath,
-    )
+    rel_to_root = template.rel_to_root
     if template.kind == KIND_JINJA_MACRO:
         if rel_to_root.startswith(tuple(DYNAMIC_DISPATCH_RULES)):
             # Macros inside dynamically-imported files are called through
@@ -302,47 +306,43 @@ def dynamic_dispatch_note(template: Template) -> str | None:
     return None
 
 
+def _reference_sets(template: Template, file_index: FileIndex) -> tuple[frozenset[str], ...]:
+    """The token sets of ``file_index`` a reference to ``template`` lives in."""
+    if template.kind == KIND_TEMPLETOR_TEMPLATE:
+        # Named in string literals (render_template("account/login")); a
+        # root-level template is also reachable as render.name(...) attribute
+        # access on infogami's Render DictPile.
+        if "/" not in template.name:
+            return file_index.quoted, file_index.render_attrs
+        return (file_index.quoted,)
+    if template.kind == KIND_TEMPLETOR_MACRO:
+        return (file_index.words,)
+    if template.kind == KIND_JINJA_TEMPLATE:
+        return (file_index.quoted,)
+    # Jinja macros are called as name(...) or named by {%- import %} lines;
+    # aliased imports are covered because the name is its own word in
+    # alias.name(...).
+    return file_index.called_words, file_index.import_words
+
+
 def find_usage(template: Template, index: SearchIndex) -> str | None:
     """Return evidence (a corpus path or dispatch note) that this is used."""
     if note := dynamic_dispatch_note(template):
         return note
 
     self_rel = template.relpath
-    if template.kind == KIND_TEMPLETOR_TEMPLATE:
-        # Root-level templates are also reachable as render.name(...)
-        # attribute access on infogami's Render DictPile.
-        check_render_attr = "/" not in template.name
-        for rel, file_index in index.entries:
-            if rel == self_rel:
-                continue
-            if template.name in file_index.quoted:
-                return rel
-            if check_render_attr and template.name in file_index.render_attrs:
-                return rel
-        return None
-    elif template.kind == KIND_TEMPLETOR_MACRO:
-        for rel, file_index in index.entries:
-            if rel != self_rel and template.name in file_index.words:
-                return rel
-        return None
-    elif template.kind == KIND_JINJA_TEMPLATE:
-        for rel, file_index in index.entries:
-            if rel != self_rel and template.name in file_index.quoted:
-                return rel
-        return None
-    elif template.kind == KIND_JINJA_MACRO:
-        # Calls always use parentheses; from-imports list names without
-        # them.  Aliased imports are covered because the name is its own
-        # word in alias.name(...).
-        for rel, file_index in index.entries:
-            if template.name in file_index.called_words or template.name in file_index.import_words:
-                return rel
-        if _macro_used_in_own_file(
-            template.path.read_text(encoding="utf-8", errors="replace"),
-            template.name,
-        ):
-            return f"{self_rel} (self-referencing macro)"
-        return None
+    for rel, file_index in index.entries:
+        # A file's own contents never count as a reference from elsewhere;
+        # self-referencing Jinja macros are handled separately below.
+        if rel == self_rel:
+            continue
+        if any(template.name in tokens for tokens in _reference_sets(template, file_index)):
+            return rel
+    if template.kind == KIND_JINJA_MACRO and _macro_used_in_own_file(
+        template.path.read_text(encoding="utf-8", errors="replace"),
+        template.name,
+    ):
+        return f"{self_rel} (self-referencing macro)"
     return None
 
 
@@ -356,28 +356,17 @@ def analyze(exclusions: Iterable[str] = ()) -> Analysis:
     corpus = build_corpus()
     inventory = build_inventory()
     index = build_search_index(corpus)
-    # Cheap pre-filter: every usage pattern embeds the name literally, so a
-    # name absent from the corpus text cannot possibly be referenced.
-    haystack = "\n".join(corpus.values())
 
-    unused = [
-        t
-        for t in inventory
-        if t.name not in exclusions
-        # The pre-filter below is only sound for pattern matching: dynamically
-        # dispatched templates are used without their names appearing anywhere.
-        and dynamic_dispatch_note(t) is None
-        and (t.name not in haystack or find_usage(t, index) is None)
-    ]
+    unused = [t for t in inventory if t.name not in exclusions and find_usage(t, index) is None]
 
     used_exclusions: dict[str, str] = {}
     missing_exclusions: set[str] = set()
-    names = {t.name for t in inventory}
     for name in exclusions:
-        if name not in names:
+        matches = [t for t in inventory if t.name == name]
+        if not matches:
             missing_exclusions.add(name)
             continue
-        for t in (candidate for candidate in inventory if candidate.name == name):
+        for t in matches:
             if evidence := find_usage(t, index):
                 used_exclusions[name] = evidence
 

--- a/openlibrary/utils/template_usage.py
+++ b/openlibrary/utils/template_usage.py
@@ -1,0 +1,389 @@
+"""Static analysis to find templates and macros that are never referenced.
+
+Open Library renders pages with two template systems side by side:
+
+* Templetor (web.py/Infogami) -- ``openlibrary/templates/**/*.html`` page
+  templates (referenced as ``"account/mybooks"``) and
+  ``openlibrary/macros/*.html`` macros (referenced by bare file stem, e.g.
+  ``CoverImage``).
+* Jinja -- ``*.html.jinja`` files in both roots, referenced by their full path
+  relative to the Jinja loader roots (``openlibrary/macros`` then
+  ``openlibrary/templates``), e.g. ``"design/layout.html.jinja"``.
+
+This module inventories every template/macro file plus every Jinja
+``{% macro %}`` definition, then searches the code base (Python, Templetor,
+Jinja, JS/TS/Vue, config files) for references.  Anything with no reference is
+reported as unused.
+
+The analysis is deliberately conservative: it prefers to miss an unused
+template over flagging one that is actually used, because a false positive
+fails the build and invites deleting a template that is still live.  References that cannot be seen statically are
+handled in two ways:
+
+* ``DYNAMIC_DISPATCH_RULES`` documents directories whose templates are
+  resolved at runtime by name construction (DB type keys, changeset kinds,
+  provider registries, design-system section ids) -- those are always
+  considered used, and so are the Jinja macros defined inside them (they are
+  imported under dynamic aliases such as ``page.nav()``).
+* Templates/macros that are used only from *database* content (wiki-stored
+  templates under ``/upstream/templates/*``, wiki-stored macros, or
+  ``{{Macro(...)}}`` markdown in any page body) are invisible to static
+  analysis.  The pytest wrapper keeps an explicit exclusion list for those;
+  see ``openlibrary/tests/test_unused_templates.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_ROOTS = (
+    REPO_ROOT / "openlibrary" / "templates",
+    REPO_ROOT / "openlibrary" / "macros",
+)
+
+KIND_TEMPLETOR_TEMPLATE = "templetor template"
+KIND_TEMPLETOR_MACRO = "templetor macro"
+KIND_JINJA_TEMPLATE = "jinja template"
+KIND_JINJA_MACRO = "jinja macro"
+
+# File types that may contain template references (Python code, both template
+# systems' files, front-end sources, and config).  Docs (*.md) are excluded:
+# a template mentioned in documentation is not used by it.  Test files are
+# included on purpose -- a template rendered only from a test is still alive.
+CORPUS_SUFFIXES = frozenset({".py", ".js", ".ts", ".tsx", ".vue", ".html", ".jinja", ".yml", ".yaml", ".json"})
+
+# Directories never scanned for references (third-party code, build output, VCS).
+CORPUS_SKIP_DIRS = frozenset(
+    {
+        "vendor",
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        "dist",
+        "build",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+# This module and its test must not count their own contents as references
+# (the exclusion list and rule tables mention template names verbatim).
+CORPUS_SKIP_FILES = frozenset(
+    {
+        "openlibrary/utils/template_usage.py",
+        "openlibrary/tests/test_unused_templates.py",
+    }
+)
+
+# Directories under openlibrary/templates/ whose files are never referenced by
+# a literal name: the runtime builds their names dynamically.  Mapped to the
+# code that does the dispatch, so the rule can be checked and updated.
+DYNAMIC_DISPATCH_RULES: dict[str, str] = {
+    "type/": (
+        "selected by infogami's typetemplate() as "
+        "render[<db type key> + '/' + name] -- the type keys live in the "
+        "database, not the code (infogami/utils/template.py)"
+    ),
+    "recentchanges/": (
+        "selected from DB changeset kinds via get_template('recentchanges/' + "
+        "kind + '/...') with recentchanges/default/... fallback "
+        "(openlibrary/plugins/upstream/recentchanges.py, "
+        "openlibrary/plugins/upstream/utils.py, "
+        "templates/recentchanges/render.html)"
+    ),
+    "book_providers/": ("filename constructed as f'book_providers/{short_name}_{typ}.html' from the provider registry (openlibrary/book_providers.py)"),
+    "design/": (
+        "imported dynamically by Jinja as 'design/' + section.id + "
+        "'.html.jinja' and via the component registry component.partial "
+        "(templates/design/layout.html.jinja, "
+        "openlibrary/plugins/openlibrary/design.py)"
+    ),
+}
+
+JINJA_MACRO_DEF_RE = re.compile(r"{%-?\s*macro\s+(\w+)\s*\(")
+
+
+@dataclass(frozen=True)
+class Template:
+    """A template/macros file, or a single {% macro %} definition in one."""
+
+    name: str
+    path: Path
+    kind: str
+
+    @property
+    def relpath(self) -> str:
+        return self.path.relative_to(REPO_ROOT).as_posix()
+
+
+@dataclass
+class Analysis:
+    """Result of the unused-template scan."""
+
+    templates: list[Template]
+    unused: list[Template]
+    # Exclusion-list entries that are actually referenced in code (so the
+    # entry hides real usage and must be removed), mapped to the evidence.
+    used_exclusions: dict[str, str]
+    # Exclusion-list entries with no matching template/macro on disk.
+    missing_exclusions: set[str]
+
+
+def iter_template_files() -> list[Template]:
+    templates = []
+    for root in TEMPLATE_ROOTS:
+        is_macros_root = root.name == "macros"
+        for path in sorted(root.rglob("*.html")):
+            # Templetor resolves names with any extension stripped, so the
+            # canonical name is the path relative to the root minus ".html".
+            name = path.relative_to(root).as_posix()[: -len(".html")]
+            kind = KIND_TEMPLETOR_MACRO if is_macros_root else KIND_TEMPLETOR_TEMPLATE
+            templates.append(Template(name, path, kind))
+        for path in sorted(root.rglob("*.html.jinja")):
+            # Jinja resolves the full path relative to its loader roots.
+            name = path.relative_to(root).as_posix()
+            templates.append(Template(name, path, KIND_JINJA_TEMPLATE))
+    return templates
+
+
+def build_inventory() -> list[Template]:
+    templates = iter_template_files()
+    for t in templates:
+        if t.kind != KIND_JINJA_TEMPLATE:
+            continue
+        text = t.path.read_text(encoding="utf-8", errors="replace")
+        for match in JINJA_MACRO_DEF_RE.finditer(text):
+            templates.append(Template(match.group(1), t.path, KIND_JINJA_MACRO))
+    return sorted(set(templates), key=lambda t: (t.kind, t.relpath, t.name))
+
+
+def build_corpus() -> dict[str, str]:
+    """Read every source file that may contain template references."""
+    corpus: dict[str, str] = {}
+    # followlinks: the top-level infogami/ directory is a symlink to
+    # vendor/infogami/infogami, and references like render.viewpage live in
+    # there.  vendor/ itself is pruned, so it is only read via the symlink.
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT, followlinks=True):
+        dirnames[:] = sorted(d for d in dirnames if d not in CORPUS_SKIP_DIRS)
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path.suffix not in CORPUS_SUFFIXES:
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in CORPUS_SKIP_FILES:
+                continue
+            corpus[rel] = path.read_text(encoding="utf-8", errors="replace")
+    return corpus
+
+
+QUOTED_LITERAL_RE = re.compile(r'"([^"\n]+)"|\'([^\'\n]+)\'')
+WORD_RE = re.compile(r"\w+")
+CALLED_WORD_RE = re.compile(r"\w+(?=\s*\()")
+RENDER_ATTR_RE = re.compile(r"\brender\.(\w+)")
+
+
+@dataclass(frozen=True)
+class FileIndex:
+    """Pre-extracted references from one corpus file.
+
+    Scanning every file with a regex per template name is O(names x files x
+    file size); extracting these sets once per file turns each usage check
+    into O(1) set lookups.
+    """
+
+    # String literals (pair-matched quotes, nested other-type quotes one
+    # level deep), each also stored with its last extension stripped:
+    # render_template()/get_template() strip extensions at resolve time, so
+    # "site/head.tmpl" and "lists/feed_updates.xml" both reference .html files.
+    quoted: frozenset[str]
+    # All word tokens, interned.  Templetor macros are referenced by bare
+    # name wherever they appear: $:macros.Name(...), render_macro("Name"),
+    # CacheableMacro("Name") indirection, JS component names.  Names are
+    # usually CamelCase but not always (i18n, iframe).
+    words: frozenset[str]
+    # Attributes accessed on `render` (render.notfound(...), render.site(...)).
+    render_attrs: frozenset[str]
+    # Words followed by "(" -- how Jinja macros are called (alias.name(...)).
+    # Only extracted for .jinja files, the only place non-exempt macros live.
+    called_words: frozenset[str]
+    # Words on lines containing `import` ({% from "..." import a, b %}).
+    import_words: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SearchIndex:
+    """Per-file indexes sorted by path, so evidence reporting is stable."""
+
+    entries: tuple[tuple[str, FileIndex], ...]
+
+
+def _add_quoted(text: str, quoted: set[str]) -> None:
+    """Add every quoted literal in text (raw + extension-stripped).
+
+    Recurses once into literals that themselves contain the other quote
+    type, e.g. data-i18n="$:render_template('search/availability_i18n')"
+    where the template name sits in single quotes inside an HTML attribute.
+    """
+    for match in QUOTED_LITERAL_RE.finditer(text):
+        literal = match.group(1) if match.group(1) is not None else match.group(2)
+        quoted.add(literal)
+        if "." in literal:
+            quoted.add(literal.rsplit(".", 1)[0])
+        if "'" in literal or '"' in literal:
+            _add_quoted(literal, quoted)
+
+
+def _index_file(text: str, suffix: str) -> FileIndex:
+    quoted: set[str] = set()
+    _add_quoted(text, quoted)
+    called_words: frozenset[str] = frozenset()
+    import_words: frozenset[str] = frozenset()
+    if suffix == ".jinja":
+        # Jinja macro calls/imports only matter in .jinja files, so the
+        # costlier extractions below run there and nowhere else.
+        called_words = frozenset(CALLED_WORD_RE.findall(text))
+        import_words = frozenset(word for line in text.splitlines() if re.search(r"\bimport\b", line) for word in WORD_RE.findall(line))
+    return FileIndex(
+        quoted=frozenset(quoted),
+        words=frozenset(map(sys.intern, WORD_RE.findall(text))),
+        render_attrs=frozenset(RENDER_ATTR_RE.findall(text)),
+        called_words=called_words,
+        import_words=import_words,
+    )
+
+
+def build_search_index(corpus: dict[str, str]) -> SearchIndex:
+    return SearchIndex(entries=tuple((rel, _index_file(text, Path(rel).suffix)) for rel, text in sorted(corpus.items())))
+
+
+def _macro_used_in_own_file(text: str, name: str) -> bool:
+    """Whether a Jinja macro is called inside its own defining file.
+
+    Self-use counts as usage (helper macros composing other macros in the
+    same file), but the ``{% macro name(`` definition lines do not.
+    """
+    for match in re.finditer(rf"\b{re.escape(name)}\s*\(", text):
+        if re.search(r"macro\s*$", text[: match.start()]):
+            continue
+        return True
+    return False
+
+
+def dynamic_dispatch_note(template: Template) -> str | None:
+    """Dispatch note if this template is only reachable via name construction.
+
+    Directories in ``DYNAMIC_DISPATCH_RULES`` never appear literally in call
+    sites: the runtime builds their names from DB type keys, changeset kinds,
+    provider registries, or design-system section ids.
+    """
+    rel_to_root = next(
+        (template.path.relative_to(root).as_posix() for root in TEMPLATE_ROOTS if template.path.is_relative_to(root)),
+        template.relpath,
+    )
+    if template.kind == KIND_JINJA_MACRO:
+        if rel_to_root.startswith(tuple(DYNAMIC_DISPATCH_RULES)):
+            # Macros inside dynamically-imported files are called through
+            # dynamic aliases (e.g. page.nav()), which no pattern can see.
+            return "defined in a dynamically imported template"
+        return None
+    for prefix, why in DYNAMIC_DISPATCH_RULES.items():
+        if rel_to_root.startswith(prefix):
+            return f"dynamically dispatched ({why})"
+    return None
+
+
+def find_usage(template: Template, index: SearchIndex) -> str | None:
+    """Return evidence (a corpus path or dispatch note) that this is used."""
+    if note := dynamic_dispatch_note(template):
+        return note
+
+    self_rel = template.relpath
+    if template.kind == KIND_TEMPLETOR_TEMPLATE:
+        # Root-level templates are also reachable as render.name(...)
+        # attribute access on infogami's Render DictPile.
+        check_render_attr = "/" not in template.name
+        for rel, file_index in index.entries:
+            if rel == self_rel:
+                continue
+            if template.name in file_index.quoted:
+                return rel
+            if check_render_attr and template.name in file_index.render_attrs:
+                return rel
+        return None
+    elif template.kind == KIND_TEMPLETOR_MACRO:
+        for rel, file_index in index.entries:
+            if rel != self_rel and template.name in file_index.words:
+                return rel
+        return None
+    elif template.kind == KIND_JINJA_TEMPLATE:
+        for rel, file_index in index.entries:
+            if rel != self_rel and template.name in file_index.quoted:
+                return rel
+        return None
+    elif template.kind == KIND_JINJA_MACRO:
+        # Calls always use parentheses; from-imports list names without
+        # them.  Aliased imports are covered because the name is its own
+        # word in alias.name(...).
+        for rel, file_index in index.entries:
+            if template.name in file_index.called_words or template.name in file_index.import_words:
+                return rel
+        if _macro_used_in_own_file(
+            template.path.read_text(encoding="utf-8", errors="replace"),
+            template.name,
+        ):
+            return f"{self_rel} (self-referencing macro)"
+        return None
+    return None
+
+
+def analyze(exclusions: Iterable[str] = ()) -> Analysis:
+    """Scan the code base and report unused templates/macros.
+
+    ``exclusions`` are names to skip (used only from database content); they
+    are also audited so stale entries -- ones actually referenced in code, or
+    matching nothing on disk -- surface as errors.
+    """
+    corpus = build_corpus()
+    inventory = build_inventory()
+    index = build_search_index(corpus)
+    # Cheap pre-filter: every usage pattern embeds the name literally, so a
+    # name absent from the corpus text cannot possibly be referenced.
+    haystack = "\n".join(corpus.values())
+
+    unused = [
+        t
+        for t in inventory
+        if t.name not in exclusions
+        # The pre-filter below is only sound for pattern matching: dynamically
+        # dispatched templates are used without their names appearing anywhere.
+        and dynamic_dispatch_note(t) is None
+        and (t.name not in haystack or find_usage(t, index) is None)
+    ]
+
+    used_exclusions: dict[str, str] = {}
+    missing_exclusions: set[str] = set()
+    names = {t.name for t in inventory}
+    for name in exclusions:
+        if name not in names:
+            missing_exclusions.add(name)
+            continue
+        for t in (candidate for candidate in inventory if candidate.name == name):
+            if evidence := find_usage(t, index):
+                used_exclusions[name] = evidence
+
+    return Analysis(
+        templates=inventory,
+        unused=unused,
+        used_exclusions=used_exclusions,
+        missing_exclusions=missing_exclusions,
+    )


### PR DESCRIPTION
> **Note:** third PR in the stack — the test passes only with the two deletion PRs below it merged (or stacked beneath it). Review those first.

## Summary

Adds a static-analysis test that fails CI whenever a template or macro has no references anywhere in the code base, so unused templates can't accumulate silently again. With the stacked deletions in place, it passes today.

## How it works

`openlibrary/utils/template_usage.py` inventories every Templetor template (`openlibrary/templates/**/*.html`), Templetor macro (`openlibrary/macros/*.html`), Jinja template (`*.html.jinja`), and Jinja `{% macro %}` definition — then checks each for references across Python, Templetor, Jinja, and JS sources. The matching handles the non-obvious reference forms:

- **Extension stripping**: `render_template("site/head.tmpl")` and `("lists/feed_updates.xml")` resolve `.html` files
- **`render.name(...)`** attribute access on infogami's Render DictPile (root-level templates)
- **Bare macro names**, catching `render_macro("Name")`, `CacheableMacro("Name")` string indirection, and JS partial component names
- **Jinja imports/calls** (`{% import %}`, `alias.name(`), with self-referencing macros distinguished from definitions

Directories whose templates are resolved by runtime name construction are exempted via a documented `DYNAMIC_DISPATCH_RULES` table, each entry citing the dispatching code: `templates/type/` (DB type keys via `typetemplate()`), `recentchanges/` (changeset kinds), `book_providers/` (provider registry), `design/` (Jinja dynamic imports).

The analysis is deliberately conservative — it prefers missing an unused template over flagging a live one — and each corpus file is pre-extracted into an index once, so the whole scan runs in ~1.3s.

## What the test does

- `test_no_unused_templates_and_macros` fails with the full list of unused items and remediation guidance; sanity-asserts the inventory size so a broken glob can't make it vacuously green
- `test_exclusion_list_is_not_stale` fails if an exclusion entry disappears from disk or becomes referenced in code, keeping the list honest

## Exclusion lists (for usage invisible to static analysis)

`DB_USED_EXCLUSIONS` — used only from database content, verified against the production "other" dump and live pages (the verification methodology, including that db template copies are stale shadows, is documented in the test file):
- `ListCarousel` — `{{ListCarousel(...)}}` markdown in live `/collections/*` db pages (verified rendering on production)
- `SubjectSearch` — created in f7b9ae436 specifically to be embedded as `{{SubjectSearch()}}` in the db-stored `/subjects` wiki pages (verified rendering on production)

`MANUAL_EXCLUSIONS` — maintainer-verified without evidence, kept separate so the two categories stay distinguishable:
- `CodeBlock.html.jinja` — believed used; no reference found anywhere. Drop the entry if that turns out to be wrong.

## Testing

- `openlibrary/tests/test_unused_templates.py`: 2 passed (~1.1s)
- Full template suite (`test_templates.py` + `test_jinja.py`): 687 passed
