### PR TITLE
test: intentionally conflicting with #13344 (do not merge)

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -35,7 +35,7 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
         $# For the Works & Editions page, only use ground_truth_availability API for selected Edition
         $# if edition availability status is error
         $ render_times['databarWork: LoanStatus'] = time()
-        $ expensive_check = page.get('availability', {}).get('status') in ['error']
+        $ expensive_check = editions_page and page.get('availability', {}).get('status') in ['error']
         $:macros.LoanStatus(page, allow_expensive_availability_check=expensive_check, secondary_action=editions_page, check_loan_status=editions_page, post=lists_widget, lending_state=lending_state)
         $ render_times['databarWork: LoanStatus'] = time() - render_times['databarWork: LoanStatus']
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -756,7 +756,10 @@ class Work(models.Work):
         # via editions-search, we can sidestep get_availability to only
         # check availability for borrowable editions
         ocaids = [ed.ocaid for ed in editions if ed.ocaid]
-        availability = lending.get_availability("identifier", ocaids)
+        # Batch availability requests to avoid overloading the lending API
+        availability = {}
+        for i in range(0, len(ocaids), 50):
+            availability.update(lending.get_availability("identifier", ocaids[i : i + 50]))
         for ed in editions:
             ed.availability = availability.get(ed.ocaid) or {"status": "error"}
 


### PR DESCRIPTION
**DO NOT MERGE** — test PR for merge-conflict resolution workflow.

This PR intentionally modifies the **same lines** in the **same files** as #13344 ("Disable IA availability request from get_sorted_editions") but with different changes, so that merging both will produce a merge conflict:

- `openlibrary/plugins/upstream/models.py` — batches IA availability requests in `get_sorted_editions` (same block #13344 rewrites to use Solr `ebook_access`)
- `openlibrary/macros/databarWork.html` — restricts the expensive availability check to the editions page (same line #13344 removes)

Created to verify GitHub's conflict detection and our resolution workflow. Close without merging once testing is complete.