### PR TITLE
Render /status page and testing-status API from one typed TestingStatus

### DIFF
--- a/openlibrary/fastapi/status.py
+++ b/openlibrary/fastapi/status.py
@@ -10,17 +10,19 @@ from __future__ import annotations
 import os
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from openlibrary.fastapi.auth import MaintainerDep  # noqa: TC001
-from openlibrary.plugins.openlibrary.status import get_testing_status
+from openlibrary.plugins.openlibrary.status import load_testing_status
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
 router = APIRouter(tags=["status"], include_in_schema=SHOW_INTERNAL_IN_SCHEMA)
 
 
 class TestingPRResponse(BaseModel):
-    """A single PR in the testing environment, with live drift info merged in."""
+    """A single PR in the testing environment, with live drift info merged in. Mirrors TestingPRStatus."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     pr: int = Field(..., description="GitHub pull request number")
     title: str = Field(..., description="PR title")
@@ -28,20 +30,22 @@ class TestingPRResponse(BaseModel):
     active: bool = Field(..., description="Whether the PR is active in the testing set")
     added_at: str = Field(..., description="ISO timestamp when the PR was added")
     added_by: str = Field(..., description="OL username that added the PR")
-    pull_latest_sha: str = Field("", description="Pending SHA from 'Fetch Latest'; applied on deploy")
-    pending_active: bool | None = Field(None, description="Pending enable/disable; applied on deploy")
-    author: str = Field("", description="GitHub login of the PR author")
-    author_avatar: str = Field("", description="GitHub avatar URL of the PR author")
-    assignee: str = Field("", description="GitHub login of the assignee, empty if unassigned")
-    assignee_avatar: str = Field("", description="GitHub avatar URL of the assignee")
-    head_sha: str = Field("", description="Current branch HEAD (short SHA); empty if GitHub unavailable")
-    drift: int = Field(-1, description="Commits the pinned commit is behind HEAD; -1 if unknown")
-    merged: bool = Field(False, description="Whether the PR has been merged into master")
-    is_new: bool = Field(False, description="Whether the PR was added since the last deploy")
+    pull_latest_sha: str = Field(..., description="Pending SHA from 'Fetch Latest'; applied on deploy. Empty if none")
+    pending_active: bool | None = Field(..., description="Pending enable/disable; applied on deploy. Null if none")
+    author: str = Field(..., description="GitHub login of the PR author")
+    author_avatar: str = Field(..., description="GitHub avatar URL of the PR author")
+    assignee: str = Field(..., description="GitHub login of the assignee, empty if unassigned")
+    assignee_avatar: str = Field(..., description="GitHub avatar URL of the assignee")
+    head_sha: str = Field(..., description="Current branch HEAD (short SHA); empty if GitHub unavailable")
+    drift: int = Field(..., description="Commits the pinned commit is behind HEAD; -1 if unknown")
+    merged: bool = Field(..., description="Whether the PR has been merged into master")
+    is_new: bool = Field(..., description="Whether the PR was added since the last deploy")
 
 
 class TestingStatusResponse(BaseModel):
-    """Status of the testing environment (the /status deploy table)."""
+    """Status of the testing environment (the /status deploy table). Mirrors TestingStatus."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     last_deploy_at: str = Field(..., description="ISO timestamp of the last deploy; empty if never deployed")
     has_pending: bool = Field(..., description="Whether there are pending changes ready to deploy")
@@ -55,7 +59,6 @@ class TestingStatusResponse(BaseModel):
 )
 def testing_status(_: MaintainerDep) -> TestingStatusResponse:
     """Return the testing environment status backing the /status deploy table."""
-    payload = get_testing_status()
-    if payload is None:
+    if (result := load_testing_status()) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No testing state file found")
-    return TestingStatusResponse(**payload)
+    return TestingStatusResponse.model_validate(result)

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import urllib.error
 import urllib.request
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
@@ -34,28 +34,20 @@ _DRIFT_CACHE_TTL = 5 * 60  # 5 minutes
 
 class status(delegate.page):
     def GET(self):
-        testing_state = _load_testing_state()
+        testing_status = load_testing_status()
         is_maintainer_user = _is_maintainer()
-        drift_info = {}
-        if testing_state:
-            drift_info, _ = _get_drift_info(testing_state)
-        show_testing = testing_state is not None and is_maintainer_user
-        payload = get_testing_status(testing_state, drift_info) or {}
-        has_pending = payload.get("has_pending", False)
         i = web.input(deploy_triggered=None, drift_refreshed=None)
         return render_template(
             "status",
             status_info,
             features_table=get_features_table(),
             dev_merged_status=get_dev_merged_status(),
-            testing_state=testing_state,
-            drift_info=drift_info,
+            testing_status=testing_status,
             is_maintainer=is_maintainer_user,
-            show_testing=show_testing,
+            show_testing=testing_status is not None and is_maintainer_user,
             deploy_triggered=bool(i.deploy_triggered),
             drift_refreshed=bool(i.drift_refreshed),
             jenkins_job_url=_JENKINS_JOB_URL,
-            has_pending=has_pending,
         )
 
 
@@ -207,43 +199,6 @@ class status_refresh(delegate.page):
             raise web.unauthorized()
         _evict_drift_cache()
         raise web.seeother("/status?drift_refreshed=1")
-
-
-def get_testing_status(
-    testing_state: TestingState | None = None,
-    drift_info: dict | None = None,
-) -> dict | None:
-    """Compose the testing-environment status payload.
-
-    Returns a dict with ``last_deploy_at``, ``has_pending``, and a list of
-    PRs (state fields merged with live drift info), or None if there is no
-    testing state file. Shared by the /status page and the FastAPI
-    testing-status API so they can't drift apart.
-    """
-    state = testing_state if testing_state is not None else _load_testing_state()
-    if not state:
-        return None
-    if drift_info is None:
-        drift_info, _ = _get_drift_info(state)
-    last_deploy = state.last_deploy_at
-    has_pending = any(
-        p.pull_latest_sha or p.pending_active is not None or drift_info.get(p.pr, {}).get("merged", False) or not last_deploy or p.added_at > last_deploy
-        for p in state.prs
-    )
-    return {
-        "last_deploy_at": last_deploy,
-        "has_pending": has_pending,
-        "prs": [
-            {
-                **p.to_dict(),
-                "head_sha": drift_info.get(p.pr, {}).get("head_sha", ""),
-                "drift": drift_info.get(p.pr, {}).get("drift", -1),
-                "merged": drift_info.get(p.pr, {}).get("merged", False),
-                "is_new": bool(last_deploy and p.added_at > last_deploy),
-            }
-            for p in state.prs
-        ],
-    }
 
 
 @functools.cache
@@ -414,6 +369,50 @@ def _load_testing_state() -> TestingState | None:
             )
         return TestingState.from_dict(data)
     return None
+
+
+@dataclass
+class TestingPRStatus(TestingPR):
+    """A TestingPR merged with live GitHub drift info and derived flags."""
+
+    head_sha: str = ""  # current branch HEAD (short SHA); empty if GitHub unavailable
+    drift: int = -1  # commits the pinned commit is behind HEAD; -1 if unknown
+    merged: bool = False  # PR has been merged into master
+    is_new: bool = False  # added since the last deploy
+
+
+@dataclass
+class TestingStatus:
+    """Status of the testing environment: what backs the /status deploy table and the JSON API."""
+
+    last_deploy_at: str  # ISO timestamp, empty if never deployed
+    prs: list[TestingPRStatus]
+    has_pending: bool  # any change that a deploy would apply
+
+
+def build_testing_status(state: TestingState, drift_info: dict) -> TestingStatus:
+    """Compose the testing-environment status from persisted state and live drift info. Pure."""
+    last_deploy = state.last_deploy_at
+    prs = [
+        TestingPRStatus(
+            **asdict(p),
+            head_sha=drift_info.get(p.pr, {}).get("head_sha", ""),
+            drift=drift_info.get(p.pr, {}).get("drift", -1),
+            merged=drift_info.get(p.pr, {}).get("merged", False),
+            is_new=bool(last_deploy and p.added_at > last_deploy),
+        )
+        for p in state.prs
+    ]
+    has_pending = any(p.pull_latest_sha or p.pending_active is not None or p.merged or not last_deploy or p.is_new for p in prs)
+    return TestingStatus(last_deploy_at=last_deploy, prs=prs, has_pending=has_pending)
+
+
+def load_testing_status() -> TestingStatus | None:
+    """Load the state file and live drift info; None if there is no state file."""
+    if (state := _load_testing_state()) is None:
+        return None
+    drift_info, _ = _get_drift_info(state)
+    return build_testing_status(state, drift_info)
 
 
 def _save_testing_state(state: TestingState) -> None:

--- a/openlibrary/templates/status.html
+++ b/openlibrary/templates/status.html
@@ -1,4 +1,4 @@
-$def with (status = {}, features_table = [], dev_merged_status=None, testing_state=None, drift_info=None, is_maintainer=False, show_testing=False, deploy_triggered=False, drift_refreshed=False, jenkins_job_url='', has_pending=False)
+$def with (status = {}, features_table = [], dev_merged_status=None, testing_status=None, is_maintainer=False, show_testing=False, deploy_triggered=False, drift_refreshed=False, jenkins_job_url='')
 $# Template entry point for /status page
 $var title: $_("Open Library server status")
 
@@ -68,8 +68,7 @@ $var title: $_("Open Library server status")
         <button type="submit">$_("Add PR(s)")</button>
       </form>
 
-    $if testing_state and testing_state.prs:
-      $ last_deploy_at = testing_state.last_deploy_at
+    $if testing_status and testing_status.prs:
       <form method="POST" id="testing-form">
         <table class="testing-table">
           <thead>
@@ -88,14 +87,9 @@ $var title: $_("Open Library server status")
             </tr>
           </thead>
           <tbody>
-            $for pr in testing_state.prs:
-              $ d = (drift_info or {}).get(pr.pr, {})
-              $ drift = d.get('drift', -1)
-              $ head_sha = d.get('head_sha', '')
-              $ merged = d.get('merged', False)
-              $ is_new = bool(last_deploy_at and pr.added_at > last_deploy_at)
-              $ row_class = 'row-merged' if merged else ('row-pending-enable' if pr.pending_active is True else ('row-pending-disable' if pr.pending_active is False else ('row-new' if is_new else ('' if pr.active else 'row-inactive'))))
-              $ row_class += (' drift-high' if drift > 5 else (' drift-low' if drift > 0 else ''))
+            $for pr in testing_status.prs:
+              $ row_class = 'row-merged' if pr.merged else ('row-pending-enable' if pr.pending_active is True else ('row-pending-disable' if pr.pending_active is False else ('row-new' if pr.is_new else ('' if pr.active else 'row-inactive'))))
+              $ row_class += (' drift-high' if pr.drift > 5 else (' drift-low' if pr.drift > 0 else ''))
               <tr class="$row_class.strip()">
                 $if is_maintainer:
                   <td><input type="checkbox" name="prs" value="$pr.pr"></td>
@@ -121,16 +115,16 @@ $var title: $_("Open Library server status")
                   $else:
                     <a href="https://github.com/internetarchive/openlibrary/commit/$pr.commit">$pr.short_commit</a>
                 </td>
-                <td>$head_sha</td>
+                <td>$pr.head_sha</td>
                 <td>
-                  $if drift == 0:
+                  $if pr.drift == 0:
                     $_("up to date")
-                  $elif drift < 0:
+                  $elif pr.drift < 0:
                     $_("unknown")
-                  $elif drift == 1:
+                  $elif pr.drift == 1:
                     $_("1 commit behind")
                   $else:
-                    $(_("%(count)s commits behind") % {"count": drift})
+                    $(_("%(count)s commits behind") % {"count": pr.drift})
                 </td>
                 <td>
                   $if pr.pending_active is True:
@@ -158,7 +152,7 @@ $var title: $_("Open Library server status")
           </div>
       </form>
 
-      $if is_maintainer and has_pending:
+      $if is_maintainer and testing_status.has_pending:
         <div class="testing-standalone" style="margin-top: 0.75em;">
           <form method="POST" action="/status/deploy" style="display:inline;">
             <button type="submit" class="cta-btn cta-btn--primary">$_("Deploy")</button>

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -39,38 +39,59 @@ def _make_state(prs=None, last_deploy_at="2026-08-05T18:00:00+00:00"):
     return status_module.TestingState(last_deploy_at=last_deploy_at, prs=prs or [_make_pr()])
 
 
-def test_get_testing_status_merges_drift_and_derived_fields():
+def test_build_testing_status_merges_drift_and_derived_fields():
+    state = _make_state()
+    drift_info = {state.prs[0].pr: {"head_sha": "abc1234", "drift": 2, "merged": False}}
+
+    result = status_module.build_testing_status(state, drift_info)
+
+    assert result.last_deploy_at == "2026-08-05T18:00:00+00:00"
+    assert result.has_pending is True  # added after last deploy
+    pr = result.prs[0]
+    assert (pr.head_sha, pr.drift, pr.merged, pr.is_new) == ("abc1234", 2, False, True)
+    assert (pr.title, pr.added_by) == ("Test PR", "openlibrary")
+
+
+def test_build_testing_status_missing_drift_uses_unknown_defaults():
+    state = _make_state(prs=[_make_pr(pr_number=13238, added_at="2026-08-01T00:00:00+00:00")])
+
+    result = status_module.build_testing_status(state, {})
+
+    pr = result.prs[0]
+    assert (pr.head_sha, pr.drift, pr.merged, pr.is_new) == ("", -1, False, False)
+    assert result.has_pending is False
+
+
+@pytest.mark.parametrize(
+    ("pr_kwargs", "drift", "last_deploy_at", "expected"),
+    [
+        ({}, {}, "2026-08-05T18:00:00+00:00", True),  # added since last deploy
+        ({"added_at": "2026-08-01T00:00:00+00:00"}, {}, "2026-08-05T18:00:00+00:00", False),
+        ({"added_at": "2026-08-01T00:00:00+00:00"}, {}, "", True),  # never deployed
+        ({"added_at": "2026-08-01T00:00:00+00:00"}, {"merged": True}, "2026-08-05T18:00:00+00:00", True),
+    ],
+)
+def test_build_testing_status_has_pending(pr_kwargs, drift, last_deploy_at, expected):
+    pr = _make_pr(**pr_kwargs)
+    result = status_module.build_testing_status(_make_state(prs=[pr], last_deploy_at=last_deploy_at), {pr.pr: drift})
+    assert result.has_pending is expected
+
+
+def test_load_testing_status_returns_none_without_state():
+    with patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=None):
+        assert status_module.load_testing_status() is None
+
+
+def test_load_testing_status_composes_state_and_drift():
     state = _make_state()
     drift_info = {state.prs[0].pr: {"head_sha": "abc1234", "drift": 2, "merged": False}}
     with (
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch("openlibrary.plugins.openlibrary.status._get_drift_info", return_value=(drift_info, False)),
     ):
-        payload = status_module.get_testing_status()
+        result = status_module.load_testing_status()
 
-    assert payload["last_deploy_at"] == "2026-08-05T18:00:00+00:00"
-    assert payload["has_pending"] is True  # added after last deploy
-    pr = payload["prs"][0]
-    assert pr["head_sha"] == "abc1234"
-    assert pr["drift"] == 2
-    assert pr["merged"] is False
-    assert pr["is_new"] is True
-    assert pr["title"] == "Test PR"
-    assert pr["added_by"] == "openlibrary"
-
-
-def test_get_testing_status_accepts_precomputed_state_and_drift():
-    state = _make_state(prs=[_make_pr(pr_number=13238)])
-    drift_info = {13238: {"head_sha": "", "drift": -1, "merged": True}}
-    payload = status_module.get_testing_status(state, drift_info)
-
-    assert payload["prs"][0]["drift"] == -1
-    assert payload["prs"][0]["merged"] is True
-
-
-def test_get_testing_status_returns_none_without_state():
-    with patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=None):
-        assert status_module.get_testing_status() is None
+    assert result.prs[0].drift == 2
 
 
 def test_ensure_testing_state_file_creates_empty_state(tmp_path, monkeypatch):
@@ -122,7 +143,13 @@ def test_setup_skips_state_file_creation_outside_local_dev(monkeypatch):
 
 def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=True)
-    payload = {
+    state = _make_state()
+    result = status_module.build_testing_status(state, {13269: {"head_sha": "abc1234", "drift": 2, "merged": False}})
+    with patch("openlibrary.fastapi.status.load_testing_status", return_value=result) as mock:
+        response = fastapi_client.get("/status/testing.json")
+
+    assert response.status_code == 200
+    assert response.json() == {
         "last_deploy_at": "2026-08-05T18:00:00+00:00",
         "has_pending": True,
         "prs": [
@@ -146,22 +173,13 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
             }
         ],
     }
-    with patch("openlibrary.fastapi.status.get_testing_status", return_value=payload) as mock:
-        response = fastapi_client.get("/status/testing.json")
-
-    assert response.status_code == 200
-    assert response.json() == payload
     mock.assert_called_once_with()
 
 
 def test_testing_status_endpoint_matches_response_model(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=True)
-    payload = {
-        "last_deploy_at": "",
-        "has_pending": False,
-        "prs": [_make_pr().to_dict()],
-    }
-    with patch("openlibrary.fastapi.status.get_testing_status", return_value=payload):
+    result = status_module.build_testing_status(_make_state(last_deploy_at=""), {})
+    with patch("openlibrary.fastapi.status.load_testing_status", return_value=result):
         response = fastapi_client.get("/status/testing.json")
 
     assert response.status_code == 200
@@ -170,7 +188,7 @@ def test_testing_status_endpoint_matches_response_model(fastapi_client, mock_aut
 
 def test_testing_status_endpoint_404_when_no_state(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=True)
-    with patch("openlibrary.fastapi.status.get_testing_status", return_value=None):
+    with patch("openlibrary.fastapi.status.load_testing_status", return_value=None):
         response = fastapi_client.get("/status/testing.json")
 
     assert response.status_code == 404
@@ -184,8 +202,7 @@ def test_testing_status_endpoint_requires_auth(fastapi_client):
 
 def test_testing_status_endpoint_forbidden_for_non_maintainer(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=False)
-    payload = {"last_deploy_at": "", "has_pending": False, "prs": []}
-    with patch("openlibrary.fastapi.status.get_testing_status", return_value=payload) as mock:
+    with patch("openlibrary.fastapi.status.load_testing_status") as mock:
         response = fastapi_client.get("/status/testing.json")
 
     assert response.status_code == 403


### PR DESCRIPTION
Follow-up to #13278 (base is that PR's branch, `testing-env/status-api`). Pure refactor — no user-visible change.

### The problem

#13278 introduced `get_testing_status()` so that the `/status` page and the new `/status/testing.json` API would share one source of truth for the testing-environment table. In practice they only half-shared it.

The page called the helper but kept just one value from it (`has_pending`). Everything else in the table — each row's drift, whether the PR was merged, whether it was new since the last deploy — was still computed a second time inside the template from the raw state objects. So the two surfaces had two copies of the same derivation logic and could quietly disagree, which is exactly what the helper was meant to prevent.

Two smaller things compounded that. The helper had two modes (it would go load the state file and call GitHub itself if you didn't hand it those inputs), so you couldn't tell from its signature whether calling it did I/O, and testing it meant patching private module functions. And the API built its payload by going through `TestingPR.to_dict()`, which is the serializer for the on-disk state file — it deliberately drops empty fields — so the shape of the JSON API was tied to the format of a local file.

### The idea

Compute the status **once, as a typed object**, and have both the page and the API render from that object. Separate "gather the inputs" (I/O) from "derive the status" (pure) so each is obvious and easy to test.

### What changed

`build_testing_status(state, drift_info)` is a pure function that returns a `TestingStatus` — a small dataclass holding `last_deploy_at`, `has_pending`, and a list of `TestingPRStatus` (a `TestingPR` plus the live fields `head_sha`, `drift`, `merged`, `is_new`). It does no I/O; you can call it in a test with plain inputs and assert on attributes.

`load_testing_status()` is the one thin wrapper that reads the state file, fetches drift from GitHub, and calls the builder. It returns `None` when there's no state file, which is what the API turns into a 404 and the page turns into "don't show the section."

The page passes that single `testing_status` object to the template, and the template reads `pr.drift`, `pr.merged`, `pr.is_new` directly. The per-row re-derivation and the separate `drift_info` / `has_pending` / `testing_state` template args are gone. The API validates its pydantic response straight from the same object (`from_attributes=True`), so it no longer goes through the file serializer.

```mermaid
flowchart LR
    F["_testing-prs.json"] --> L["load_testing_status"]
    G["GitHub drift"] --> L
    L --> B["build_testing_status<br/>pure, typed"]
    B --> P["/status page"]
    B --> A["/status/testing.json"]
```

Net effect: one place defines what a PR's status is, one place fetches inputs, and the two surfaces literally cannot drift.

### Technical

Pattern worth reusing for other page/API pairs: a pure `build_*` that returns a typed domain object, a thin `load_*` that does the I/O, and a pydantic response model that validates from that object rather than from a hand-built dict.

### Testing

- `pytest openlibrary/tests/fastapi/test_testing_status.py openlibrary/tests/fastapi/test_auth.py` — 37 passed. The helper tests now call `build_testing_status` with real inputs (no private patching), including a parametrized `has_pending` matrix and a missing-drift default case.
- Full `make test-py`: 5774 passed; the only failure (`test_home.py::test_home_template`) is pre-existing on master.
- Live in dev: `/status` renders the rows and Deploy button as before; `/status/testing.json` returns 200 with the full payload as maintainer and 401 without a cookie.

### Screenshot

n/a — page markup unchanged.

### Stakeholders

<!-- to be added -->
