### PR TITLE
Fix docker compose up erroring from volume-population race conditions

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -11,7 +11,11 @@ services:
       # Debugger
       - 127.0.0.1:${WEB_DEBUG_PORT:-3000}:3000
     volumes:
-      # Persistent volume mount for installed git submodules
+      # Since we have multiple services using these named volumes, this causes a
+      # race condition when the volume is first copied/populated from the image
+      # -- see https://github.com/moby/moby/issues/43068. To fix, all other
+      # services mount these volumes with "nocopy: true" to skip that initial
+      # copy/population and hence rely on web to do it.
       - ol-vendor:/openlibrary/vendor
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
@@ -39,9 +43,19 @@ services:
       # Debugger
       - 127.0.0.1:${FAST_WEB_DEBUG_PORT:-3001}:3000
     volumes:
-      - ol-vendor:/openlibrary/vendor
+      # nocopy to avoid initialization race conditions with other services --
+      # see comment on web.volumes
+      - type: volume
+        source: ol-vendor
+        target: /openlibrary/vendor
+        volume:
+          nocopy: true
       # Persistent volume mount for generated css and js
-      - ol-build:/openlibrary/static/build
+      - type: volume
+        source: ol-build
+        target: /openlibrary/static/build
+        volume:
+          nocopy: true
       - ${OL_MOUNT_DIR:-.}:/openlibrary
     environment:
       - LOCAL_DEV=true
@@ -85,8 +99,13 @@ services:
       solr:
         condition: service_healthy
     volumes:
-      # Persistent volume mount for installed git submodules
-      - ol-vendor:/openlibrary/vendor
+      # nocopy to avoid initialization race conditions with other services --
+      # see comment on web.volumes
+      - type: volume
+        source: ol-vendor
+        target: /openlibrary/vendor
+        volume:
+          nocopy: true
       - ${OL_MOUNT_DIR:-.}:/openlibrary
 
   db:
@@ -118,7 +137,13 @@ services:
     ports:
       - ${COVERS_PORT:-7075}:7075
     volumes:
-      - ol-vendor:/openlibrary/vendor
+      # nocopy to avoid initialization race conditions with other services --
+      # see comment on web.volumes
+      - type: volume
+        source: ol-vendor
+        target: /openlibrary/vendor
+        volume:
+          nocopy: true
       - ${OL_MOUNT_DIR:-.}:/openlibrary
 
   infobase:
@@ -133,7 +158,13 @@ services:
     # ports:
     #  - 7000:7000
     volumes:
-      - ol-vendor:/openlibrary/vendor
+      # nocopy to avoid initialization race conditions with other services --
+      # see comment on web.volumes
+      - type: volume
+        source: ol-vendor
+        target: /openlibrary/vendor
+        volume:
+          nocopy: true
       - ${OL_MOUNT_DIR:-.}:/openlibrary
     depends_on:
       db:
@@ -156,9 +187,23 @@ services:
         max-size: "512m"
         max-file: "4"
     volumes:
-      - ol-vendor:/openlibrary/vendor
-      - ol-build:/openlibrary/static/build
-      - ol-nodemodules:/openlibrary/node_modules
+      # nocopy to avoid initialization race conditions with other services --
+      # see comment on web.volumes
+      - type: volume
+        source: ol-vendor
+        target: /openlibrary/vendor
+        volume:
+          nocopy: true
+      - type: volume
+        source: ol-build
+        target: /openlibrary/static/build
+        volume:
+          nocopy: true
+      - type: volume
+        source: ol-nodemodules
+        target: /openlibrary/node_modules
+        volume:
+          nocopy: true
       - ${OL_MOUNT_DIR:-.}:/openlibrary
       # For OSP download persistence across restarts
       - solr-updater-data:/solr-updater-data


### PR DESCRIPTION
Was constantly getting errors on a fresh instance docker compose up due to the named volumes being shared across different containers.

`Error response from daemon: failed to mkdir /var/lib/docker/volumes/openlibrary_ol-vendor/_data/infogami: mkdir /var/lib/docker/volumes/openlibrary_ol-vendor/_data/infogami: file exists`

Turns out this is a known bug in docker: https://github.com/moby/moby/issues/43068 . It happens because when a container first comes up with an empty named volume mounted, it starts copying the files baked into the image at that path to the named volume. When many containers try to do this at the same time, it causes a race condition where multiple things are trying to write to the same spot.

Using nocopy basically decides that only one of them does that initial population.


### Technical
<!-- What should be noted about the implementation? -->

Note: There is a small concern that `infobase`, on which `web` depends, might then be started before web does it's copy-over. But it seems to be working ok -- had AI do the from-zero startup 5 times and 0 errors occurred.

AI says one option is to have a "bootstrapping" container that depends on no one and who everyone depends on. It might make sense to make home that container if we see this as an issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

`docker compose up -d` after removing all containers/volumes. It should come up on the first try, without any errors!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
