### PR TITLE
Status panel: undelete PRs and auto-remove closed ones

### DIFF
--- a/openlibrary/components/TestingEnvironment.vue
+++ b/openlibrary/components/TestingEnvironment.vue
@@ -45,7 +45,7 @@ const { toast, setToast } = useToast();
 // busy is a shared re-entrancy guard between status fetching and actions.
 const busy = shallowRef(false);
 const { view, payload, now, loadStatus, retry } = useTestingStatus(busy);
-const { refreshing, adding, deploying, addInput, togglePr, updatePr, removePr, deploy, refresh, addPrs } = useActions({
+const { refreshing, adding, deploying, addInput, togglePr, updatePr, removePr, restorePr, deploy, refresh, addPrs } = useActions({
     busy,
     loadStatus,
     setToast,
@@ -209,6 +209,7 @@ onBeforeUnmount(() => syncDeployFavicon(false));
                 @toggle="togglePr"
                 @update="updatePr"
                 @remove="removePr"
+                @restore="restorePr"
               />
             </tbody>
           </table>

--- a/openlibrary/components/TestingEnvironment/DeploySection.vue
+++ b/openlibrary/components/TestingEnvironment/DeploySection.vue
@@ -183,6 +183,10 @@ function prUrl(pr) {
             class="testing-env__change-detail"
           >{{ strings.mergedToMaster }}</span>
           <span
+            v-else-if="change.reason === 'closed'"
+            class="testing-env__change-detail"
+          >{{ strings.closedWithoutMerging }}</span>
+          <span
             v-else-if="change.detail"
             class="testing-env__change-detail testing-env__change-detail--sha"
           >{{ change.detail }}</span>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -30,6 +30,10 @@ const emit = defineEmits(['toggle', 'update', 'remove', 'restore']);
 
 const inSet = computed(() => props.pr.in_set !== false);
 
+// A staged removal makes the row read-only until deploy or restore: the
+// deploy drops it, so its toggle and pin controls would change nothing.
+const removalStaged = computed(() => props.pr.pending_remove === true);
+
 const liveNow = computed(() => props.pr.live_now === true);
 
 const mergeConflict = computed(() => props.pr.merge_conflict === true);
@@ -50,7 +54,7 @@ const isActive = computed(() => effectiveActive(props.pr));
 // `action`; any non-empty value means a change is staged for it.
 const pending = computed(() => Boolean(props.pr.action));
 
-const canUpdatePr = computed(() => canUpdate(props.pr));
+const canUpdatePr = computed(() => !removalStaged.value && canUpdate(props.pr));
 
 const pill = computed(() => driftPill(props.pr, props.strings));
 
@@ -68,7 +72,7 @@ function text(key, ...args) {
       class="testing-env__col-toggle"
     >
       <button
-        v-if="inSet"
+        v-if="inSet && !removalStaged"
         type="button"
         class="testing-env__switch"
         :aria-pressed="isActive ? 'true' : 'false'"
@@ -187,7 +191,7 @@ function text(key, ...args) {
       class="testing-env__col-actions"
     >
       <button
-        v-if="inSet"
+        v-if="inSet && !removalStaged"
         type="button"
         class="testing-env__row-action testing-env__row-action--danger"
         :title="strings.remove"
@@ -223,7 +227,7 @@ function text(key, ...args) {
         </svg>
       </button>
       <button
-        v-else
+        v-else-if="inSet"
         type="button"
         class="testing-env__row-action testing-env__row-action--restore"
         :title="strings.restore"

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -230,7 +230,21 @@ function text(key, ...args) {
         :aria-label="strings.restore"
         @click="emit('restore', pr)"
       >
-        ⏪
+        <svg
+          class="testing-env__btn-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
       </button>
     </td>
   </tr>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -230,21 +230,7 @@ function text(key, ...args) {
         :aria-label="strings.restore"
         @click="emit('restore', pr)"
       >
-        <svg
-          class="testing-env__btn-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-          <path d="M3 3v5h5" />
-        </svg>
+        ⏪
       </button>
     </td>
   </tr>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -162,7 +162,14 @@ function text(key, ...args) {
             </svg>
           </button>
           <span
-            v-if="pending"
+            v-if="pr.closed"
+            class="testing-env__pending testing-env__closed"
+            role="img"
+            :title="strings.closed"
+            :aria-label="strings.closed"
+          >⛔</span>
+          <span
+            v-else-if="pending"
             class="testing-env__pending"
             role="img"
             :title="strings.changeOnDeploy"

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -26,7 +26,7 @@ const props = defineProps({
     }
 });
 
-const emit = defineEmits(['toggle', 'update', 'remove']);
+const emit = defineEmits(['toggle', 'update', 'remove', 'restore']);
 
 const inSet = computed(() => props.pr.in_set !== false);
 
@@ -213,6 +213,30 @@ function text(key, ...args) {
             x2="14"
             y2="17"
           />
+        </svg>
+      </button>
+      <button
+        v-else
+        type="button"
+        class="testing-env__row-action testing-env__row-action--restore"
+        :title="strings.restore"
+        :aria-label="strings.restore"
+        @click="emit('restore', pr)"
+      >
+        <svg
+          class="testing-env__btn-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
         </svg>
       </button>
     </td>

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -11,7 +11,7 @@ const ACTION_ERRORS = {
 };
 
 /**
- * PR toggle, update, remove, deploy, refresh, and add actions.
+ * PR toggle, update, remove, restore, deploy, refresh, and add actions.
  *
  * @param {object}  opts
  * @param {import('vue').ShallowRef<boolean>} opts.busy       — shared re-entrancy guard
@@ -67,6 +67,13 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         runAction('/status/remove', { prs: [pr.pr] });
     }
 
+    // Undo a removal: a deleted row is still running on the box until the next
+    // deploy, so re-adding it puts it back in the testing set. The /status/add
+    // handler re-fetches the PR from GitHub, mirroring how the add box works.
+    function restorePr(pr) {
+        runAction('/status/add', { pr: String(pr.pr) });
+    }
+
     async function deploy() {
         if (busy.value) return;
         deploying.value = true;
@@ -111,6 +118,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         togglePr,
         updatePr,
         removePr,
+        restorePr,
         deploy,
         refresh,
         addPrs

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -67,9 +67,10 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         runAction('/status/remove', { prs: [pr.pr] });
     }
 
-    // Undo a removal: re-add via /status/add (the same path the add box uses).
+    // Undo a staged removal: the server just clears the flag, so the row's
+    // pinned commit and toggle state come back untouched.
     function restorePr(pr) {
-        runAction('/status/add', { pr: String(pr.pr) });
+        runAction('/status/restore', { prs: [pr.pr] });
     }
 
     async function deploy() {

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -67,9 +67,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         runAction('/status/remove', { prs: [pr.pr] });
     }
 
-    // Undo a removal: a deleted row is still running on the box until the next
-    // deploy, so re-adding it puts it back in the testing set. The /status/add
-    // handler re-fetches the PR from GitHub, mirroring how the add box works.
+    // Undo a removal: re-add via /status/add (the same path the add box uses).
     function restorePr(pr) {
         runAction('/status/add', { pr: String(pr.pr) });
     }

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -410,6 +410,12 @@ a.testing-env__pill:focus-visible {
   justify-self: center;
 }
 
+/* A closed (not merged) PR reads as finished-but-not-landed, so its lock
+   sits in the same slot as the staged-change hourglass but in a muted tint. */
+.testing-env__closed {
+  color: var(--color-text-muted);
+}
+
 /* Icon-only row actions (update / remove): bordered buttons, blue for update,
    red for remove on hover; tooltips ride in the title attribute. */
 .testing-env__row-action {

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -443,6 +443,14 @@ a.testing-env__pill:focus-visible {
   color: var(--color-error-fg);
 }
 
+/* Restore (undo a removal): same icon-only treatment, tinted green so a
+   non-destructive re-add reads differently from the red remove button. */
+.testing-env__row-action--restore:hover:not(:disabled) {
+  border-color: var(--color-success-fg);
+  background: var(--color-success-bg);
+  color: var(--color-success-fg);
+}
+
 /* Last of the row backgrounds: pointer feedback beats every state tint. */
 .testing-env__row:hover td {
   background: var(--color-control-hover);

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -410,8 +410,7 @@ a.testing-env__pill:focus-visible {
   justify-self: center;
 }
 
-/* A closed (not merged) PR reads as finished-but-not-landed, so its lock
-   sits in the same slot as the staged-change hourglass but in a muted tint. */
+/* A closed (not merged) PR reads in the same slot as the hourglass, muted. */
 .testing-env__closed {
   color: var(--color-text-muted);
 }
@@ -449,8 +448,7 @@ a.testing-env__pill:focus-visible {
   color: var(--color-error-fg);
 }
 
-/* Restore (undo a removal): same icon-only treatment, tinted green so a
-   non-destructive re-add reads differently from the red remove button. */
+/* Restore (undo a removal): green tint to read as non-destructive. */
 .testing-env__row-action--restore:hover:not(:disabled) {
   border-color: var(--color-success-fg);
   background: var(--color-success-bg);

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -30,6 +30,7 @@ export const DEFAULT_STRINGS = {
     liveNow: 'Live now',
     notLive: 'Not yet deployed',
     mergeConflict: 'Deploy failed (merge conflict)',
+    closed: 'This PR is already closed.',
     actions: 'Actions',
     ok: 'OK',
     prOnTesting: 'PR #%s on testing',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -39,6 +39,7 @@ export const DEFAULT_STRINGS = {
     enable: 'Enable',
     disable: 'Disable',
     remove: 'Remove',
+    restore: 'Restore',
     refresh: 'Refresh from GitHub',
     deploy: 'Deploy',
     changeOne: '%s change will be applied',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -47,6 +47,7 @@ export const DEFAULT_STRINGS = {
     changeMany: '%s changes will be applied',
     nothingToDeploy: 'Nothing to deploy — testing matches the current set.',
     mergedToMaster: 'merged to master',
+    closedWithoutMerging: 'closed without merging',
     unknown: 'Drift unknown, pinned at %s',
     currentCommit: 'Up-to-date, pinned at %s',
     behindOne: '%s commit behind %s',

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7460,6 +7460,10 @@ msgid "Deploy failed (merge conflict)"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
+msgid "This PR is already closed."
+msgstr ""
+
+#: TestingEnvironment.html.jinja
 msgid "OK"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7485,6 +7485,10 @@ msgid "Disable"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
+msgid "Restore"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
 msgid "Refresh from GitHub"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7519,6 +7519,10 @@ msgid "merged to master"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
+msgid "closed without merging"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
 #, python-format
 msgid "Drift unknown, pinned at %(sha)s"
 msgstr ""

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -40,6 +40,7 @@
     "changeMany": _("%(num)s changes will be applied", num="%s"),
     "nothingToDeploy": _("Nothing to deploy — testing matches the current set."),
     "mergedToMaster": _("merged to master"),
+    "closedWithoutMerging": _("closed without merging"),
     "unknown": _("Drift unknown, pinned at %(sha)s", sha="%s"),
     "currentCommit": _("Up-to-date, pinned at %(sha)s", sha="%s"),
     "behindOne": ngettext("%(num)s commit behind %(sha)s", "%(num)s commits behind %(sha)s", 1, num="%s", sha="%s"),

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -23,6 +23,7 @@
     "liveNow": _("Live now"),
     "notLive": _("Not yet deployed"),
     "mergeConflict": _("Deploy failed (merge conflict)"),
+    "closed": _("This PR is already closed."),
     "actions": _("Actions"),
     "ok": _("OK"),
     "prOnTesting": _("PR %(num)s on testing", num="%s"),

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -32,6 +32,7 @@
     "enable": _("Enable"),
     "disable": _("Disable"),
     "remove": _("Remove"),
+    "restore": _("Restore"),
     "refresh": _("Refresh from GitHub"),
     "deploy": _("Deploy"),
     "changeOne": _("%(num)s change will be applied", num="%s"),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -239,11 +239,7 @@ class status_deploy(delegate.page):
         # persist=False so the drift metadata refresh can never write staged
         # changes before Jenkins accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
-        state.prs = [
-            p
-            for p in state.prs
-            if not p.pending_remove and not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)
-        ]
+        state.prs = [p for p in state.prs if not p.pending_remove and not _drop_reason(drift_info.get(p.pr, {}))]
         # Apply all pending changes before deploying
         for p in state.prs:
             if p.pull_latest_sha:
@@ -312,6 +308,19 @@ def _live_now(state: TestingState, p: TestingPR) -> bool:
     return bool(state.last_deploy_at and p.added_at <= state.last_deploy_at)
 
 
+def _drop_reason(info: dict) -> str:
+    """Why the deploy drops a PR — ``merged`` or ``closed`` — or "" to keep it.
+
+    The deploy filter and the pending-change plan both consume this, so the
+    plan can never promise a drop the deploy doesn't perform, or vice versa.
+    """
+    if info.get("merged", False):
+        return "merged"
+    if info.get("closed", False):
+        return "closed"
+    return ""
+
+
 def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChange]:
     """The plan: what deploying would change, one entry per staged change.
 
@@ -328,11 +337,8 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     last_deploy = state.last_deploy_at
     changes: list[PendingChange] = []
     for p in state.prs:
-        if drift_info.get(p.pr, {}).get("merged", False):
-            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="merged", detail=""))
-            continue
-        if drift_info.get(p.pr, {}).get("closed", False):
-            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="closed", detail=""))
+        if reason := _drop_reason(drift_info.get(p.pr, {})):
+            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason=reason, detail=""))
             continue
         if p.pending_remove:
             # A staged removal drops the row on deploy, so nothing else staged

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -201,10 +201,9 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Decide merged/closed removals on the *un-mutated* state — `merged` and
-        # `closed` are independent of staged pins/toggles — and with persist=False,
-        # so the drift metadata refresh can never write staged changes to disk
-        # before Jenkins accepts the build.
+        # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
+        # drift metadata refresh can never write staged changes before Jenkins
+        # accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
         state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
         # Apply all pending changes before deploying
@@ -267,9 +266,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     """The plan: what deploying would change, one entry per staged change.
 
     Every row action writes staged intent that only status_deploy applies, so
-    this walks the same fields it flushes. A PR merged to master — or closed on
-    GitHub without a merge — is dropped by the deploy regardless of what else is
-    staged on it, so it yields one ``remove`` and nothing more.
+    this walks the same fields it flushes. A PR merged to master — or closed
+    without merging — is dropped on deploy regardless of what else is staged on
+    it, so it yields one ``remove`` and nothing more.
 
     Removal is the one action that stages nothing: it deletes the row. Those are
     recovered at the end by diffing ``state.deployed`` — what the last deploy
@@ -755,8 +754,7 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": head_sha[:7],
             "drift": drift,
             "merged": merged,
-            # Closing a PR also closes the GitHub issue's state, and a merge is
-            # itself a close — so "closed" means closed *without* being merged.
+            # A merge is itself a close, so "closed" means closed without merging.
             "closed": gh.get("state") == "closed" and not merged,
             "title": gh.get("title", f"PR #{pr.pr}"),
             "author": user.get("login", ""),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -201,12 +201,12 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Decide merged-removals on the *un-mutated* state — `merged` is
-        # independent of staged pins/toggles — and with persist=False, so the
-        # drift metadata refresh can never write staged changes to disk before
-        # Jenkins accepts the build.
+        # Decide merged/closed removals on the *un-mutated* state — `merged` and
+        # `closed` are independent of staged pins/toggles — and with persist=False,
+        # so the drift metadata refresh can never write staged changes to disk
+        # before Jenkins accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
-        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False)]
+        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
         # Apply all pending changes before deploying
         for p in state.prs:
             if p.pull_latest_sha:
@@ -267,9 +267,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     """The plan: what deploying would change, one entry per staged change.
 
     Every row action writes staged intent that only status_deploy applies, so
-    this walks the same fields it flushes. A PR merged to master is dropped by
-    the deploy regardless of what else is staged on it, so it yields one
-    ``remove`` and nothing more.
+    this walks the same fields it flushes. A PR merged to master — or closed on
+    GitHub without a merge — is dropped by the deploy regardless of what else is
+    staged on it, so it yields one ``remove`` and nothing more.
 
     Removal is the one action that stages nothing: it deletes the row. Those are
     recovered at the end by diffing ``state.deployed`` — what the last deploy
@@ -280,6 +280,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     for p in state.prs:
         if drift_info.get(p.pr, {}).get("merged", False):
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="merged", detail=""))
+            continue
+        if drift_info.get(p.pr, {}).get("closed", False):
+            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="closed", detail=""))
             continue
         if not last_deploy or p.added_at > last_deploy:
             # A pin staged on a PR that isn't live yet isn't a separate change:
@@ -450,6 +453,7 @@ class TestingPRStatus(TestingPR):
     is_new: bool = False  # added since the last deploy
     live_now: bool = False  # the last deploy put this PR on the box
     merge_conflict: bool = False  # the last deploy's merge of this PR conflicted, so it did not land
+    closed: bool = False  # the PR was closed on GitHub without being merged; the next deploy drops it
     action: str = ""  # what the next deploy does with this row: add, pin, enable, disable, remove, or empty
     in_set: bool = True  # False for rows dropped from the set but still on the box
 
@@ -461,7 +465,7 @@ class PendingChange(BaseModel):
     title: str
     kind: str  # add, pin, enable, disable, remove
     detail: str = ""  # short SHA for add/pin changes; empty otherwise
-    reason: str = ""  # why a removal is staged: merged or dropped; empty otherwise
+    reason: str = ""  # why a removal is staged: merged, closed, or dropped; empty otherwise
 
 
 class TestingStatus(BaseModel):
@@ -520,6 +524,7 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
             is_new=bool(last_deploy and p.added_at > last_deploy),
             live_now=p.pr in state.deployed or (not deployed_record and bool(last_deploy and p.added_at <= last_deploy)),
             merge_conflict=p.pr in merge_conflicts,
+            closed=drift_info.get(p.pr, {}).get("closed", False),
             action=actions.get(p.pr, ""),
             in_set=True,
         )
@@ -667,7 +672,7 @@ async def _get_drift_info_async(state: TestingState, persist: bool = True) -> tu
     state_changed = False
     infos = await asyncio.gather(*(_get_pr_drift_async(p) for p in state.prs))
     for p, info in zip(state.prs, infos):
-        drift[p.pr] = {k: info[k] for k in ("head_sha", "drift", "merged")}
+        drift[p.pr] = {k: info[k] for k in ("head_sha", "drift", "merged", "closed")}
         for attr in ("title", "author", "author_avatar", "assignee", "assignee_avatar"):
             new_val = info.get(attr, "")
             if new_val and getattr(p, attr) != new_val:
@@ -750,6 +755,9 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": head_sha[:7],
             "drift": drift,
             "merged": merged,
+            # Closing a PR also closes the GitHub issue's state, and a merge is
+            # itself a close — so "closed" means closed *without* being merged.
+            "closed": gh.get("state") == "closed" and not merged,
             "title": gh.get("title", f"PR #{pr.pr}"),
             "author": user.get("login", ""),
             "author_avatar": user.get("avatar_url", ""),
@@ -761,6 +769,7 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": "",
             "drift": -1,
             "merged": False,
+            "closed": False,
             "title": "",
             "author": "",
             "author_avatar": "",

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -89,6 +89,10 @@ class status_add(delegate.page):
             raise web.badrequest()
         state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
         existing = {p.pr for p in state.prs}
+        # Re-adding a PR whose removal is staged is an undo, not a new add.
+        for p in state.prs:
+            if p.pr in pr_numbers:
+                p.pending_remove = False
         user = get_current_user()
         failed = []
         for pr_number in pr_numbers:
@@ -130,9 +134,39 @@ class status_remove(delegate.page):
             raise web.unauthorized()
         i = web.input(prs=[])
         to_remove = {int(p) for p in i.prs}
-        if state := _load_testing_state():
-            state.prs = [p for p in state.prs if p.pr not in to_remove]
-            _save_testing_state(state)
+        state = _load_testing_state()
+        if not state or not to_remove:
+            return _json_ok()
+        # Removing a live PR stages the removal — the deploy deletes the row —
+        # so restore is a true undo: the pin and toggle state survive. A PR
+        # that never reached the box has nothing to undo and drops outright.
+        kept = []
+        for p in state.prs:
+            if p.pr in to_remove:
+                if not _live_now(state, p):
+                    continue
+                p.pending_remove = True
+            kept.append(p)
+        state.prs = kept
+        _save_testing_state(state)
+        return _json_ok()
+
+
+class status_restore(delegate.page):
+    path = "/status/restore"
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(prs=[])
+        to_restore = {int(p) for p in i.prs}
+        state = _load_testing_state()
+        if not state or not to_restore:
+            return _json_ok()
+        for p in state.prs:
+            if p.pr in to_restore:
+                p.pending_remove = False
+        _save_testing_state(state)
         return _json_ok()
 
 
@@ -201,11 +235,15 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
-        # drift metadata refresh can never write staged changes before Jenkins
-        # accepts the build.
+        # Drop staged removals and merged/closed PRs on the *un-mutated* state;
+        # persist=False so the drift metadata refresh can never write staged
+        # changes before Jenkins accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
-        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
+        state.prs = [
+            p
+            for p in state.prs
+            if not p.pending_remove and not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)
+        ]
         # Apply all pending changes before deploying
         for p in state.prs:
             if p.pull_latest_sha:
@@ -262,6 +300,18 @@ def _is_deploying(state: TestingState) -> bool:
     return False
 
 
+def _live_now(state: TestingState, p: TestingPR) -> bool:
+    """Whether the last deploy put this PR on the box.
+
+    A populated ``deployed`` record is authoritative. The record postdates most
+    state files, so an empty one means "pre-record" rather than "nothing was
+    ever deployed": anything added before the last deploy was part of it.
+    """
+    if state.deployed:
+        return p.pr in state.deployed
+    return bool(state.last_deploy_at and p.added_at <= state.last_deploy_at)
+
+
 def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChange]:
     """The plan: what deploying would change, one entry per staged change.
 
@@ -270,9 +320,10 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     without merging — is dropped on deploy regardless of what else is staged on
     it, so it yields one ``remove`` and nothing more.
 
-    Removal is the one action that stages nothing: it deletes the row. Those are
-    recovered at the end by diffing ``state.deployed`` — what the last deploy
-    built — against what is left.
+    Removal is staged like everything else: ``pending_remove`` marks the row
+    and the deploy deletes it. Rows removed outright by code that predates the
+    flag survive only in ``state.deployed``; those are recovered at the end by
+    diffing it — what the last deploy built — against what is left.
     """
     last_deploy = state.last_deploy_at
     changes: list[PendingChange] = []
@@ -283,6 +334,11 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
         if drift_info.get(p.pr, {}).get("closed", False):
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="closed", detail=""))
             continue
+        if p.pending_remove:
+            # A staged removal drops the row on deploy, so nothing else staged
+            # on it matters. No reason: this one the maintainer asked for.
+            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", detail=""))
+            continue
         if not last_deploy or p.added_at > last_deploy:
             # A pin staged on a PR that isn't live yet isn't a separate change:
             # it's just the SHA the PR lands at, so report the effective one.
@@ -291,9 +347,10 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="pin", detail=p.short_pull_latest))
         if (toggle := p.pending_toggle) is not None:
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="enable" if toggle else "disable", detail=""))
-    # Deployed but no longer in the set: removed, and still on the box until the
-    # next deploy drops it. State files written before `deployed` existed start
-    # empty here, so their first deploy is what makes removals visible.
+    # Deployed but no longer in the set: removed outright by pre-`pending_remove`
+    # code, and still on the box until the next deploy drops it. State files
+    # written before `deployed` existed start empty here, so their first deploy
+    # is what makes removals visible.
     # ``reason`` separates these from the merged ones above, which are the same
     # kind for a different cause and must not borrow each other's wording.
     remaining = {p.pr for p in state.prs}
@@ -383,6 +440,7 @@ class TestingPR(BaseModel):
     added_by: str = ""  # OL username
     pull_latest_sha: str = ""  # pending SHA from "Fetch Latest"; applied on deploy
     pending_active: bool | None = None  # pending enable/disable; applied on deploy
+    pending_remove: bool = False  # staged removal; the deploy deletes the row
     author: str = ""  # GitHub login of PR author
     author_avatar: str = ""  # GitHub avatar URL (append &s=N for sizing)
     assignee: str = ""  # GitHub login of assignee, empty if unassigned
@@ -423,9 +481,9 @@ class TestingState(BaseModel):
     prs: list[TestingPR] = Field(default_factory=list)
     # Set only when Jenkins accepted a build; self-expires after _DEPLOY_WINDOW.
     deploy_started_at: str = ""
-    # {pr number: title} of what the last deploy actually built. Removing a PR
-    # deletes it from `prs` outright, so this is the only record that the box is
-    # still running it — without it a removal is invisible and undeployable.
+    # {pr number: title} of what the last deploy actually built — what
+    # `live_now` renders from. Rows removed outright by code that predates
+    # `pending_remove` survive only here, as read-only dropped rows.
     deployed: dict[int, str] = Field(default_factory=dict)
 
 
@@ -508,12 +566,6 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
     for change in pending_changes:
         actions.setdefault(change.pr, change.kind)
     remaining = {p.pr for p in state.prs}
-    # The `deployed` record postdates most state files, so an empty one means
-    # "pre-record" rather than "nothing was ever deployed": infer what the last
-    # deploy built the same way _pending_changes does — anything added before it
-    # was part of it. A populated record is authoritative (it also catches PRs
-    # deployed then removed, which no longer exist in prs).
-    deployed_record = bool(state.deployed)
     prs = [
         TestingPRStatus(
             **p.model_dump(),
@@ -521,7 +573,7 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
             drift=drift_info.get(p.pr, {}).get("drift", -1),
             merged=drift_info.get(p.pr, {}).get("merged", False),
             is_new=bool(last_deploy and p.added_at > last_deploy),
-            live_now=p.pr in state.deployed or (not deployed_record and bool(last_deploy and p.added_at <= last_deploy)),
+            live_now=_live_now(state, p),
             merge_conflict=p.pr in merge_conflicts,
             closed=drift_info.get(p.pr, {}).get("closed", False),
             action=actions.get(p.pr, ""),
@@ -529,8 +581,9 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
         )
         for p in state.prs
     ]
-    # Deployed but no longer in the set: the deploy drops them from the box, so
-    # they get a read-only row flagged for removal rather than vanishing.
+    # Deployed but no longer in the set (removed outright by pre-`pending_remove`
+    # code): the deploy drops them from the box, so they get a read-only row
+    # flagged for removal rather than vanishing.
     for pr, title in state.deployed.items():
         if pr not in remaining:
             prs.append(
@@ -543,6 +596,7 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
                     added_by="",
                     pull_latest_sha="",
                     pending_active=None,
+                    pending_remove=False,
                     author="",
                     author_avatar="",
                     assignee="",

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -276,6 +276,19 @@ def test_pending_changes_closed_pr_yields_only_a_removal():
     assert [(c.kind, c.reason) for c in changes] == [("remove", "closed")]
 
 
+def test_pending_changes_staged_removal_yields_only_a_removal():
+    """A staged removal drops the row on deploy, so nothing else staged on it matters."""
+    pr = _make_pr(pr_number=13238, added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_remove = True
+    pr.pull_latest_sha = "9f8e7d6c5b4a39281706f5e4d3c2b1a098765432"
+    state = _make_state(prs=[pr])
+
+    changes = status_module._pending_changes(state, {})
+
+    # No reason: unlike merged/closed, this removal the maintainer asked for.
+    assert [(c.kind, c.reason) for c in changes] == [("remove", "")]
+
+
 def test_build_testing_status_marks_closed_prs():
     """A closed PR carries the closed flag and reads as a pending removal."""
     pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
@@ -331,6 +344,27 @@ def test_deploy_drops_closed_prs():
         status_module.status_deploy().POST()
 
     assert state.prs == []
+
+
+def test_deploy_drops_staged_removals():
+    """Deploying deletes rows whose removal is staged; the rest survive."""
+    doomed = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    doomed.pending_remove = True
+    survivor = _make_pr(pr_number=13238, added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[doomed, survivor])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._get_drift_info", return_value=({}, False)),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+    ):
+        status_module.status_deploy().POST()
+
+    assert [p.pr for p in state.prs] == [13238]
+    assert state.deployed == {13238: survivor.title}
 
 
 def test_pending_changes_folds_a_pin_into_an_unlanded_add():
@@ -407,6 +441,20 @@ def test_payload_action_mirrors_the_plan_kinds():
     actions = {p.pr: p.action for p in result.prs}
 
     assert actions == {13269: "add", 13238: "pin", 13240: "disable"}
+
+
+def test_payload_marks_a_staged_removal():
+    """The row stays in the set with its state intact, reading as a pending removal."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_remove = True
+    state = _make_state(prs=[pr])
+    state.deployed = {pr.pr: pr.title}
+
+    result = status_module.build_testing_status(state, {})
+    row = result.prs[0]
+
+    assert (row.pending_remove, row.in_set, row.action) == (True, True, "remove")
+    assert result.has_pending is True
 
 
 def test_payload_includes_dropped_prs_as_readonly_rows():
@@ -568,6 +616,87 @@ def test_add_skips_pr_and_marks_failure_when_github_errors():
     assert state.prs == []
 
 
+def test_remove_stages_a_removal_for_a_live_pr():
+    """Removing a deployed PR stages it: the row survives with its pin and toggle."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pull_latest_sha = "9f8e7d6c5b4a39281706f5e4d3c2b1a098765432"
+    state = _make_state(prs=[pr])
+    state.deployed = {pr.pr: pr.title}
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state") as mock_save,
+        patch("web.input", return_value=web.storage(prs=["13269"])),
+    ):
+        response = status_module.status_remove().POST()
+
+    assert json.loads(response["rawtext"]) == {"ok": True}
+    assert [p.pr for p in state.prs] == [13269]
+    assert state.prs[0].pending_remove is True
+    assert state.prs[0].pull_latest_sha == "9f8e7d6c5b4a39281706f5e4d3c2b1a098765432"
+    mock_save.assert_called_once_with(state)
+
+
+def test_remove_deletes_a_never_deployed_pr_outright():
+    """A PR that never reached the box has nothing to undo, so no staged removal."""
+    pr = _make_pr()  # added after last deploy
+    state = _make_state(prs=[pr])
+    state.deployed = {13238: "Other PR"}
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("web.input", return_value=web.storage(prs=["13269"])),
+    ):
+        status_module.status_remove().POST()
+
+    assert state.prs == []
+
+
+def test_restore_clears_a_staged_removal():
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_remove = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state") as mock_save,
+        patch("web.input", return_value=web.storage(prs=["13269"])),
+    ):
+        response = status_module.status_restore().POST()
+
+    assert json.loads(response["rawtext"]) == {"ok": True}
+    assert state.prs[0].pending_remove is False
+    mock_save.assert_called_once_with(state)
+
+
+def test_add_cancels_a_staged_removal():
+    """Re-adding a PR whose removal is staged is an undo, not a duplicate row."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_remove = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._get_pr_info") as mock_info,
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
+        patch("web.input", return_value=web.storage(pr="13269")),
+    ):
+        response = status_module.status_add().POST()
+
+    assert json.loads(response["rawtext"]) == {"ok": True}
+    assert [p.pr for p in state.prs] == [13269]
+    assert state.prs[0].pending_remove is False
+    # Already in the set: no GitHub fetch, no fresh row.
+    mock_info.assert_not_called()
+
+
 def test_deploy_unconfigured_answers_error_but_advances_state():
     """Local dev (no Jenkins token): state advances so the UI is exercisable,
     but the response says nothing was actually deployed."""
@@ -706,6 +835,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
                 "added_by": "openlibrary",
                 "pull_latest_sha": "",
                 "pending_active": None,
+                "pending_remove": False,
                 "author": "author",
                 "author_avatar": "",
                 "assignee": "assignee",

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -92,6 +92,7 @@ async def test_get_drift_info_fetches_prs_concurrently():
         "head_sha": "abc1234",
         "drift": 0,
         "merged": False,
+        "closed": False,
         "title": "Test PR",
         "author": "author",
         "author_avatar": "",
@@ -119,7 +120,7 @@ async def test_get_drift_info_fetches_prs_concurrently():
 
     assert from_cache is False
     assert peak > 1  # sequential awaits would never see overlap
-    assert drift == {p.pr: {"head_sha": "abc1234", "drift": 0, "merged": False} for p in state.prs}
+    assert drift == {p.pr: {"head_sha": "abc1234", "drift": 0, "merged": False, "closed": False} for p in state.prs}
 
 
 def test_build_testing_status_marks_merge_conflicts():
@@ -262,6 +263,74 @@ def test_pending_changes_merged_pr_yields_only_a_removal():
     changes = status_module._pending_changes(state, {13238: {"merged": True}})
 
     assert [c.kind for c in changes] == ["remove"]
+
+
+def test_pending_changes_closed_pr_yields_only_a_removal():
+    """A closed (not merged) PR is dropped on deploy just like a merged one."""
+    pr = _make_pr(pr_number=13238, added_at="2026-08-01T10:00:00+00:00")
+    pr.pull_latest_sha = "9f8e7d6c5b4a39281706f5e4d3c2b1a098765432"
+    state = _make_state(prs=[pr])
+
+    changes = status_module._pending_changes(state, {13238: {"merged": False, "closed": True}})
+
+    assert [(c.kind, c.reason) for c in changes] == [("remove", "closed")]
+
+
+def test_build_testing_status_marks_closed_prs():
+    """A closed PR carries the closed flag and reads as a pending removal."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    result = status_module.build_testing_status(state, {pr.pr: {"head_sha": "abc1234", "drift": 0, "merged": False, "closed": True}})
+
+    row = result.prs[0]
+    assert row.closed is True
+    assert row.action == "remove"
+    assert result.has_pending is True
+
+
+@pytest.mark.asyncio
+async def test_pr_drift_distinguishes_closed_from_merged():
+    """Merging closes a PR too; only a close without a merge counts as closed."""
+
+    async def fake_get(path):
+        if path.startswith("pulls/"):
+            return {"state": "closed", "merged": False, "merged_at": None, "head": {"sha": "abc1234"}, "user": {}, "assignee": {}, "title": "Closed PR"}
+        return {}  # compare response; no ahead_by → drift unknown
+
+    with patch("openlibrary.plugins.openlibrary.status._github_get_async", side_effect=fake_get):
+        assert (await status_module._get_pr_drift_async(_make_pr()))["closed"] is True
+
+    async def fake_get_merged(path):
+        if path.startswith("pulls/"):
+            return {"state": "closed", "merged": True, "merged_at": "2026-08-01", "head": {"sha": "abc1234"}, "user": {}, "assignee": {}, "title": "Merged PR"}
+        return {}
+
+    with patch("openlibrary.plugins.openlibrary.status._github_get_async", side_effect=fake_get_merged):
+        info = await status_module._get_pr_drift_async(_make_pr())
+    assert info["closed"] is False
+    assert info["merged"] is True
+
+
+def test_deploy_drops_closed_prs():
+    """Deploying removes closed (not merged) PRs from the set, like merged ones."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch(
+            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            return_value=({pr.pr: {"head_sha": "", "drift": 0, "merged": False, "closed": True}}, False),
+        ),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+    ):
+        status_module.status_deploy().POST()
+
+    assert state.prs == []
 
 
 def test_pending_changes_folds_a_pin_into_an_unlanded_add():
@@ -644,6 +713,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
                 "head_sha": "abc1234",
                 "drift": 2,
                 "merged": False,
+                "closed": False,
                 "is_new": True,
                 "live_now": False,
                 "merge_conflict": False,


### PR DESCRIPTION
Two small status-page (/status testing environment) improvements:

- **Undo (restore)** for a deleted PR: a removed-but-still-on-the-box row now gets a restore button that re-adds it to the testing set.
- **Closed PRs** (closed without merging) get a locked indicator in the drift column, and are removed from the set on the next deploy.


Bottom one is what it looks like when a PR is pending removal (deleted but you can undo it).
Annoyingly it loses your commit but I have to rework the backend to do that and I'll do that once we move this to fastapi (soon).

<img width="2208" height="522" alt="image" src="https://github.com/user-attachments/assets/afe37fc4-5d05-461c-bfa4-d6a47e289770" />
