### PR TITLE
Enhance FastAPI app metadata for better OpenAPI documentation

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -160,8 +160,15 @@ def create_app() -> FastAPI | None:
             raise
 
     app = FastAPI(
-        title="OpenLibrary ASGI",
-        version="0.0.1",
+        title="Open Library API",
+        description=(
+            "The Open Library API provides comprehensive access to library catalog data including "
+            "books, authors, works, lists, and user data. Supports both public and authenticated "
+            "endpoints with full data validation and type safety."
+        ),
+        version="1.0.0",
+        contact={"name": "Open Library Team", "url": "https://openlibrary.org", "email": "support@openlibrary.org"},
+        license_info={"name": "AGPL-3.0", "url": "https://github.com/internetarchive/openlibrary/blob/master/LICENSE"},
         debug=os.environ.get("LOCAL_DEV", "false").lower() == "true",
         lifespan=lifespan,
         strict_content_type=False,  # A breaking change and not applicable to our app. See: https://fastapi.tiangolo.com/advanced/strict-content-type/

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -167,7 +167,7 @@ def create_app() -> FastAPI | None:
             "endpoints with full data validation and type safety."
         ),
         version="1.0.0",
-        contact={"name": "Open Library Team", "url": "https://openlibrary.org", "email": "support@openlibrary.org"},
+        contact={"name": "Open Library Team", "url": "https://openlibrary.org", "email": "openlibrary@archive.org"},
         license_info={"name": "AGPL-3.0", "url": "https://github.com/internetarchive/openlibrary/blob/master/LICENSE"},
         debug=os.environ.get("LOCAL_DEV", "false").lower() == "true",
         lifespan=lifespan,


### PR DESCRIPTION
Improve the OpenAPI specification metadata to provide better developer experience and API discoverability.

## Changes
- Update title from "OpenLibrary ASGI" to "Open Library API"
- Increment version from "0.0.1" to "1.0.0" for meaningful semantic versioning
- Add comprehensive description of API capabilities and data access
- Include contact information (name, URL, email)
- Add license information (AGPL-3.0 with GitHub link)

## Impact
This enhancement makes the API documentation more discoverable and informative for developers using Swagger UI and other OpenAPI tools without changing any actual API behavior.

## Testing
- Verified updated metadata appears correctly in OpenAPI spec at http://localhost:18080/openapi.json
- All pre-commit hooks pass
- No API behavior changes