### PR TITLE
migrate deploy api to fastapi

### DIFF
--- a/openlibrary/components/TestingEnvironment.vue
+++ b/openlibrary/components/TestingEnvironment.vue
@@ -45,7 +45,7 @@ const { toast, setToast } = useToast();
 // busy is a shared re-entrancy guard between status fetching and actions.
 const busy = shallowRef(false);
 const { view, payload, now, loadStatus, retry } = useTestingStatus(busy);
-const { refreshing, adding, deploying, addInput, togglePr, updatePr, removePr, deploy, refresh, addPrs } = useActions({
+const { refreshing, adding, deploying, addInput, togglePr, updatePr, removePr, restorePr, deploy, refresh, addPrs } = useActions({
     busy,
     loadStatus,
     setToast,
@@ -209,6 +209,7 @@ onBeforeUnmount(() => syncDeployFavicon(false));
                 @toggle="togglePr"
                 @update="updatePr"
                 @remove="removePr"
+                @restore="restorePr"
               />
             </tbody>
           </table>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -230,7 +230,21 @@ function text(key, ...args) {
         :aria-label="strings.restore"
         @click="emit('restore', pr)"
       >
-        ⏪
+        <svg
+          class="testing-env__btn-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
       </button>
     </td>
   </tr>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -6,6 +6,7 @@ import {
     canUpdate,
     driftPill,
     effectiveActive,
+    effectivePendingRemoval,
     sprintf
 } from './utils.js';
 
@@ -45,6 +46,9 @@ const dotLabel = computed(() => {
 // toggle when one is pending (the server emits pending_active then),
 // otherwise the live state. Clicking flips the row either way.
 const isActive = computed(() => effectiveActive(props.pr));
+
+// Whether this PR is staged for removal on the next deploy.
+const pendingRemoval = computed(() => effectivePendingRemoval(props.pr));
 
 // The server classifies what the next deploy does with this row in
 // `action`; any non-empty value means a change is staged for it.
@@ -169,6 +173,13 @@ function text(key, ...args) {
             :aria-label="strings.closed"
           >⛔</span>
           <span
+            v-else-if="pendingRemoval"
+            class="testing-env__pending testing-env__pending--removal"
+            role="img"
+            :title="strings.stagedRemoval"
+            :aria-label="strings.stagedRemoval"
+          >🗑️</span>
+          <span
             v-else-if="pending"
             class="testing-env__pending"
             role="img"
@@ -186,8 +197,34 @@ function text(key, ...args) {
       v-if="maintainer"
       class="testing-env__col-actions"
     >
+      <!-- Staged for removal: show cancel-removal button -->
       <button
-        v-if="inSet"
+        v-if="inSet && pendingRemoval"
+        type="button"
+        class="testing-env__row-action testing-env__row-action--restore"
+        :title="strings.unstageRemoval"
+        :aria-label="strings.unstageRemoval"
+        @click="emit('restore', pr)"
+      >
+        <svg
+          class="testing-env__btn-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
+      </button>
+      <!-- Normal: show trash button -->
+      <button
+        v-else-if="inSet"
         type="button"
         class="testing-env__row-action testing-env__row-action--danger"
         :title="strings.remove"
@@ -222,6 +259,7 @@ function text(key, ...args) {
           />
         </svg>
       </button>
+      <!-- Dropped from set (still on box): show restore button -->
       <button
         v-else
         type="button"

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -230,21 +230,7 @@ function text(key, ...args) {
         :aria-label="strings.restore"
         @click="emit('restore', pr)"
       >
-        <svg
-          class="testing-env__btn-icon"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-          <path d="M3 3v5h5" />
-        </svg>
+        ⏪
       </button>
     </td>
   </tr>

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -162,7 +162,14 @@ function text(key, ...args) {
             </svg>
           </button>
           <span
-            v-if="pending"
+            v-if="pr.closed"
+            class="testing-env__pending testing-env__closed"
+            role="img"
+            :title="strings.closed"
+            :aria-label="strings.closed"
+          >⛔</span>
+          <span
+            v-else-if="pending"
             class="testing-env__pending"
             role="img"
             :title="strings.changeOnDeploy"

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -26,7 +26,7 @@ const props = defineProps({
     }
 });
 
-const emit = defineEmits(['toggle', 'update', 'remove']);
+const emit = defineEmits(['toggle', 'update', 'remove', 'restore']);
 
 const inSet = computed(() => props.pr.in_set !== false);
 
@@ -213,6 +213,30 @@ function text(key, ...args) {
             x2="14"
             y2="17"
           />
+        </svg>
+      </button>
+      <button
+        v-else
+        type="button"
+        class="testing-env__row-action testing-env__row-action--restore"
+        :title="strings.restore"
+        :aria-label="strings.restore"
+        @click="emit('restore', pr)"
+      >
+        <svg
+          class="testing-env__btn-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
         </svg>
       </button>
     </td>

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -1,5 +1,5 @@
 import { shallowRef } from 'vue';
-import { effectiveActive, postAction } from '../utils.js';
+import { effectiveActive, patchAction, postAction } from '../utils.js';
 
 // The action endpoints answer {"ok": false, "error": "<code>"} for
 // business failures; map each code to the translated toast that
@@ -31,15 +31,40 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         return String(fmt).replace(/%s/g, () => (args.length ? args.shift() : '%s'));
     }
 
+    /**
+     * Run a form-encoded POST action, reload status, and toast on failure.
+     */
     async function runAction(action, fields) {
         if (busy.value) return false;
         busy.value = true;
         try {
             const result = await postAction(action, fields);
             await loadStatus(false, false, false);
-            // A business failure ({"ok": false, "error": "<code>"}) is a
-            // completed request, not a thrown fetch — say why instead of
-            // pretending the action landed.
+            if (result && result.ok === false) {
+                const key = ACTION_ERRORS[result.error] || 'actionFailed';
+                setToast(text(key));
+                return result;
+            }
+            return result;
+        } catch {
+            setToast(text('actionFailed'));
+            return false;
+        } finally {
+            busy.value = false;
+        }
+    }
+
+    /**
+     * Run a JSON PATCH action on a single PR, reload status, and toast on
+     * failure. Same error/reload contract as ``runAction`` but speaks JSON
+     * to the new REST endpoint.
+     */
+    async function patchPr(pr, fields) {
+        if (busy.value) return false;
+        busy.value = true;
+        try {
+            const result = await patchAction(`/status/prs/${pr.pr}`, fields);
+            await loadStatus(false, false, false);
             if (result && result.ok === false) {
                 const key = ACTION_ERRORS[result.error] || 'actionFailed';
                 setToast(text(key));
@@ -55,21 +80,19 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
     }
 
     function togglePr(pr) {
-        const action = effectiveActive(pr) ? '/status/disable' : '/status/enable';
-        runAction(action, { prs: [pr.pr] });
+        patchPr(pr, { active: !effectiveActive(pr) });
     }
 
     function updatePr(pr) {
-        runAction('/status/pull-latest', { prs: [pr.pr] });
+        patchPr(pr, { pull_latest: true });
     }
 
     function removePr(pr) {
-        runAction('/status/remove', { prs: [pr.pr] });
+        patchPr(pr, { pending_removal: true });
     }
 
-    // Undo a removal: re-add via /status/add (the same path the add box uses).
     function restorePr(pr) {
-        runAction('/status/add', { pr: String(pr.pr) });
+        patchPr(pr, { pending_removal: false });
     }
 
     async function deploy() {
@@ -98,7 +121,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         if (!value) return;
         adding.value = true;
         try {
-            const result = await runAction('/status/add', { pr: value });
+            const result = await runAction('/status/prs', { prs: [value] });
             // A failed add keeps the input so it's obvious the PR didn't land.
             if (result && result.ok) {
                 addInput.value = '';

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -11,7 +11,7 @@ const ACTION_ERRORS = {
 };
 
 /**
- * PR toggle, update, remove, deploy, refresh, and add actions.
+ * PR toggle, update, remove, restore, deploy, refresh, and add actions.
  *
  * @param {object}  opts
  * @param {import('vue').ShallowRef<boolean>} opts.busy       — shared re-entrancy guard
@@ -67,6 +67,13 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         runAction('/status/remove', { prs: [pr.pr] });
     }
 
+    // Undo a removal: a deleted row is still running on the box until the next
+    // deploy, so re-adding it puts it back in the testing set. The /status/add
+    // handler re-fetches the PR from GitHub, mirroring how the add box works.
+    function restorePr(pr) {
+        runAction('/status/add', { pr: String(pr.pr) });
+    }
+
     async function deploy() {
         if (busy.value) return;
         deploying.value = true;
@@ -111,6 +118,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         togglePr,
         updatePr,
         removePr,
+        restorePr,
         deploy,
         refresh,
         addPrs

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -1,5 +1,5 @@
 import { shallowRef } from 'vue';
-import { effectiveActive, patchAction, postAction } from '../utils.js';
+import { effectiveActive, patchAction, postAction, statusApiUrl } from '../utils.js';
 
 // The action endpoints answer {"ok": false, "error": "<code>"} for
 // business failures; map each code to the translated toast that
@@ -63,7 +63,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         if (busy.value) return false;
         busy.value = true;
         try {
-            const result = await patchAction(`/status/prs/${pr.pr}`, fields);
+            const result = await patchAction(statusApiUrl(`/status/prs/${pr.pr}`), fields);
             await loadStatus(false, false, false);
             if (result && result.ok === false) {
                 const key = ACTION_ERRORS[result.error] || 'actionFailed';
@@ -99,7 +99,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         if (busy.value) return;
         deploying.value = true;
         try {
-            await runAction('/status/deploy', {});
+            await runAction(statusApiUrl('/status/deploy'), {});
         } finally {
             deploying.value = false;
         }
@@ -109,7 +109,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         if (busy.value) return;
         refreshing.value = true;
         try {
-            await runAction('/status/refresh', {});
+            await runAction(statusApiUrl('/status/refresh'), {});
         } finally {
             refreshing.value = false;
         }
@@ -121,7 +121,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         if (!value) return;
         adding.value = true;
         try {
-            const result = await runAction('/status/prs', { prs: [value] });
+            const result = await runAction(statusApiUrl('/status/prs'), { prs: [value] });
             // A failed add keeps the input so it's obvious the PR didn't land.
             if (result && result.ok) {
                 addInput.value = '';

--- a/openlibrary/components/TestingEnvironment/composables/useActions.js
+++ b/openlibrary/components/TestingEnvironment/composables/useActions.js
@@ -67,9 +67,7 @@ export function useActions({ busy, loadStatus, setToast, strings }) {
         runAction('/status/remove', { prs: [pr.pr] });
     }
 
-    // Undo a removal: a deleted row is still running on the box until the next
-    // deploy, so re-adding it puts it back in the testing set. The /status/add
-    // handler re-fetches the PR from GitHub, mirroring how the add box works.
+    // Undo a removal: re-add via /status/add (the same path the add box uses).
     function restorePr(pr) {
         runAction('/status/add', { pr: String(pr.pr) });
     }

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -410,6 +410,12 @@ a.testing-env__pill:focus-visible {
   justify-self: center;
 }
 
+/* A closed (not merged) PR reads as finished-but-not-landed, so its lock
+   sits in the same slot as the staged-change hourglass but in a muted tint. */
+.testing-env__closed {
+  color: var(--color-text-muted);
+}
+
 /* Icon-only row actions (update / remove): bordered buttons, blue for update,
    red for remove on hover; tooltips ride in the title attribute. */
 .testing-env__row-action {

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -443,6 +443,14 @@ a.testing-env__pill:focus-visible {
   color: var(--color-error-fg);
 }
 
+/* Restore (undo a removal): same icon-only treatment, tinted green so a
+   non-destructive re-add reads differently from the red remove button. */
+.testing-env__row-action--restore:hover:not(:disabled) {
+  border-color: var(--color-success-fg);
+  background: var(--color-success-bg);
+  color: var(--color-success-fg);
+}
+
 /* Last of the row backgrounds: pointer feedback beats every state tint. */
 .testing-env__row:hover td {
   background: var(--color-control-hover);

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -415,6 +415,11 @@ a.testing-env__pill:focus-visible {
   color: var(--color-text-muted);
 }
 
+/* Staged removal: red-tinted to signal a destructive pending action. */
+.testing-env__pending--removal {
+  color: var(--color-error-fg);
+}
+
 /* Icon-only row actions (update / remove): bordered buttons, blue for update,
    red for remove on hover; tooltips ride in the title attribute. */
 .testing-env__row-action {

--- a/openlibrary/components/TestingEnvironment/styles.css
+++ b/openlibrary/components/TestingEnvironment/styles.css
@@ -410,8 +410,7 @@ a.testing-env__pill:focus-visible {
   justify-self: center;
 }
 
-/* A closed (not merged) PR reads as finished-but-not-landed, so its lock
-   sits in the same slot as the staged-change hourglass but in a muted tint. */
+/* A closed (not merged) PR reads in the same slot as the hourglass, muted. */
 .testing-env__closed {
   color: var(--color-text-muted);
 }
@@ -449,8 +448,7 @@ a.testing-env__pill:focus-visible {
   color: var(--color-error-fg);
 }
 
-/* Restore (undo a removal): same icon-only treatment, tinted green so a
-   non-destructive re-add reads differently from the red remove button. */
+/* Restore (undo a removal): green tint to read as non-destructive. */
 .testing-env__row-action--restore:hover:not(:disabled) {
   border-color: var(--color-success-fg);
   background: var(--color-success-bg);

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -41,6 +41,8 @@ export const DEFAULT_STRINGS = {
     disable: 'Disable',
     remove: 'Remove',
     restore: 'Restore',
+    stagedRemoval: 'Removal staged for next deploy',
+    unstageRemoval: 'Cancel staged removal',
     refresh: 'Refresh from GitHub',
     deploy: 'Deploy',
     changeOne: '%s change will be applied',
@@ -132,6 +134,26 @@ export async function postAction(action, fields = {}) {
     });
     if (!response.ok) {
         throw new Error(`${action} failed: ${response.status}`);
+    }
+    return response.json();
+}
+
+/**
+ * PATCH a resource with a JSON body. Used by the new REST-style endpoints
+ * (e.g. PATCH /status/prs/{id}) that accept partial updates.
+ */
+export async function patchAction(url, fields = {}) {
+    const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json'
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify(fields)
+    });
+    if (!response.ok) {
+        throw new Error(`${url} failed: ${response.status}`);
     }
     return response.json();
 }
@@ -267,6 +289,13 @@ export function effectiveActive(pr) {
     return pr.pending_active === undefined || pr.pending_active === null
         ? pr.active !== false
         : pr.pending_active;
+}
+
+/**
+ * Whether the PR is staged for removal on the next deploy.
+ */
+export function effectivePendingRemoval(pr) {
+    return pr.pending_removal === true;
 }
 
 /**

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -30,6 +30,7 @@ export const DEFAULT_STRINGS = {
     liveNow: 'Live now',
     notLive: 'Not yet deployed',
     mergeConflict: 'Deploy failed (merge conflict)',
+    closed: 'This PR is already closed.',
     actions: 'Actions',
     ok: 'OK',
     prOnTesting: 'PR #%s on testing',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -39,6 +39,7 @@ export const DEFAULT_STRINGS = {
     enable: 'Enable',
     disable: 'Disable',
     remove: 'Remove',
+    restore: 'Restore',
     refresh: 'Refresh from GitHub',
     deploy: 'Deploy',
     changeOne: '%s change will be applied',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -81,15 +81,20 @@ export function decodeAndParseJSON(str) {
 }
 
 /**
- * Return the same-origin JSON endpoint for the current deployment.
+ * Prefix a /status/* path with /_fast on the testing site.
  *
  * The testing site exposes FastAPI behind /_fast; local development proxies
  * the unprefixed path through web.py to the FastAPI container.
  */
+export function statusApiUrl(path, location = window.location) {
+    return location.hostname === 'testing.openlibrary.org' ? `/_fast${path}` : path;
+}
+
+/**
+ * Return the same-origin JSON endpoint for the current deployment.
+ */
 export function testingStatusUrl(location) {
-    return location.hostname === 'testing.openlibrary.org'
-        ? '/_fast/status/testing.json'
-        : '/status/testing.json';
+    return statusApiUrl('/status/testing.json', location);
 }
 
 /**

--- a/openlibrary/fastapi/status.py
+++ b/openlibrary/fastapi/status.py
@@ -18,7 +18,6 @@ from openlibrary.plugins.openlibrary.jenkins import jenkins_deploy_status
 from openlibrary.plugins.openlibrary.status import (
     TestingState,
     TestingStatus,
-    _evict_drift_cache,
     _get_pr_info_async,
     _load_testing_state,
     _parse_pr_numbers_from_string,
@@ -145,7 +144,6 @@ async def update_pr(pr_id: int, body: UpdatePRRequest, _: MaintainerDep) -> dict
 
     if changed:
         _save_testing_state(state)
-        _evict_drift_cache()
 
     return {"ok": True}
 

--- a/openlibrary/fastapi/status.py
+++ b/openlibrary/fastapi/status.py
@@ -8,26 +8,26 @@ via JSON without a browser.
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import datetime
 import os
-import re
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 
 from openlibrary.fastapi.auth import MaintainerDep  # noqa: TC001
-from openlibrary.plugins.openlibrary.jenkins import jenkins_deploy_status, trigger_rebuild
+from openlibrary.plugins.openlibrary.jenkins import jenkins_deploy_status
 from openlibrary.plugins.openlibrary.status import (
-    TestingPR,
     TestingState,
     TestingStatus,
     _evict_drift_cache,
-    _get_drift_info_async,
     _get_pr_info_async,
     _load_testing_state,
+    _parse_pr_numbers_from_string,
     _save_testing_state,
+    add_prs_to_set_async,
+    execute_deploy_async,
     load_testing_status_async,
+    refresh_drift_cache,
+    stage_pr_update,
 )
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
@@ -83,68 +83,21 @@ class AddPRsRequest(BaseModel):
     prs: list[str] = Field(..., min_length=1, description="PR numbers or URLs to add")
 
 
-def _parse_pr_numbers(raw: str) -> list[int]:
-    """Extract PR numbers from a single string (numbers, URLs, mixed)."""
-    parts = re.split(r"[\s,]+", raw.strip())
-    numbers: list[int] = []
-    for part in parts:
-        if not part:
-            continue
-        with contextlib.suppress(ValueError, AttributeError):
-            if m := re.search(r"/pull/(\d+)", part):
-                numbers.append(int(m.group(1)))
-            else:
-                numbers.append(int(part.lstrip("#")))
-    return numbers
-
-
 @router.post(
     "/status/prs",
     description="Add one or more PRs to the testing set. Accepts PR numbers or GitHub URLs.",
 )
 async def add_prs(body: AddPRsRequest, _: MaintainerDep) -> dict:
     state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
-    existing = {p.pr for p in state.prs}
-
-    # Parse all input strings into PR numbers.
     pr_numbers: list[int] = []
     for raw in body.prs:
-        pr_numbers.extend(_parse_pr_numbers(raw))
+        pr_numbers.extend(_parse_pr_numbers_from_string(raw))
     if not pr_numbers:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid PR numbers provided")
-
-    # Fetch metadata from GitHub concurrently.
-    infos = await asyncio.gather(*(_get_pr_info_async(n) for n in pr_numbers))
-
-    failed: list[int] = []
-    for pr_number, info in zip(pr_numbers, infos):
-        if pr_number in existing:
-            continue
-        if info.get("error"):
-            failed.append(pr_number)
-            continue
-        state.prs.append(
-            TestingPR(
-                pr=pr_number,
-                commit=info["head_sha"],
-                active=True,
-                title=info["title"],
-                added_at=datetime.datetime.now(datetime.UTC).isoformat(),
-                added_by="",
-                author=info["author"],
-                author_avatar=info["author_avatar"],
-                assignee=info["assignee"],
-                assignee_avatar=info["assignee_avatar"],
-            )
-        )
-        existing.add(pr_number)
-
-    _save_testing_state(state)
-    _evict_drift_cache()
-
-    if failed:
-        return {"ok": False, "error": "add_failed", "failed": failed}
-    return {"ok": True}
+    result = await add_prs_to_set_async(state, pr_numbers)
+    if result.get("error"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result["error"])
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -179,22 +132,16 @@ async def update_pr(pr_id: int, body: UpdatePRRequest, _: MaintainerDep) -> dict
 
     changed = False
 
-    # Stage enable/disable
-    if body.active is not None:
-        target.pending_active = body.active if body.active != target.active else None
-        changed = True
+    # Stage enable/disable and/or removal (pure state mutation).
+    if body.active is not None or body.pending_removal is not None:
+        changed = stage_pr_update(state, [pr_id], active=body.active, pending_removal=body.pending_removal)
 
-    # Stage pull-latest (fetch current HEAD from GitHub)
+    # Stage pull-latest (fetch current HEAD from GitHub).
     if body.pull_latest is True:
         info = await _get_pr_info_async(pr_id)
         if info.get("head_sha") and not info.get("error"):
             target.pull_latest_sha = info["head_sha"]
             changed = True
-
-    # Stage or unstage removal
-    if body.pending_removal is not None:
-        target.pending_removal = True if body.pending_removal else None
-        changed = True
 
     if changed:
         _save_testing_state(state)
@@ -216,43 +163,10 @@ async def deploy_prs(_: MaintainerDep) -> dict:
     state = _load_testing_state()
     if not state:
         return {"ok": True}
-
-    # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
-    # drift metadata refresh can never write staged changes before Jenkins
-    # accepts the build.
-    drift_info, _drift_from_cache = await _get_drift_info_async(state, persist=False)
-    state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
-
-    # Apply all pending changes before deploying
-    for p in state.prs:
-        if p.pull_latest_sha:
-            p.commit = p.pull_latest_sha
-            p.pull_latest_sha = ""
-        if p.pending_active is not None:
-            p.active = p.pending_active
-            p.pending_active = None
-    # Stage-removal PRs are deleted from the set on deploy.
-    state.prs = [p for p in state.prs if not p.pending_removal]
-    for p in state.prs:
-        p.pending_removal = None
-
-    # Nothing above is persisted until Jenkins accepts the build, so a failed
-    # trigger leaves every staged change intact and retryable.
-    outcome = trigger_rebuild(state.prs)
-    if outcome == "failed":
-        return {"ok": False, "error": "deploy_failed"}
-
-    state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
-    state.deployed = {p.pr: p.title for p in state.prs if p.active}
-    if outcome == "triggered":
-        state.deploy_started_at = state.last_deploy_at
-
-    _save_testing_state(state)
-    _evict_drift_cache()
-
-    if outcome == "triggered":
-        return {"ok": True}
-    return {"ok": False, "error": "deploy_unconfigured"}
+    result = await execute_deploy_async(state)
+    if result.get("error"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result["error"])
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -265,5 +179,5 @@ async def deploy_prs(_: MaintainerDep) -> dict:
     description="Evict the GitHub drift cache so the next status fetch is fresh.",
 )
 async def refresh_status(_: MaintainerDep) -> dict:
-    _evict_drift_cache()
+    refresh_drift_cache()
     return {"ok": True}

--- a/openlibrary/fastapi/status.py
+++ b/openlibrary/fastapi/status.py
@@ -8,16 +8,35 @@ via JSON without a browser.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import datetime
 import os
+import re
 
 from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
 
 from openlibrary.fastapi.auth import MaintainerDep  # noqa: TC001
-from openlibrary.plugins.openlibrary.jenkins import jenkins_deploy_status
-from openlibrary.plugins.openlibrary.status import TestingStatus, load_testing_status_async
+from openlibrary.plugins.openlibrary.jenkins import jenkins_deploy_status, trigger_rebuild
+from openlibrary.plugins.openlibrary.status import (
+    TestingPR,
+    TestingState,
+    TestingStatus,
+    _evict_drift_cache,
+    _get_drift_info_async,
+    _get_pr_info_async,
+    _load_testing_state,
+    _save_testing_state,
+    load_testing_status_async,
+)
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
 router = APIRouter(tags=["status"], include_in_schema=SHOW_INTERNAL_IN_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
 
 
 @router.get(
@@ -46,3 +65,205 @@ async def testing_status(_: MaintainerDep) -> TestingStatus:
             }
         )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Create — add PR(s) to the testing set
+# ---------------------------------------------------------------------------
+
+
+class AddPRsRequest(BaseModel):
+    """Body for POST /status/prs.
+
+    ``prs`` accepts a list of strings — PR numbers or full GitHub URLs,
+    whitespace- or comma-separated (the server parses them the same way
+    the legacy add box did).
+    """
+
+    prs: list[str] = Field(..., min_length=1, description="PR numbers or URLs to add")
+
+
+def _parse_pr_numbers(raw: str) -> list[int]:
+    """Extract PR numbers from a single string (numbers, URLs, mixed)."""
+    parts = re.split(r"[\s,]+", raw.strip())
+    numbers: list[int] = []
+    for part in parts:
+        if not part:
+            continue
+        with contextlib.suppress(ValueError, AttributeError):
+            if m := re.search(r"/pull/(\d+)", part):
+                numbers.append(int(m.group(1)))
+            else:
+                numbers.append(int(part.lstrip("#")))
+    return numbers
+
+
+@router.post(
+    "/status/prs",
+    description="Add one or more PRs to the testing set. Accepts PR numbers or GitHub URLs.",
+)
+async def add_prs(body: AddPRsRequest, _: MaintainerDep) -> dict:
+    state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
+    existing = {p.pr for p in state.prs}
+
+    # Parse all input strings into PR numbers.
+    pr_numbers: list[int] = []
+    for raw in body.prs:
+        pr_numbers.extend(_parse_pr_numbers(raw))
+    if not pr_numbers:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid PR numbers provided")
+
+    # Fetch metadata from GitHub concurrently.
+    infos = await asyncio.gather(*(_get_pr_info_async(n) for n in pr_numbers))
+
+    failed: list[int] = []
+    for pr_number, info in zip(pr_numbers, infos):
+        if pr_number in existing:
+            continue
+        if info.get("error"):
+            failed.append(pr_number)
+            continue
+        state.prs.append(
+            TestingPR(
+                pr=pr_number,
+                commit=info["head_sha"],
+                active=True,
+                title=info["title"],
+                added_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                added_by="",
+                author=info["author"],
+                author_avatar=info["author_avatar"],
+                assignee=info["assignee"],
+                assignee_avatar=info["assignee_avatar"],
+            )
+        )
+        existing.add(pr_number)
+
+    _save_testing_state(state)
+    _evict_drift_cache()
+
+    if failed:
+        return {"ok": False, "error": "add_failed", "failed": failed}
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Update — stage a change on a single PR
+# ---------------------------------------------------------------------------
+
+
+class UpdatePRRequest(BaseModel):
+    """Body for PATCH /status/prs/{id}.
+
+    All fields are optional. Only the fields included in the request body
+    are changed; omitted fields are left untouched.
+    """
+
+    active: bool | None = Field(None, description="Stage enable (true) or disable (false)")
+    pull_latest: bool | None = Field(None, description="Stage fetch of latest HEAD commit")
+    pending_removal: bool | None = Field(None, description="Stage (true) or unstage (false) removal")
+
+
+@router.patch(
+    "/status/prs/{pr_id}",
+    description="Stage a change on a PR (enable, disable, pin, remove, or unstage removal).",
+)
+async def update_pr(pr_id: int, body: UpdatePRRequest, _: MaintainerDep) -> dict:
+    state = _load_testing_state()
+    if state is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No testing state found")
+
+    target = next((p for p in state.prs if p.pr == pr_id), None)
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"PR #{pr_id} not in testing set")
+
+    changed = False
+
+    # Stage enable/disable
+    if body.active is not None:
+        target.pending_active = body.active if body.active != target.active else None
+        changed = True
+
+    # Stage pull-latest (fetch current HEAD from GitHub)
+    if body.pull_latest is True:
+        info = await _get_pr_info_async(pr_id)
+        if info.get("head_sha") and not info.get("error"):
+            target.pull_latest_sha = info["head_sha"]
+            changed = True
+
+    # Stage or unstage removal
+    if body.pending_removal is not None:
+        target.pending_removal = body.pending_removal
+        changed = True
+
+    if changed:
+        _save_testing_state(state)
+        _evict_drift_cache()
+
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Deploy — trigger Jenkins and flush all pending changes
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/status/deploy",
+    description="Trigger a Jenkins deploy, flushing all pending changes (pins, toggles, removals).",
+)
+async def deploy_prs(_: MaintainerDep) -> dict:
+    state = _load_testing_state()
+    if not state:
+        return {"ok": True}
+
+    # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
+    # drift metadata refresh can never write staged changes before Jenkins
+    # accepts the build.
+    drift_info, _drift_from_cache = await _get_drift_info_async(state, persist=False)
+    state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
+
+    # Apply all pending changes before deploying
+    for p in state.prs:
+        if p.pull_latest_sha:
+            p.commit = p.pull_latest_sha
+            p.pull_latest_sha = ""
+        if p.pending_active is not None:
+            p.active = p.pending_active
+            p.pending_active = None
+    # Stage-removal PRs are deleted from the set on deploy.
+    state.prs = [p for p in state.prs if not p.pending_removal]
+    for p in state.prs:
+        p.pending_removal = None
+
+    # Nothing above is persisted until Jenkins accepts the build, so a failed
+    # trigger leaves every staged change intact and retryable.
+    outcome = trigger_rebuild(state.prs)
+    if outcome == "failed":
+        return {"ok": False, "error": "deploy_failed"}
+
+    state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
+    state.deployed = {p.pr: p.title for p in state.prs if p.active}
+    if outcome == "triggered":
+        state.deploy_started_at = state.last_deploy_at
+
+    _save_testing_state(state)
+    _evict_drift_cache()
+
+    if outcome == "triggered":
+        return {"ok": True}
+    return {"ok": False, "error": "deploy_unconfigured"}
+
+
+# ---------------------------------------------------------------------------
+# Refresh — evict the drift cache
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/status/refresh",
+    description="Evict the GitHub drift cache so the next status fetch is fresh.",
+)
+async def refresh_status(_: MaintainerDep) -> dict:
+    _evict_drift_cache()
+    return {"ok": True}

--- a/openlibrary/fastapi/status.py
+++ b/openlibrary/fastapi/status.py
@@ -193,7 +193,7 @@ async def update_pr(pr_id: int, body: UpdatePRRequest, _: MaintainerDep) -> dict
 
     # Stage or unstage removal
     if body.pending_removal is not None:
-        target.pending_removal = body.pending_removal
+        target.pending_removal = True if body.pending_removal else None
         changed = True
 
     if changed:

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7460,6 +7460,10 @@ msgid "Deploy failed (merge conflict)"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
+msgid "This PR is already closed."
+msgstr ""
+
+#: TestingEnvironment.html.jinja
 msgid "OK"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7485,6 +7485,10 @@ msgid "Disable"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
+msgid "Restore"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
 msgid "Refresh from GitHub"
 msgstr ""
 

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -23,6 +23,7 @@
     "liveNow": _("Live now"),
     "notLive": _("Not yet deployed"),
     "mergeConflict": _("Deploy failed (merge conflict)"),
+    "closed": _("This PR is already closed."),
     "actions": _("Actions"),
     "ok": _("OK"),
     "prOnTesting": _("PR %(num)s on testing", num="%s"),

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -32,6 +32,7 @@
     "enable": _("Enable"),
     "disable": _("Disable"),
     "remove": _("Remove"),
+    "restore": _("Restore"),
     "refresh": _("Refresh from GitHub"),
     "deploy": _("Deploy"),
     "changeOne": _("%(num)s change will be applied", num="%s"),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -88,35 +88,43 @@ class status_add(delegate.page):
         if not pr_numbers:
             raise web.badrequest()
         state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
-        existing = {p.pr for p in state.prs}
+        by_pr = {p.pr: p for p in state.prs}
         user = get_current_user()
         failed = []
+        changed = False
         for pr_number in pr_numbers:
-            if pr_number not in existing:
-                info = _get_pr_info(pr_number)
-                if info.get("error"):
-                    # GitHub unreachable, rate-limited, or an invalid PR — never
-                    # pretend the add landed. The error response lets the panel
-                    # keep the input so the failure is visible.
-                    failed.append(pr_number)
-                    continue
-                state.prs.append(
-                    TestingPR(
-                        pr=pr_number,
-                        commit=info["head_sha"],
-                        active=True,
-                        title=info["title"],
-                        added_at=datetime.datetime.now(datetime.UTC).isoformat(),
-                        added_by=user.key.split("/")[-1] if user else "",
-                        author=info["author"],
-                        author_avatar=info["author_avatar"],
-                        assignee=info["assignee"],
-                        assignee_avatar=info["assignee_avatar"],
-                    )
+            if pr_number in by_pr:
+                # PR already in the set — if it was staged for removal,
+                # unstage it (restore).
+                if by_pr[pr_number].pending_removal:
+                    by_pr[pr_number].pending_removal = None
+                    changed = True
+                continue
+            info = _get_pr_info(pr_number)
+            if info.get("error"):
+                # GitHub unreachable, rate-limited, or an invalid PR — never
+                # pretend the add landed. The error response lets the panel
+                # keep the input so the failure is visible.
+                failed.append(pr_number)
+                continue
+            state.prs.append(
+                TestingPR(
+                    pr=pr_number,
+                    commit=info["head_sha"],
+                    active=True,
+                    title=info["title"],
+                    added_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                    added_by=user.key.split("/")[-1] if user else "",
+                    author=info["author"],
+                    author_avatar=info["author_avatar"],
+                    assignee=info["assignee"],
+                    assignee_avatar=info["assignee_avatar"],
                 )
-                existing.add(pr_number)
-        _save_testing_state(state)
-        _evict_drift_cache()
+            )
+            changed = True
+        if changed:
+            _save_testing_state(state)
+            _evict_drift_cache()
         if failed:
             return _json_error("add_failed")
         return _json_ok()
@@ -130,8 +138,11 @@ class status_remove(delegate.page):
             raise web.unauthorized()
         i = web.input(prs=[])
         to_remove = {int(p) for p in i.prs}
-        if state := _load_testing_state():
-            state.prs = [p for p in state.prs if p.pr not in to_remove]
+        state = _load_testing_state()
+        if state and to_remove:
+            for p in state.prs:
+                if p.pr in to_remove:
+                    p.pending_removal = True
             _save_testing_state(state)
         return _json_ok()
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -214,6 +214,10 @@ class status_deploy(delegate.page):
             if p.pending_active is not None:
                 p.active = p.pending_active
                 p.pending_active = None
+        # Stage-removal PRs are deleted from the set on deploy.
+        state.prs = [p for p in state.prs if not p.pending_removal]
+        for p in state.prs:
+            p.pending_removal = None
         # Nothing above is persisted until Jenkins accepts the build, so a failed
         # trigger leaves every staged change intact and retryable.
         outcome = trigger_rebuild(state.prs)
@@ -291,6 +295,8 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="pin", detail=p.short_pull_latest))
         if (toggle := p.pending_toggle) is not None:
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="enable" if toggle else "disable", detail=""))
+        if p.pending_removal:
+            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="staged", detail=""))
     # Deployed but no longer in the set: removed, and still on the box until the
     # next deploy drops it. State files written before `deployed` existed start
     # empty here, so their first deploy is what makes removals visible.
@@ -383,6 +389,7 @@ class TestingPR(BaseModel):
     added_by: str = ""  # OL username
     pull_latest_sha: str = ""  # pending SHA from "Fetch Latest"; applied on deploy
     pending_active: bool | None = None  # pending enable/disable; applied on deploy
+    pending_removal: bool | None = None  # pending remove; applied on deploy
     author: str = ""  # GitHub login of PR author
     author_avatar: str = ""  # GitHub avatar URL (append &s=N for sizing)
     assignee: str = ""  # GitHub login of assignee, empty if unassigned

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -79,54 +79,15 @@ class status_add(delegate.page):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(pr="")
-        raw = re.split(r"[\s,]+", i.pr.strip())
-        pr_numbers = []
-        for val in raw:
-            if val:
-                with contextlib.suppress(ValueError, AttributeError):
-                    pr_numbers.append(_parse_pr_number(val))
+        pr_numbers = _parse_pr_numbers_from_string(i.pr)
         if not pr_numbers:
             raise web.badrequest()
         state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
-        by_pr = {p.pr: p for p in state.prs}
         user = get_current_user()
-        failed = []
-        changed = False
-        for pr_number in pr_numbers:
-            if pr_number in by_pr:
-                # PR already in the set — if it was staged for removal,
-                # unstage it (restore).
-                if by_pr[pr_number].pending_removal:
-                    by_pr[pr_number].pending_removal = None
-                    changed = True
-                continue
-            info = _get_pr_info(pr_number)
-            if info.get("error"):
-                # GitHub unreachable, rate-limited, or an invalid PR — never
-                # pretend the add landed. The error response lets the panel
-                # keep the input so the failure is visible.
-                failed.append(pr_number)
-                continue
-            state.prs.append(
-                TestingPR(
-                    pr=pr_number,
-                    commit=info["head_sha"],
-                    active=True,
-                    title=info["title"],
-                    added_at=datetime.datetime.now(datetime.UTC).isoformat(),
-                    added_by=user.key.split("/")[-1] if user else "",
-                    author=info["author"],
-                    author_avatar=info["author_avatar"],
-                    assignee=info["assignee"],
-                    assignee_avatar=info["assignee_avatar"],
-                )
-            )
-            changed = True
-        if changed:
-            _save_testing_state(state)
-            _evict_drift_cache()
-        if failed:
-            return _json_error("add_failed")
+        added_by = user.key.split("/")[-1] if user else ""
+        result = add_prs_to_set(state, pr_numbers, added_by)
+        if result.get("error"):
+            return _json_error(result["error"])
         return _json_ok()
 
 
@@ -137,13 +98,10 @@ class status_remove(delegate.page):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(prs=[])
-        to_remove = {int(p) for p in i.prs}
         state = _load_testing_state()
-        if state and to_remove:
-            for p in state.prs:
-                if p.pr in to_remove:
-                    p.pending_removal = True
+        if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], pending_removal=True):
             _save_testing_state(state)
+            _evict_drift_cache()
         return _json_ok()
 
 
@@ -154,14 +112,10 @@ class status_enable(delegate.page):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(prs=[])
-        to_enable = {int(p) for p in i.prs}
         state = _load_testing_state()
-        if not state or not to_enable:
-            return _json_ok()
-        for p in state.prs:
-            if p.pr in to_enable:
-                p.pending_active = True
-        _save_testing_state(state)
+        if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], active=True):
+            _save_testing_state(state)
+            _evict_drift_cache()
         return _json_ok()
 
 
@@ -172,14 +126,10 @@ class status_disable(delegate.page):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(prs=[])
-        to_disable = {int(p) for p in i.prs}
         state = _load_testing_state()
-        if not state or not to_disable:
-            return _json_ok()
-        for p in state.prs:
-            if p.pr in to_disable:
-                p.pending_active = False
-        _save_testing_state(state)
+        if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], active=False):
+            _save_testing_state(state)
+            _evict_drift_cache()
         return _json_ok()
 
 
@@ -190,16 +140,9 @@ class status_pull_latest(delegate.page):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(prs=[])
-        to_update = {int(p) for p in i.prs}
         state = _load_testing_state()
-        if not state or not to_update:
-            return _json_ok()
-        for p in state.prs:
-            if p.pr in to_update:
-                info = _get_pr_info(p.pr)
-                if info["head_sha"] and info["head_sha"] != p.commit:
-                    p.pull_latest_sha = info["head_sha"]
-        _save_testing_state(state)
+        if state and i.prs:
+            pull_latest_from_github(state, [int(p) for p in i.prs])
         return _json_ok()
 
 
@@ -212,43 +155,10 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
-        # drift metadata refresh can never write staged changes before Jenkins
-        # accepts the build.
-        drift_info, _ = _get_drift_info(state, persist=False)
-        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
-        # Apply all pending changes before deploying
-        for p in state.prs:
-            if p.pull_latest_sha:
-                p.commit = p.pull_latest_sha
-                p.pull_latest_sha = ""
-            if p.pending_active is not None:
-                p.active = p.pending_active
-                p.pending_active = None
-        # Stage-removal PRs are deleted from the set on deploy.
-        state.prs = [p for p in state.prs if not p.pending_removal]
-        for p in state.prs:
-            p.pending_removal = None
-        # Nothing above is persisted until Jenkins accepts the build, so a failed
-        # trigger leaves every staged change intact and retryable.
-        outcome = trigger_rebuild(state.prs)
-        if outcome == "failed":
-            return _json_error("deploy_failed")
-        state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
-        # What this build puts on the box: active PRs only, the same filter
-        # trigger_rebuild sends. Recorded so a later removal has a set to be
-        # missing from — nothing else survives one.
-        state.deployed = {p.pr: p.title for p in state.prs if p.active}
-        if outcome == "triggered":
-            state.deploy_started_at = state.last_deploy_at
-        _save_testing_state(state)
-        _evict_drift_cache()
-        # "unconfigured" (no Jenkins token, local dev) still advances state so
-        # the panel is exercisable, but the response says the box was never
-        # touched so the UI doesn't claim a real deploy happened.
-        if outcome == "triggered":
-            return _json_ok()
-        return _json_error("deploy_unconfigured")
+        result = execute_deploy(state)
+        if result.get("error"):
+            return _json_error(result["error"])
+        return _json_ok()
 
 
 class status_refresh(delegate.page):
@@ -257,7 +167,7 @@ class status_refresh(delegate.page):
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
-        _evict_drift_cache()
+        refresh_drift_cache()
         return _json_ok()
 
 
@@ -810,6 +720,163 @@ def _parse_pr_number(value: str) -> int:
     if m := re.search(r"/pull/(\d+)", value):
         return int(m.group(1))
     return int(value.lstrip("#"))
+
+
+def _parse_pr_numbers_from_string(raw: str) -> list[int]:
+    """Extract PR numbers from a single string (numbers, URLs, mixed, comma/whitespace-separated)."""
+    numbers: list[int] = []
+    for part in re.split(r"[\s,]+", raw.strip()):
+        if part:
+            with contextlib.suppress(ValueError, AttributeError):
+                numbers.append(_parse_pr_number(part))
+    return numbers
+
+
+# ---------------------------------------------------------------------------
+# Service functions: shared business logic for both web.py and FastAPI
+# ---------------------------------------------------------------------------
+
+
+async def add_prs_to_set_async(state: TestingState, pr_numbers: list[int], added_by: str = "") -> dict:
+    """Add PR(s) to the testing set.  Handles restore of staged removals.
+
+    Returns {"ok": True} or {"ok": False, "error": "add_failed", "failed": [...]}.
+    Saves state and evicts cache if anything changed.
+    """
+    by_pr = {p.pr: p for p in state.prs}
+    failed: list[int] = []
+    changed = False
+    # Restore PRs already in the set but staged for removal.
+    for pr_number in pr_numbers:
+        if pr_number in by_pr and by_pr[pr_number].pending_removal:
+            by_pr[pr_number].pending_removal = None
+            changed = True
+    # Fetch metadata for new PRs concurrently.
+    new_prs = [n for n in pr_numbers if n not in by_pr]
+    if new_prs:
+        infos = await asyncio.gather(*(_get_pr_info_async(n) for n in new_prs))
+        for pr_number, info in zip(new_prs, infos):
+            if info.get("error"):
+                failed.append(pr_number)
+                continue
+            state.prs.append(
+                TestingPR(
+                    pr=pr_number,
+                    commit=info["head_sha"],
+                    active=True,
+                    title=info["title"],
+                    added_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                    added_by=added_by,
+                    author=info["author"],
+                    author_avatar=info["author_avatar"],
+                    assignee=info["assignee"],
+                    assignee_avatar=info["assignee_avatar"],
+                )
+            )
+            changed = True
+    if changed:
+        _save_testing_state(state)
+        _evict_drift_cache()
+    if failed:
+        return {"ok": False, "error": "add_failed", "failed": failed}
+    return {"ok": True}
+
+
+def stage_pr_update(
+    state: TestingState,
+    pr_numbers: list[int],
+    *,
+    active: bool | None = None,
+    pending_removal: bool | None = None,
+) -> bool:
+    """Stage field changes on PRs (enable/disable/remove/restore).
+
+    Pure state mutation — caller must persist and evict cache.
+    Returns True if anything changed.
+    """
+    targets = {int(n) for n in pr_numbers}
+    changed = False
+    for p in state.prs:
+        if p.pr not in targets:
+            continue
+        if active is not None:
+            p.pending_active = active if active != p.active else None
+            changed = True
+        if pending_removal is not None:
+            p.pending_removal = True if pending_removal else None
+            changed = True
+    return changed
+
+
+async def stage_pull_latest_async(state: TestingState, pr_numbers: list[int]) -> dict:
+    """Fetch latest HEAD from GitHub and stage pins for the given PRs.
+
+    Returns {"ok": True}.  Saves state and evicts cache.
+    """
+    targets = {int(n) for n in pr_numbers}
+    to_fetch = [p for p in state.prs if p.pr in targets]
+    if to_fetch:
+        infos = await asyncio.gather(*(_get_pr_info_async(p.pr) for p in to_fetch))
+        for p, info in zip(to_fetch, infos):
+            if info.get("head_sha") and not info.get("error"):
+                p.pull_latest_sha = info["head_sha"]
+    _save_testing_state(state)
+    _evict_drift_cache()
+    return {"ok": True}
+
+
+async def execute_deploy_async(state: TestingState) -> dict:
+    """Execute a deploy: flush all pending changes and trigger Jenkins.
+
+    Returns {"ok": True} or {"ok": False, "error": "..."}.
+    Saves state and evicts cache.
+    """
+    drift_info, _ = await _get_drift_info_async(state, persist=False)
+    # Drop merged/closed PRs.
+    state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
+    # Apply all pending changes before deploying.
+    for p in state.prs:
+        if p.pull_latest_sha:
+            p.commit = p.pull_latest_sha
+            p.pull_latest_sha = ""
+        if p.pending_active is not None:
+            p.active = p.pending_active
+            p.pending_active = None
+    # Stage-removal PRs are deleted from the set on deploy.
+    state.prs = [p for p in state.prs if not p.pending_removal]
+    for p in state.prs:
+        p.pending_removal = None
+    # Nothing above is persisted until Jenkins accepts the build, so a failed
+    # trigger leaves every staged change intact and retryable.
+    outcome = trigger_rebuild(state.prs)
+    if outcome == "failed":
+        return {"ok": False, "error": "deploy_failed"}
+    state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
+    # What this build puts on the box: active PRs only, the same filter
+    # trigger_rebuild sends. Recorded so a later removal has a set to be
+    # missing from — nothing else survives one.
+    state.deployed = {p.pr: p.title for p in state.prs if p.active}
+    if outcome == "triggered":
+        state.deploy_started_at = state.last_deploy_at
+    _save_testing_state(state)
+    _evict_drift_cache()
+    # "unconfigured" (no Jenkins token, local dev) still advances state so
+    # the panel is exercisable, but the response says the box was never
+    # touched so the UI doesn't claim a real deploy happened.
+    if outcome == "triggered":
+        return {"ok": True}
+    return {"ok": False, "error": "deploy_unconfigured"}
+
+
+def refresh_drift_cache() -> None:
+    """Evict the drift cache."""
+    _evict_drift_cache()
+
+
+# Sync bridge wrappers so the web.py handlers can call async service functions.
+add_prs_to_set = async_bridge.wrap(add_prs_to_set_async)
+pull_latest_from_github = async_bridge.wrap(stage_pull_latest_async)
+execute_deploy = async_bridge.wrap(execute_deploy_async)
 
 
 @public

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -101,7 +101,6 @@ class status_remove(delegate.page):
         state = _load_testing_state()
         if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], pending_removal=True):
             _save_testing_state(state)
-            _evict_drift_cache()
         return _json_ok()
 
 
@@ -115,7 +114,6 @@ class status_enable(delegate.page):
         state = _load_testing_state()
         if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], active=True):
             _save_testing_state(state)
-            _evict_drift_cache()
         return _json_ok()
 
 
@@ -129,7 +127,6 @@ class status_disable(delegate.page):
         state = _load_testing_state()
         if state and i.prs and stage_pr_update(state, [int(p) for p in i.prs], active=False):
             _save_testing_state(state)
-            _evict_drift_cache()
         return _json_ok()
 
 
@@ -821,7 +818,6 @@ async def stage_pull_latest_async(state: TestingState, pr_numbers: list[int]) ->
             if info.get("head_sha") and not info.get("error"):
                 p.pull_latest_sha = info["head_sha"]
     _save_testing_state(state)
-    _evict_drift_cache()
     return {"ok": True}
 
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -201,10 +201,9 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Decide merged/closed removals on the *un-mutated* state — `merged` and
-        # `closed` are independent of staged pins/toggles — and with persist=False,
-        # so the drift metadata refresh can never write staged changes to disk
-        # before Jenkins accepts the build.
+        # Drop merged/closed PRs on the *un-mutated* state; persist=False so the
+        # drift metadata refresh can never write staged changes before Jenkins
+        # accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
         state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
         # Apply all pending changes before deploying
@@ -267,9 +266,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     """The plan: what deploying would change, one entry per staged change.
 
     Every row action writes staged intent that only status_deploy applies, so
-    this walks the same fields it flushes. A PR merged to master — or closed on
-    GitHub without a merge — is dropped by the deploy regardless of what else is
-    staged on it, so it yields one ``remove`` and nothing more.
+    this walks the same fields it flushes. A PR merged to master — or closed
+    without merging — is dropped on deploy regardless of what else is staged on
+    it, so it yields one ``remove`` and nothing more.
 
     Removal is the one action that stages nothing: it deletes the row. Those are
     recovered at the end by diffing ``state.deployed`` — what the last deploy
@@ -755,8 +754,7 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": head_sha[:7],
             "drift": drift,
             "merged": merged,
-            # Closing a PR also closes the GitHub issue's state, and a merge is
-            # itself a close — so "closed" means closed *without* being merged.
+            # A merge is itself a close, so "closed" means closed without merging.
             "closed": gh.get("state") == "closed" and not merged,
             "title": gh.get("title", f"PR #{pr.pr}"),
             "author": user.get("login", ""),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -201,12 +201,12 @@ class status_deploy(delegate.page):
         state = _load_testing_state()
         if not state:
             return _json_ok()
-        # Decide merged-removals on the *un-mutated* state — `merged` is
-        # independent of staged pins/toggles — and with persist=False, so the
-        # drift metadata refresh can never write staged changes to disk before
-        # Jenkins accepts the build.
+        # Decide merged/closed removals on the *un-mutated* state — `merged` and
+        # `closed` are independent of staged pins/toggles — and with persist=False,
+        # so the drift metadata refresh can never write staged changes to disk
+        # before Jenkins accepts the build.
         drift_info, _ = _get_drift_info(state, persist=False)
-        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False)]
+        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False) and not drift_info.get(p.pr, {}).get("closed", False)]
         # Apply all pending changes before deploying
         for p in state.prs:
             if p.pull_latest_sha:
@@ -267,9 +267,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     """The plan: what deploying would change, one entry per staged change.
 
     Every row action writes staged intent that only status_deploy applies, so
-    this walks the same fields it flushes. A PR merged to master is dropped by
-    the deploy regardless of what else is staged on it, so it yields one
-    ``remove`` and nothing more.
+    this walks the same fields it flushes. A PR merged to master — or closed on
+    GitHub without a merge — is dropped by the deploy regardless of what else is
+    staged on it, so it yields one ``remove`` and nothing more.
 
     Removal is the one action that stages nothing: it deletes the row. Those are
     recovered at the end by diffing ``state.deployed`` — what the last deploy
@@ -280,6 +280,9 @@ def _pending_changes(state: TestingState, drift_info: dict) -> list[PendingChang
     for p in state.prs:
         if drift_info.get(p.pr, {}).get("merged", False):
             changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="merged", detail=""))
+            continue
+        if drift_info.get(p.pr, {}).get("closed", False):
+            changes.append(PendingChange(pr=p.pr, title=p.title, kind="remove", reason="closed", detail=""))
             continue
         if not last_deploy or p.added_at > last_deploy:
             # A pin staged on a PR that isn't live yet isn't a separate change:
@@ -450,6 +453,7 @@ class TestingPRStatus(TestingPR):
     is_new: bool = False  # added since the last deploy
     live_now: bool = False  # the last deploy put this PR on the box
     merge_conflict: bool = False  # the last deploy's merge of this PR conflicted, so it did not land
+    closed: bool = False  # the PR was closed on GitHub without being merged; the next deploy drops it
     action: str = ""  # what the next deploy does with this row: add, pin, enable, disable, remove, or empty
     in_set: bool = True  # False for rows dropped from the set but still on the box
 
@@ -461,7 +465,7 @@ class PendingChange(BaseModel):
     title: str
     kind: str  # add, pin, enable, disable, remove
     detail: str = ""  # short SHA for add/pin changes; empty otherwise
-    reason: str = ""  # why a removal is staged: merged or dropped; empty otherwise
+    reason: str = ""  # why a removal is staged: merged, closed, or dropped; empty otherwise
 
 
 class TestingStatus(BaseModel):
@@ -520,6 +524,7 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
             is_new=bool(last_deploy and p.added_at > last_deploy),
             live_now=p.pr in state.deployed or (not deployed_record and bool(last_deploy and p.added_at <= last_deploy)),
             merge_conflict=p.pr in merge_conflicts,
+            closed=drift_info.get(p.pr, {}).get("closed", False),
             action=actions.get(p.pr, ""),
             in_set=True,
         )
@@ -667,7 +672,7 @@ async def _get_drift_info_async(state: TestingState, persist: bool = True) -> tu
     state_changed = False
     infos = await asyncio.gather(*(_get_pr_drift_async(p) for p in state.prs))
     for p, info in zip(state.prs, infos):
-        drift[p.pr] = {k: info[k] for k in ("head_sha", "drift", "merged")}
+        drift[p.pr] = {k: info[k] for k in ("head_sha", "drift", "merged", "closed")}
         for attr in ("title", "author", "author_avatar", "assignee", "assignee_avatar"):
             new_val = info.get(attr, "")
             if new_val and getattr(p, attr) != new_val:
@@ -750,6 +755,9 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": head_sha[:7],
             "drift": drift,
             "merged": merged,
+            # Closing a PR also closes the GitHub issue's state, and a merge is
+            # itself a close — so "closed" means closed *without* being merged.
+            "closed": gh.get("state") == "closed" and not merged,
             "title": gh.get("title", f"PR #{pr.pr}"),
             "author": user.get("login", ""),
             "author_avatar": user.get("avatar_url", ""),
@@ -761,6 +769,7 @@ async def _get_pr_drift_async(pr: TestingPR) -> dict:
             "head_sha": "",
             "drift": -1,
             "merged": False,
+            "closed": False,
             "title": "",
             "author": "",
             "author_avatar": "",

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -555,7 +555,7 @@ def test_add_skips_pr_and_marks_failure_when_github_errors():
     with (
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
-        patch("openlibrary.plugins.openlibrary.status._get_pr_info", return_value=gh_info),
+        patch("openlibrary.plugins.openlibrary.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
         patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
@@ -576,7 +576,7 @@ def test_deploy_unconfigured_answers_error_but_advances_state():
     with (
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
-        patch("openlibrary.plugins.openlibrary.status._get_drift_info", return_value=({}, False)),
+        patch("openlibrary.plugins.openlibrary.status._get_drift_info_async", new_callable=AsyncMock, return_value=({}, False)),
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
@@ -624,7 +624,8 @@ def test_deploy_failure_never_persists_staged_changes():
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch(
-            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            "openlibrary.plugins.openlibrary.status._get_drift_info_async",
+            new_callable=AsyncMock,
             return_value=(
                 {13238: {"head_sha": "", "drift": 0, "merged": False}, 13240: {"head_sha": "", "drift": 0, "merged": False}},
                 False,
@@ -1144,9 +1145,9 @@ async def test_fastapi_add_prs_batch(fastapi_client, mock_authenticated_user, mo
 
     with (
         patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
-        patch("openlibrary.fastapi.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
-        patch("openlibrary.fastapi.status._save_testing_state") as mock_save,
-        patch("openlibrary.fastapi.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state") as mock_save,
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
     ):
         response = fastapi_client.post("/status/prs", json={"prs": ["12914", "13269"]})
 
@@ -1174,9 +1175,9 @@ async def test_fastapi_add_prs_skips_existing(fastapi_client, mock_authenticated
 
     with (
         patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
-        patch("openlibrary.fastapi.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
-        patch("openlibrary.fastapi.status._save_testing_state"),
-        patch("openlibrary.fastapi.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
     ):
         response = fastapi_client.post("/status/prs", json={"prs": ["12914"]})
 
@@ -1202,10 +1203,10 @@ async def test_fastapi_deploy_flushes_pending_removal(fastapi_client, mock_authe
 
     with (
         patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
-        patch("openlibrary.fastapi.status._get_drift_info_async", new_callable=AsyncMock, return_value=({}, False)),
-        patch("openlibrary.fastapi.status.trigger_rebuild", return_value="triggered"),
-        patch("openlibrary.fastapi.status._save_testing_state") as mock_save,
-        patch("openlibrary.fastapi.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status._get_drift_info_async", new_callable=AsyncMock, return_value=({}, False)),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="triggered"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state") as mock_save,
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
     ):
         response = fastapi_client.post("/status/deploy")
 
@@ -1219,7 +1220,7 @@ async def test_fastapi_deploy_flushes_pending_removal(fastapi_client, mock_authe
 async def test_fastapi_refresh_evicts_cache(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=True)
 
-    with patch("openlibrary.fastapi.status._evict_drift_cache") as mock_evict:
+    with patch("openlibrary.plugins.openlibrary.status._evict_drift_cache") as mock_evict:
         response = fastapi_client.post("/status/refresh")
 
     assert response.status_code == 200

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -919,3 +919,309 @@ def test_testing_status_endpoint_forbidden_for_non_maintainer(fastapi_client, mo
     assert response.status_code == 403
     assert response.json()["detail"] == "Insufficient permissions"
     mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# pending_removal tests
+# ---------------------------------------------------------------------------
+
+
+def test_pending_changes_includes_staged_removal():
+    """A PR with pending_removal=True emits a remove change in the plan."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    changes = status_module._pending_changes(state, {})
+
+    assert len(changes) == 1
+    assert changes[0].kind == "remove"
+    assert changes[0].reason == "staged"
+    assert changes[0].pr == 13269
+
+
+def test_pending_changes_staged_removal_alongside_other_changes():
+    """A staged removal can coexist with other staged changes on other PRs."""
+    removal = _make_pr(pr_number=13269, added_at="2026-08-01T10:00:00+00:00")
+    removal.pending_removal = True
+    toggled = _make_pr(pr_number=13238, added_at="2026-08-01T10:00:00+00:00")
+    toggled.pending_active = False
+    state = _make_state(prs=[removal, toggled])
+
+    changes = status_module._pending_changes(state, {})
+
+    assert [(c.kind, c.pr) for c in changes] == [
+        ("disable", 13238),
+        ("remove", 13269),
+    ]
+
+
+def test_pending_changes_staged_removal_ignored_for_merged_pr():
+    """A merged PR yields only a merged removal, even if pending_removal is set."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    changes = status_module._pending_changes(state, {13269: {"merged": True}})
+
+    assert len(changes) == 1
+    assert changes[0].reason == "merged"
+
+
+def test_build_testing_status_marks_pending_removal_action():
+    """A PR staged for removal gets action='remove' in the row."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+    state.deployed = {13269: pr.title}
+
+    result = status_module.build_testing_status(state, {})
+
+    row = result.prs[0]
+    assert row.action == "remove"
+    assert row.in_set is True  # still in the set, just staged for removal
+    assert row.live_now is True
+
+
+def test_deploy_flushes_pending_removal():
+    """Deploying removes PRs with pending_removal=True from the set."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch(
+            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            return_value=({13269: {"head_sha": "", "drift": 0, "merged": False}}, False),
+        ),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="triggered"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+    ):
+        status_module.status_deploy().POST()
+
+    # The PR should be removed from the set
+    assert state.prs == []
+    # The deploy record should be empty (no active PRs left)
+    assert state.deployed == {}
+
+
+def test_webpy_remove_stages_removal():
+    """The legacy /status/remove endpoint now stages removal instead of deleting."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("web.input", return_value=web.storage(prs=["13269"])),
+    ):
+        status_module.status_remove().POST()
+
+    # PR should still be in the set, just staged for removal
+    assert len(state.prs) == 1
+    assert state.prs[0].pending_removal is True
+
+
+def test_webpy_add_unstages_removal():
+    """Adding a PR that's staged for removal cancels the removal."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
+        patch("web.input", return_value=web.storage(pr="13269")),
+    ):
+        status_module.status_add().POST()
+
+    # PR should still be in the set, removal unstaged
+    assert len(state.prs) == 1
+    assert state.prs[0].pending_removal is None
+
+
+# ---------------------------------------------------------------------------
+# FastAPI mutation endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fastapi_patch_pr_stages_removal(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._save_testing_state") as mock_save,
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.patch("/status/prs/13269", json={"pending_removal": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert state.prs[0].pending_removal is True
+    mock_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_patch_pr_unstages_removal(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._save_testing_state"),
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.patch("/status/prs/13269", json={"pending_removal": False})
+
+    assert response.status_code == 200
+    assert state.prs[0].pending_removal is None
+
+
+@pytest.mark.asyncio
+async def test_fastapi_patch_pr_stages_enable(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    pr = _make_pr(active=True, added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._save_testing_state"),
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.patch("/status/prs/13269", json={"active": False})
+
+    assert response.status_code == 200
+    assert state.prs[0].pending_active is False
+
+
+@pytest.mark.asyncio
+async def test_fastapi_patch_pr_404_for_missing_pr(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    state = _make_state(prs=[])
+
+    with patch("openlibrary.fastapi.status._load_testing_state", return_value=state):
+        response = fastapi_client.patch("/status/prs/99999", json={"pending_removal": True})
+
+    assert response.status_code == 404
+    assert "not in testing set" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_fastapi_patch_pr_404_for_no_state(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+
+    with patch("openlibrary.fastapi.status._load_testing_state", return_value=None):
+        response = fastapi_client.patch("/status/prs/13269", json={"pending_removal": True})
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_fastapi_add_prs_batch(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    state = _make_state(prs=[])
+    gh_info = {
+        "title": "Test PR",
+        "head_sha": "abc1234def5678901234567890123456789012345",
+        "author": "author",
+        "author_avatar": "",
+        "assignee": "assignee",
+        "assignee_avatar": "",
+        "error": "",
+    }
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
+        patch("openlibrary.fastapi.status._save_testing_state") as mock_save,
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.post("/status/prs", json={"prs": ["12914", "13269"]})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert len(state.prs) == 2
+    assert {p.pr for p in state.prs} == {12914, 13269}
+    mock_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_add_prs_skips_existing(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    existing_pr = _make_pr(pr_number=12914, added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[existing_pr])
+    gh_info = {
+        "title": "New PR",
+        "head_sha": "abc1234def5678901234567890123456789012345",
+        "author": "author",
+        "author_avatar": "",
+        "assignee": "assignee",
+        "assignee_avatar": "",
+        "error": "",
+    }
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
+        patch("openlibrary.fastapi.status._save_testing_state"),
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.post("/status/prs", json={"prs": ["12914"]})
+
+    assert response.status_code == 200
+    assert len(state.prs) == 1  # not duplicated
+
+
+@pytest.mark.asyncio
+async def test_fastapi_add_prs_empty_input(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+
+    response = fastapi_client.post("/status/prs", json={"prs": ["not-a-number!!!"]})
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_fastapi_deploy_flushes_pending_removal(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    pr.pending_removal = True
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.fastapi.status._load_testing_state", return_value=state),
+        patch("openlibrary.fastapi.status._get_drift_info_async", new_callable=AsyncMock, return_value=({}, False)),
+        patch("openlibrary.fastapi.status.trigger_rebuild", return_value="triggered"),
+        patch("openlibrary.fastapi.status._save_testing_state") as mock_save,
+        patch("openlibrary.fastapi.status._evict_drift_cache"),
+    ):
+        response = fastapi_client.post("/status/deploy")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert state.prs == []
+    mock_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_refresh_evicts_cache(fastapi_client, mock_authenticated_user, mock_maintainer_user):
+    mock_maintainer_user(is_maintainer=True)
+
+    with patch("openlibrary.fastapi.status._evict_drift_cache") as mock_evict:
+        response = fastapi_client.post("/status/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    mock_evict.assert_called_once()

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -321,7 +321,8 @@ def test_deploy_drops_closed_prs():
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch(
-            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            "openlibrary.plugins.openlibrary.status._get_drift_info_async",
+            new_callable=AsyncMock,
             return_value=({pr.pr: {"head_sha": "", "drift": 0, "merged": False, "closed": True}}, False),
         ),
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
@@ -528,7 +529,7 @@ def test_add_appends_pr_when_github_succeeds():
     with (
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
-        patch("openlibrary.plugins.openlibrary.status._get_pr_info", return_value=gh_info),
+        patch("openlibrary.plugins.openlibrary.status._get_pr_info_async", new_callable=AsyncMock, return_value=gh_info),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
         patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
@@ -651,7 +652,8 @@ def test_deploy_success_applies_staged_changes_then_saves_once():
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch(
-            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            "openlibrary.plugins.openlibrary.status._get_drift_info_async",
+            new_callable=AsyncMock,
             return_value=(
                 {13238: {"head_sha": "", "drift": 0, "merged": False}, 13240: {"head_sha": "", "drift": 0, "merged": False}},
                 False,
@@ -994,7 +996,8 @@ def test_deploy_flushes_pending_removal():
         patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch(
-            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            "openlibrary.plugins.openlibrary.status._get_drift_info_async",
+            new_callable=AsyncMock,
             return_value=({13269: {"head_sha": "", "drift": 0, "merged": False}}, False),
         ),
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="triggered"),
@@ -1048,7 +1051,6 @@ def test_webpy_add_unstages_removal():
     assert state.prs[0].pending_removal is None
 
 
-# ---------------------------------------------------------------------------
 # FastAPI mutation endpoint tests
 # ---------------------------------------------------------------------------
 

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -706,6 +706,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
                 "added_by": "openlibrary",
                 "pull_latest_sha": "",
                 "pending_active": None,
+                "pending_removal": None,
                 "author": "author",
                 "author_avatar": "",
                 "assignee": "assignee",

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -92,6 +92,7 @@ async def test_get_drift_info_fetches_prs_concurrently():
         "head_sha": "abc1234",
         "drift": 0,
         "merged": False,
+        "closed": False,
         "title": "Test PR",
         "author": "author",
         "author_avatar": "",
@@ -119,7 +120,7 @@ async def test_get_drift_info_fetches_prs_concurrently():
 
     assert from_cache is False
     assert peak > 1  # sequential awaits would never see overlap
-    assert drift == {p.pr: {"head_sha": "abc1234", "drift": 0, "merged": False} for p in state.prs}
+    assert drift == {p.pr: {"head_sha": "abc1234", "drift": 0, "merged": False, "closed": False} for p in state.prs}
 
 
 def test_build_testing_status_marks_merge_conflicts():
@@ -262,6 +263,74 @@ def test_pending_changes_merged_pr_yields_only_a_removal():
     changes = status_module._pending_changes(state, {13238: {"merged": True}})
 
     assert [c.kind for c in changes] == ["remove"]
+
+
+def test_pending_changes_closed_pr_yields_only_a_removal():
+    """A closed (not merged) PR is dropped on deploy just like a merged one."""
+    pr = _make_pr(pr_number=13238, added_at="2026-08-01T10:00:00+00:00")
+    pr.pull_latest_sha = "9f8e7d6c5b4a39281706f5e4d3c2b1a098765432"
+    state = _make_state(prs=[pr])
+
+    changes = status_module._pending_changes(state, {13238: {"merged": False, "closed": True}})
+
+    assert [(c.kind, c.reason) for c in changes] == [("remove", "closed")]
+
+
+def test_build_testing_status_marks_closed_prs():
+    """A closed PR carries the closed flag and reads as a pending removal."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    result = status_module.build_testing_status(state, {pr.pr: {"head_sha": "abc1234", "drift": 0, "merged": False, "closed": True}})
+
+    row = result.prs[0]
+    assert row.closed is True
+    assert row.action == "remove"
+    assert result.has_pending is True
+
+
+@pytest.mark.asyncio
+async def test_pr_drift_distinguishes_closed_from_merged():
+    """Merging closes a PR too; only a close without a merge counts as closed."""
+
+    async def fake_get(path):
+        if path.startswith("pulls/"):
+            return {"state": "closed", "merged": False, "merged_at": None, "head": {"sha": "abc1234"}, "user": {}, "assignee": {}, "title": "Closed PR"}
+        return {}  # compare response; no ahead_by → drift unknown
+
+    with patch("openlibrary.plugins.openlibrary.status._github_get_async", side_effect=fake_get):
+        assert (await status_module._get_pr_drift_async(_make_pr()))["closed"] is True
+
+    async def fake_get_merged(path):
+        if path.startswith("pulls/"):
+            return {"state": "closed", "merged": True, "merged_at": "2026-08-01", "head": {"sha": "abc1234"}, "user": {}, "assignee": {}, "title": "Merged PR"}
+        return {}
+
+    with patch("openlibrary.plugins.openlibrary.status._github_get_async", side_effect=fake_get_merged):
+        info = await status_module._get_pr_drift_async(_make_pr())
+    assert info["closed"] is False
+    assert info["merged"] is True
+
+
+def test_deploy_drops_closed_prs():
+    """Deploying removes closed (not merged) PRs from the set, like merged ones."""
+    pr = _make_pr(added_at="2026-08-01T10:00:00+00:00")
+    state = _make_state(prs=[pr])
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch(
+            "openlibrary.plugins.openlibrary.status._get_drift_info",
+            return_value=({pr.pr: {"head_sha": "", "drift": 0, "merged": False, "closed": True}}, False),
+        ),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+    ):
+        status_module.status_deploy().POST()
+
+    assert state.prs == []
 
 
 def test_pending_changes_folds_a_pin_into_an_unlanded_add():
@@ -644,6 +713,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
                 "head_sha": "abc1234",
                 "drift": 2,
                 "merged": False,
+                "closed": False,
                 "is_new": True,
                 "live_now": False,
                 "merge_conflict": False,

--- a/tests/unit/js/testing-status.test.js
+++ b/tests/unit/js/testing-status.test.js
@@ -4,9 +4,11 @@ import {
     decodeAndParseJSON,
     driftPill,
     effectiveActive,
+    effectivePendingRemoval,
     faviconEnv,
     formatTime,
     getTestingStatus,
+    patchAction,
     postAction,
     sprintf,
     testingStatusUrl,
@@ -56,14 +58,31 @@ describe('Testing Environment utils', () => {
         const body = { ok: true };
         global.fetch = jest.fn().mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue(body) });
 
-        await expect(postAction('/status/remove', { prs: [13269, 13270] })).resolves.toBe(body);
+        await expect(postAction('/status/prs', { prs: ['13269', '13270'] })).resolves.toBe(body);
 
         expect(global.fetch).toHaveBeenCalledWith(
-            '/status/remove',
+            '/status/prs',
             expect.objectContaining({
                 method: 'POST',
                 credentials: 'same-origin',
                 body: new URLSearchParams([['prs', '13269'], ['prs', '13270']])
+            })
+        );
+    });
+
+    test('patches PR actions as JSON', async() => {
+        const body = { ok: true };
+        global.fetch = jest.fn().mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue(body) });
+
+        await expect(patchAction('/status/prs/13269', { pending_removal: true })).resolves.toBe(body);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/status/prs/13269',
+            expect.objectContaining({
+                method: 'PATCH',
+                credentials: 'same-origin',
+                headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+                body: JSON.stringify({ pending_removal: true })
             })
         );
     });
@@ -83,7 +102,7 @@ describe('Testing Environment utils', () => {
         global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
 
         await expect(getTestingStatus({ hostname: 'localhost' })).rejects.toThrow('500');
-        await expect(postAction('/status/remove', {})).rejects.toThrow('failed');
+        await expect(postAction('/status/prs', {})).rejects.toThrow('failed');
     });
 
     test('fills %s placeholders in order', () => {
@@ -136,6 +155,14 @@ describe('Testing Environment utils', () => {
         expect(effectiveActive({ active: true, pending_active: false })).toBe(false);
         expect(effectiveActive({ active: false, pending_active: true })).toBe(true);
         expect(effectiveActive({ active: true, pending_active: null })).toBe(true);
+    });
+
+    test('resolves pending removal state', () => {
+        expect(effectivePendingRemoval({ pending_removal: true })).toBe(true);
+        expect(effectivePendingRemoval({ pending_removal: false })).toBe(false);
+        expect(effectivePendingRemoval({ pending_removal: null })).toBe(false);
+        expect(effectivePendingRemoval({})).toBe(false);
+        expect(effectivePendingRemoval({ active: true })).toBe(false);
     });
 
     test('offers pull-latest only when a newer commit is available', () => {

--- a/tests/unit/js/testing-status.test.js
+++ b/tests/unit/js/testing-status.test.js
@@ -11,6 +11,7 @@ import {
     patchAction,
     postAction,
     sprintf,
+    statusApiUrl,
     testingStatusUrl,
     timeAgo
 } from '../../../openlibrary/components/TestingEnvironment/utils.js';
@@ -40,6 +41,13 @@ describe('Testing Environment utils', () => {
         expect(testingStatusUrl({ hostname: 'localhost' })).toBe('/status/testing.json');
         expect(testingStatusUrl({ hostname: 'testing.openlibrary.org' })).toBe('/_fast/status/testing.json');
         expect(testingStatusUrl({ hostname: 'openlibrary.org' })).toBe('/status/testing.json');
+    });
+
+    test('statusApiUrl prefixes /_fast on testing for any path', () => {
+        expect(statusApiUrl('/status/prs', { hostname: 'localhost' })).toBe('/status/prs');
+        expect(statusApiUrl('/status/prs', { hostname: 'testing.openlibrary.org' })).toBe('/_fast/status/prs');
+        expect(statusApiUrl('/status/prs/123', { hostname: 'testing.openlibrary.org' })).toBe('/_fast/status/prs/123');
+        expect(statusApiUrl('/status/deploy', { hostname: 'openlibrary.org' })).toBe('/status/deploy');
     });
 
     test('fetches JSON with same-origin credentials', async() => {


### PR DESCRIPTION
This is migrating our code to fastapi and improving the contract along the way to be more robust.

<!-- What issue does this PR close? -->
Closes #

TODO: I need to fix that when you try to add a PR in the box it says
> {"detail":[{"type":"model_attributes_type","loc":["body"],"msg":"Input should be a valid dictionary or object to extract fields from","input":"prs=13387"}]}

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
