### PR TITLE
Make it possible to copy lists into local environment with copydocs

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -282,47 +282,6 @@ def copy(
     saved.update(keys)
 
 
-def copy_list(src, dest, list_key, comment):
-    keys = set()
-
-    def jsonget(url):
-        url = url.encode("utf-8")
-        text = src._request(url).read()
-        return json.loads(text)
-
-    def get(key):
-        print("get", key)
-        return marshal(src.get(list_key))
-
-    def query(**q):
-        print("query", q)
-        return [x["key"] for x in marshal(src.query(q))]
-
-    def get_list_seeds(list_key):
-        d = jsonget(list_key + "/seeds.json")
-        return d["entries"]  # [x['url'] for x in d['entries']]
-
-    def add_seed(seed):
-        if seed["type"] in ("edition", "work"):
-            keys.add(seed["url"])
-        elif seed["type"] == "subject":
-            doc = jsonget(seed["url"] + ".json")
-            keys.update(w["key"] for w in doc["works"])
-
-    seeds = get_list_seeds(list_key)
-    for seed in seeds:
-        add_seed(seed)
-
-    edition_keys = {k for k in keys if k.startswith("/books/")}
-    work_keys = {k for k in keys if k.startswith("/works/")}
-
-    for w in work_keys:
-        edition_keys.update(query(type="/type/edition", works=w, limit=500))
-
-    keys = list(edition_keys) + list(work_keys)
-    copy(src, dest, keys, comment=comment, recursive=True)
-
-
 def main(
     keys: list[str],
     src: str = "http://openlibrary.org/",
@@ -330,7 +289,6 @@ def main(
     comment: str = "",
     recursive: bool = True,
     editions: bool = True,
-    lists: list[str] | None = None,
     search: str | None = None,
     search_limit: int = 10,
 ) -> None:
@@ -344,6 +302,8 @@ def main(
         ./scripts/copydocs.py --src http://openlibrary.org /templates/*
         # Copy specific records
         ./scripts/copydocs.py /authors/OL113592A /works/OL1098727W?v=2
+        # Copy a list (its own key also copies its referenced seeds/authors/series)
+        ./scripts/copydocs.py /people/foo/lists/OL1L
         # Copy search results
         ./scripts/copydocs.py --search "publisher:librivox" --search-limit 10
 
@@ -352,7 +312,6 @@ def main(
     :param dest: URL of the destination open library server
     :param recursive: Recursively fetch all the referred docs
     :param editions: Also fetch all the editions of works
-    :param lists: Copy docs from list(s)
     :param search: Run a search on open library and copy docs from the results
     """
 
@@ -367,9 +326,6 @@ def main(
             dest_ol.autologin()
         else:
             dest_ol.login("openlibrary@example.com", "admin123")
-
-    for list_key in lists or []:
-        copy_list(src_ol, dest_ol, list_key, comment=comment)
 
     if search:
         assert isinstance(src_ol, OpenLibrary), "Search only works with OL src"

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -172,8 +172,8 @@ def copy(
     comment: str,
     recursive: bool = False,
     editions: bool = False,
-    saved: set[str] | None = None,
     cache: dict | None = None,
+    seen: set[str] | None = None,
 ) -> None:
     """
     :param src: where we'll be copying form
@@ -181,12 +181,14 @@ def copy(
     :param comment: comment to writing when saving the documents
     :param recursive: Whether to recursively fetch an referenced docs
     :param editions: Whether to fetch editions of works as well
-    :param saved: keys saved so far
+    :param seen: keys already claimed for fetching/recursion; breaks reference
+        cycles (e.g. a user, its /usergroup, and its /permission all point
+        back to each other) that would otherwise recurse forever
     """
-    if saved is None:
-        saved = set()
     if cache is None:
         cache = {}
+    if seen is None:
+        seen = set()
 
     def get_many(keys):
         docs = marshal(src.get_many(keys).values())
@@ -233,8 +235,9 @@ def copy(
         k
         for k in keys
         # Ignore /scan_record and /scanning_center ; they can cause infinite loops?
-        if k not in saved and not k.startswith("/scan")
+        if k not in seen and not k.startswith("/scan")
     ]
+    seen.update(keys)
     docs = fetch(keys)
 
     if editions:
@@ -248,7 +251,7 @@ def copy(
                 limit=len(work_keys),
                 fields=["edition_key"],
             )
-            edition_keys = [f"/books/{olid}" for doc in resp["docs"] for olid in doc["edition_key"]]
+            edition_keys = [f"/books/{olid}" for doc in resp["docs"] for olid in doc["edition_key"] if f"/books/{olid}" not in seen]
             if edition_keys:
                 print("copying edition keys")
                 copy(
@@ -257,18 +260,16 @@ def copy(
                     edition_keys,
                     comment,
                     recursive=recursive,
-                    saved=saved,
                     cache=cache,
+                    seen=seen,
                 )
 
     if recursive:
         refs = get_references(docs)
-        refs = [r for r in set(refs) if not r.startswith(("/type/", "/languages/"))]
+        refs = [r for r in set(refs) if not r.startswith(("/type/", "/languages/")) and r not in seen]
         if refs:
             print("found references", refs)
-            copy(src, dest, refs, comment, recursive=True, saved=saved, cache=cache)
-
-    docs = [doc for doc in docs if doc["key"] not in saved]
+            copy(src, dest, refs, comment, recursive=True, cache=cache, seen=seen)
 
     keys = [doc["key"] for doc in docs]
     print("saving", keys)
@@ -279,7 +280,6 @@ def copy(
             print(dest.save_many(group, comment=comment))
         except BaseException as e:
             print(f"Something went wrong saving this batch! {e}")
-    saved.update(keys)
 
 
 def main(

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -16,6 +16,7 @@ import sys
 from collections import namedtuple
 from collections.abc import Iterator
 
+import requests
 import web
 
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
@@ -23,7 +24,7 @@ from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
 import scripts._init_path
 import scripts.tests.test_copydocs
-from openlibrary.api import OpenLibrary, marshal
+from openlibrary.api import OLError, OpenLibrary, marshal
 
 __version__ = "0.2"
 
@@ -282,6 +283,47 @@ def copy(
             print(f"Something went wrong saving this batch! {e}")
 
 
+def person_root_key(key: str) -> str | None:
+    """
+    :return: the owning /people/<username> key if `key` is a person's root
+        account or one of its sub-resources (e.g. a list); None otherwise.
+
+    >>> person_root_key("/people/foo")
+    '/people/foo'
+    >>> person_root_key("/people/foo/lists/OL1L")
+    '/people/foo'
+    >>> person_root_key("/works/OL1W")
+    """
+    parts = key.split("?")[0].split("/")
+    if len(parts) >= 3 and parts[1] == "people" and parts[2]:
+        return f"/people/{parts[2]}"
+    return None
+
+
+def ensure_person_stub(dest: OpenLibrary, infobase: str, root_key: str, comment: str) -> None:
+    """
+    Ensures `root_key` (a /people/<username> account) exists on `dest`,
+    creating an empty stub if it doesn't. A real account's /type/user,
+    /permission, and /usergroup docs reference each other, so infobase's
+    save-time reference validation can't accept them one at a time via the
+    regular copy() — registering an account creates all three together.
+    """
+    try:
+        dest.get(root_key)
+        return
+    except OLError:
+        pass
+
+    username = root_key.rsplit("/", 1)[-1]
+    print(f"creating empty stub account for {root_key}")
+    for op, data in (
+        ("register", {"username": username, "displayname": username, "email": f"{username}@example.com", "password": "password"}),
+        ("activate", {"username": username}),
+    ):
+        resp = requests.post(f"{infobase}/openlibrary.org/account/{op}", data=data)
+        resp.raise_for_status()
+
+
 def main(
     keys: list[str],
     src: str = "http://openlibrary.org/",
@@ -289,6 +331,7 @@ def main(
     comment: str = "",
     recursive: bool = True,
     editions: bool = True,
+    infobase: str = "http://infobase:7000",
     search: str | None = None,
     search_limit: int = 10,
 ) -> None:
@@ -302,7 +345,8 @@ def main(
         ./scripts/copydocs.py --src http://openlibrary.org /templates/*
         # Copy specific records
         ./scripts/copydocs.py /authors/OL113592A /works/OL1098727W?v=2
-        # Copy a list (its own key also copies its referenced seeds/authors/series)
+        # Copy a list (also copies its referenced seeds/authors/series, and
+        # stubs the owning account rather than copying it)
         ./scripts/copydocs.py /people/foo/lists/OL1L
         # Copy search results
         ./scripts/copydocs.py --search "publisher:librivox" --search-limit 10
@@ -312,6 +356,8 @@ def main(
     :param dest: URL of the destination open library server
     :param recursive: Recursively fetch all the referred docs
     :param editions: Also fetch all the editions of works
+    :param infobase: URL of the destination's infobase server, used only to
+        create stub accounts for /people/<username> keys
     :param search: Run a search on open library and copy docs from the results
     """
 
@@ -332,6 +378,18 @@ def main(
         keys += [doc["key"] for doc in src_ol.search(search, limit=search_limit, fields=["key"])["docs"]]
 
     keys = list(expand(src_ol, ("/" + k.lstrip("/") for k in keys)))
+
+    if isinstance(dest_ol, OpenLibrary):
+        remaining_keys = []
+        for key in keys:
+            root = person_root_key(key)
+            if root:
+                ensure_person_stub(dest_ol, infobase, root, comment)
+                if root == key:
+                    # The stub account *is* the copy; there's nothing real to fetch.
+                    continue
+            remaining_keys.append(key)
+        keys = remaining_keys
 
     copy(src_ol, dest_ol, keys, comment=comment, recursive=recursive, editions=editions)
 

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -294,40 +294,16 @@ def person_root_key(key: str) -> str | None:
     '/people/foo'
     >>> person_root_key("/works/OL1W")
     """
-    parts = key.split("?")[0].split("/")
+    parts = key.split("?", maxsplit=1)[0].split("/")
     if len(parts) >= 3 and parts[1] == "people" and parts[2]:
         return f"/people/{parts[2]}"
     return None
 
 
-def ensure_person_stub(dest: OpenLibrary, infobase: str, root_key: str, comment: str) -> None:
-    """
-    Ensures `root_key` (a /people/<username> account) exists on `dest`,
-    creating an empty stub if it doesn't. A real account's /type/user,
-    /permission, and /usergroup docs reference each other, so infobase's
-    save-time reference validation can't accept them one at a time via the
-    regular copy() — registering an account creates all three together.
-    """
-    try:
-        dest.get(root_key)
-        return
-    except OLError:
-        pass
-
-    username = root_key.rsplit("/", 1)[-1]
-    print(f"creating empty stub account for {root_key}")
-    for op, data in (
-        ("register", {"username": username, "displayname": username, "email": f"{username}@example.com", "password": "password"}),
-        ("activate", {"username": username}),
-    ):
-        resp = requests.post(f"{infobase}/openlibrary.org/account/{op}", data=data)
-        resp.raise_for_status()
-
-
 def main(
     keys: list[str],
     src: str = "http://openlibrary.org/",
-    dest: str = "http://localhost:8080",
+    dest: str = "http://web:8080",
     comment: str = "",
     recursive: bool = True,
     editions: bool = True,
@@ -366,13 +342,6 @@ def main(
     src_ol: Disk | OpenLibrary = OpenLibrary(src) if src.startswith("http://") else Disk(src)
     dest_ol: Disk | OpenLibrary = OpenLibrary(dest) if dest.startswith("http://") else Disk(dest)
 
-    if isinstance(dest_ol, OpenLibrary):
-        section = "[%s]" % dest.removeprefix("http://").strip("/")
-        if section in read_lines(os.path.expanduser("~/.olrc")):
-            dest_ol.autologin()
-        else:
-            dest_ol.login("openlibrary@example.com", "admin123")
-
     if search:
         assert isinstance(src_ol, OpenLibrary), "Search only works with OL src"
         keys += [doc["key"] for doc in src_ol.search(search, limit=search_limit, fields=["key"])["docs"]]
@@ -380,11 +349,26 @@ def main(
     keys = list(expand(src_ol, ("/" + k.lstrip("/") for k in keys)))
 
     if isinstance(dest_ol, OpenLibrary):
+        section = "[%s]" % dest.removeprefix("http://").strip("/")
+        if section in read_lines(os.path.expanduser("~/.olrc")):
+            dest_ol.autologin()
+        else:
+            dest_ol.login("openlibrary@example.com", "admin123")
+
         remaining_keys = []
         for key in keys:
             root = person_root_key(key)
             if root:
-                ensure_person_stub(dest_ol, infobase, root, comment)
+                try:
+                    dest_ol.get(root)
+                except OLError:
+                    username = root.rsplit("/", 1)[-1]
+                    print(f"creating empty stub account for {root}")
+                    for op, data in (
+                        ("register", {"username": username, "displayname": username, "email": f"{username}@example.com", "password": "password"}),
+                        ("activate", {"username": username}),
+                    ):
+                        requests.post(f"{infobase}/openlibrary.org/account/{op}", data=data).raise_for_status()
                 if root == key:
                     # The stub account *is* the copy; there's nothing real to fetch.
                     continue

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -270,7 +270,7 @@ def copy(
         refs = [r for r in set(refs) if not r.startswith(("/type/", "/languages/")) and r not in seen]
         if refs:
             print("found references", refs)
-            copy(src, dest, refs, comment, recursive=True, cache=cache, seen=seen)
+            copy(src, dest, refs, comment, recursive=True, editions=editions, cache=cache, seen=seen)
 
     keys = [doc["key"] for doc in docs]
     print("saving", keys)


### PR DESCRIPTION
While debugging #12966 , I needed to copy in some lists into the local dev environment, but kept hitting issues! This resolves those and lists can now easily and fully be copied in with `copydocs`.

To copy in a list recursively, you just do:

```sh
docker compose run web ./scripts/copydocs.py /people/ScarTissue/lists/OL341354L
```

And then it'll be available at http://localhost:8080/people/ScarTissue/lists/OL341354L/Book_Club_2026-08

### Technical

- Removed an old non-functional `copydocs --lists` flag
- Create a stub account when importing a list, otherwise it won't render. Note does *not* copy over permissions, usergroups, etc.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
