### PR TITLE
Make author works.json endpoint async end-to-end

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -35,8 +35,7 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
-from openlibrary.plugins.openlibrary.api import author_works as legacy_author_works
-from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async
+from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async, get_works_data_async
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
 from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
 from openlibrary.plugins.openlibrary.api import work_editions as legacy_work_editions
@@ -322,14 +321,14 @@ def work_editions(
 
 
 @router.get("/authors/OL{author_id}A/works.json", response_model=PaginatedGroupEntryResponse, response_model_exclude_none=True)
-def author_works(
+async def author_works(
     request: Request,
     author_id: Annotated[int, Path(ge=0)],
     limit: Annotated[int, Query(ge=0, le=1000, description="Maximum number of works to return")] = 50,
     offset: Annotated[int, Query(ge=0, description="Number of works to skip")] = 0,
 ) -> PaginatedGroupEntryResponse:
     """Get paginated works for an author."""
-    data = legacy_author_works.get_works_data(
+    data = await get_works_data_async(
         f"/authors/OL{author_id}A",
         url=request.url,
         limit=limit,

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -47,6 +47,7 @@ from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.plugins.openlibrary.home import get_cached_featured_subjects
 from openlibrary.utils import extract_numeric_id_from_olid
+from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.request_context import req_context, site
 
@@ -288,7 +289,7 @@ class author_works(delegate.page):
 
     def GET(self, key):
         i = web.input(limit=50, offset=0)
-        data = self.get_works_data(
+        data = get_works_data(
             key,
             url=URL(web.ctx.fullpath),
             limit=h.safeint(i.limit, 50),
@@ -298,36 +299,40 @@ class author_works(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
         return delegate.RawText(json.dumps(data), content_type="application/json")
 
-    @staticmethod
-    def get_works_data(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
-        current_site = site.get()
-        author = current_site.get(key)
-        if not author or author.type.key != "/type/author":
-            return None
 
-        limit = min(limit, 1000)
-        keys = current_site.things(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": author.key}},
-                "limit": limit,
-                "offset": offset,
-            }
-        )
-        works = current_site.get_many(keys, raw=True)
-        size = author.get_work_count()
+async def get_works_data_async(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
+    """Get paginated works for an author, shared by the legacy and FastAPI works.json endpoints."""
+    current_site = site.get()
+    author = current_site.get(key)
+    if not author or author.type.key != "/type/author":
+        return None
 
-        url = url.replace(scheme="", netloc="")
-        links = {
-            "self": str(url),
-            "author": author.key,
+    limit = min(limit, 1000)
+    keys = current_site.things(
+        {
+            "type": "/type/work",
+            "authors": {"author": {"key": author.key}},
+            "limit": limit,
+            "offset": offset,
         }
-        if offset > 0:
-            links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
-        if offset + len(works) < size:
-            links["next"] = str(url.include_query_params(offset=offset + limit))
+    )
+    works = current_site.get_many(keys, raw=True)
+    size = await author.get_work_count()
 
-        return {"links": links, "size": size, "entries": works}
+    url = url.replace(scheme="", netloc="")
+    links = {
+        "self": str(url),
+        "author": author.key,
+    }
+    if offset > 0:
+        links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
+    if offset + len(works) < size:
+        links["next"] = str(url.include_query_params(offset=offset + limit))
+
+    return {"links": links, "size": size, "entries": works}
+
+
+get_works_data = async_bridge.wrap(get_works_data_async)
 
 
 async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -18,7 +18,7 @@ from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream import borrow
 from openlibrary.plugins.upstream.table_of_contents import TableOfContents
 from openlibrary.plugins.upstream.utils import MultiDict, get_identifier_config
-from openlibrary.plugins.worksearch.code import works_by_author
+from openlibrary.plugins.worksearch.code import works_by_author, works_by_author_async
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.solr.solr_types import SolrDocument
@@ -536,10 +536,10 @@ class Author(models.Author):
             request_label="AUTHOR_BOOKS_READABLE_COUNT",
         ).num_found
 
-    def get_work_count(self):
+    async def get_work_count(self):
         """Returns the number of works by this author."""
         # TODO: avoid duplicate works_by_author calls
-        result = works_by_author(self.get_olid(), rows=0)
+        result = await works_by_author_async(self.get_olid(), rows=0)
         return result.num_found
 
     def as_fake_solr_record(self):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -20,7 +20,7 @@ from infogami.utils import delegate
 from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core import cache
 from openlibrary.core.env import get_ol_env
-from openlibrary.core.lending import add_availability, add_availability_async
+from openlibrary.core.lending import add_availability_async
 from openlibrary.core.models import Edition
 from openlibrary.fastapi.models import SolrInternalsParams
 from openlibrary.i18n import gettext as _
@@ -899,7 +899,7 @@ class search(delegate.page):
         )
 
 
-def works_by_author(
+async def works_by_author_async(
     akey: str,
     sort="editions",
     page=1,
@@ -909,11 +909,12 @@ def works_by_author(
     query: str | None = None,
     request_label: SolrRequestLabel = "UNLABELLED",
 ):
+    """Search Solr for an author's works, enriched with availability."""
     param = {"q": query or "*:*"}
     if has_fulltext:
         param["has_fulltext"] = "true"
 
-    result = run_solr_query(
+    result = await run_solr_query_async(
         WorkSearchScheme(),
         param=param,
         page=page,
@@ -937,8 +938,11 @@ def works_by_author(
     )
 
     result.docs = [get_doc(doc) for doc in result.docs]
-    add_availability([(work.get("editions") or [None])[0] or work for work in result.docs])
+    await add_availability_async([(work.get("editions") or [None])[0] or work for work in result.docs])
     return result
+
+
+works_by_author = async_bridge.wrap(works_by_author_async)
 
 
 def top_books_from_author(akey: str, rows=5) -> SearchResponse:

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -1,6 +1,6 @@
 """Tests for the FastAPI work editions and author works endpoints."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from starlette.datastructures import URL
@@ -169,7 +169,7 @@ class TestAuthorWorks:
 
     def test_uses_default_pagination(self, fastapi_client, patched_site):
         entries = [{"key": "/works/OL1W", "title": "Test Work"}]
-        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
         patched_site.get.return_value = current_site
         response = fastapi_client.get(self.ENDPOINT)
 
@@ -185,7 +185,7 @@ class TestAuthorWorks:
 
     def test_caps_limit_and_preserves_legacy_links(self, fastapi_client, patched_site):
         entries = [{"key": "/works/OL1W"}]
-        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2000), thing_keys=["/works/OL1W"], entries=entries)
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=2000), thing_keys=["/works/OL1W"], entries=entries)
         patched_site.get.return_value = current_site
         response = fastapi_client.get(f"{self.ENDPOINT}?limit=1000&offset=25")
 
@@ -204,7 +204,7 @@ class TestAuthorWorks:
 
     def test_zero_limit_passed_through(self, fastapi_client, patched_site):
         entries = [{"key": "/works/OL1W"}]
-        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
         patched_site.get.return_value = current_site
         response = fastapi_client.get(f"{self.ENDPOINT}?limit=0&offset=0")
 
@@ -217,7 +217,7 @@ class TestAuthorWorks:
         current_site.things.assert_called_once_with(self._things_query(0, 0))
 
     def test_rejects_invalid_pagination(self, fastapi_client, patched_site):
-        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=0))
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=0))
         patched_site.get.return_value = current_site
         response = fastapi_client.get(f"{self.ENDPOINT}?limit=abc&offset=xyz")
 
@@ -225,7 +225,7 @@ class TestAuthorWorks:
         current_site.get.assert_not_called()
 
     def test_rejects_negative_offset(self, fastapi_client, patched_site):
-        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=0))
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=0))
         patched_site.get.return_value = current_site
         response = fastapi_client.get(f"{self.ENDPOINT}?limit=10&offset=-5")
 
@@ -258,16 +258,16 @@ class TestAuthorWorks:
     def test_response_matches_legacy(self, fastapi_client, patched_site):
         entries = [{"key": "/works/OL1W"}]
 
-        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
+        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
         patched_site.get.return_value = legacy_site
-        legacy_response = legacy_api.author_works.get_works_data(
+        legacy_response = legacy_api.get_works_data(
             self.DOC_KEY,
             url=URL(f"{self.ENDPOINT}?limit=1&offset=0"),
             limit=1,
             offset=0,
         )
 
-        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
+        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
         patched_site.get.return_value = fastapi_site
         fastapi_response = fastapi_client.get(f"{self.ENDPOINT}?limit=1&offset=0")
 


### PR DESCRIPTION
The FastAPI `/authors/{id}/works.json` endpoint was running synchronous code that serialized requests through the AsyncBridge's single background event loop.

- Make the endpoint truly async and add `works_by_author_async` (awaits the Solr query + availability fetch natively)
- Make `Author.get_work_count` async
- Legacy web.py endpoint now calls the same async function via `async_bridge.wrap` — no duplicated sync logic

Fixes the `<asyncio.locks.Event object at 0x7fe553a6dc70 [unset]> is bound to a different event loop` we are seeing on production since we flipped to fastapi