### PR TITLE
Fix search facets fallback when partial loading fails

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5935,6 +5935,10 @@ msgstr ""
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr ""
 
+#: search/work_search_facets.html
+msgid "Search filters are temporarily unavailable. Please try again later."
+msgstr ""
+
 #: search/work_search_selected_facets.html
 msgid "Published by"
 msgstr ""

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -71,8 +71,11 @@ export async function initSearchFacets(facetsElem) {
         const param = JSON.parse(facetsElem.dataset.param);
         await whenVisible(facetsElem);
 
-        fetchPartials(param)
+        return fetchPartials(param)
             .then((data) => {
+                if (!data || typeof data.sidebar !== 'string') {
+                    throw new Error('Search facets partials response is missing sidebar markup.');
+                }
                 if (data.activeFacets) {
                     const activeFacetsElem = createElementFromMarkup(data.activeFacets);
                     const activeFacetsContainer = document.querySelector('.selected-search-facets-container');
@@ -85,11 +88,21 @@ export async function initSearchFacets(facetsElem) {
                 document.title = data.title;
             })
             .catch(() => {
-                // XXX : Handle case where `/partials` response is not `2XX` here
+                showSearchFacetsError(facetsElem);
             });
     } else {
         hydrateFacets();
     }
+}
+
+/**
+ * Replaces the loading indicators with a localized failure message.
+ *
+ * @param {HTMLElement} facetsElem Root element of the search facets sidebar component
+ */
+function showSearchFacetsError(facetsElem) {
+    facetsElem.querySelectorAll('.facet').forEach((facet) => facet.remove());
+    facetsElem.querySelector('.search-facets-error').classList.remove('ui-helper-hidden');
 }
 
 

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -78,10 +78,16 @@ export async function initSearchFacets(facetsElem) {
                 }
                 if (data.activeFacets) {
                     const activeFacetsElem = createElementFromMarkup(data.activeFacets);
+                    if (!(activeFacetsElem instanceof HTMLElement)) {
+                        throw new Error('Search facets partials response contains invalid active facets markup.');
+                    }
                     const activeFacetsContainer = document.querySelector('.selected-search-facets-container');
                     activeFacetsContainer.replaceChildren(activeFacetsElem);
                 }
                 const newFacetsElem = createElementFromMarkup(data.sidebar);
+                if (!(newFacetsElem instanceof HTMLElement)) {
+                    throw new Error('Search facets partials response contains invalid sidebar markup.');
+                }
                 facetsElem.replaceWith(newFacetsElem);
                 hydrateFacets();
 

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -76,6 +76,7 @@ $def facet_entry(display, count, facet_url, hide_entry=False):
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
         $:_('Focus your results using these <a href="/search/howto">filters</a>')
     </div>
+    <p class="search-facets-error ui-helper-hidden" role="status">$_('Search filters are temporarily unavailable. Please try again later.')</p>
     $for header, label in get_facet_map():
         $# Readability (has_fulltext) is owned by the "Readable Only" toggle in
         $# the filter row now, so it's no longer offered as a sidebar facet.

--- a/tests/unit/js/search.test.js
+++ b/tests/unit/js/search.test.js
@@ -1,4 +1,32 @@
-import { more, less } from '../../../openlibrary/plugins/openlibrary/js/search.js';
+import { initSearchFacets, more, less } from '../../../openlibrary/plugins/openlibrary/js/search.js';
+
+function createAsyncSearchFacets() {
+    const facets = document.createElement('div');
+    facets.id = 'searchFacets';
+    facets.dataset.asyncLoad = 'true';
+    facets.dataset.param = '{}';
+    facets.innerHTML = `
+        <p class="search-facets-error ui-helper-hidden" role="status">Search filters are temporarily unavailable.</p>
+        <div class="facet"><span class="small">Loading...</span></div>
+    `;
+    return facets;
+}
+
+const originalIntersectionObserver = global.IntersectionObserver;
+const originalFetch = global.fetch;
+
+class ImmediatelyVisibleObserver {
+    constructor(callback) {
+        this.callback = callback;
+    }
+
+    observe(target) {
+        this.callback([{isIntersecting: true, target}], this);
+    }
+
+    unobserve() {}
+    disconnect() {}
+}
 
 /** Creates a dummy search facets section with a list of 'facetEntry' element and a
  * 'facetMoreLess' section.
@@ -135,6 +163,40 @@ const _stubbedGetClientRects = function() {
     }
     return [{width: 1, height: 1}];
 };
+
+describe('initSearchFacets', () => {
+    beforeEach(() => {
+        global.IntersectionObserver = ImmediatelyVisibleObserver;
+        document.body.replaceChildren(createAsyncSearchFacets());
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        global.IntersectionObserver = originalIntersectionObserver;
+    });
+
+    test('shows a fallback message when the partials request fails', async() => {
+        global.fetch = jest.fn().mockResolvedValue({ok: false, status: 503});
+
+        await initSearchFacets(document.getElementById('searchFacets'));
+
+        expect(document.querySelector('.search-facets-error').classList.contains('ui-helper-hidden')).toBe(false);
+        expect(document.querySelector('.facet')).toBeNull();
+        expect(document.body.textContent).not.toContain('Loading...');
+    });
+
+    test('shows a fallback message instead of rendering an invalid sidebar payload', async() => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({title: 'Search results'}),
+        });
+
+        await initSearchFacets(document.getElementById('searchFacets'));
+
+        expect(document.querySelector('.search-facets-error').classList.contains('ui-helper-hidden')).toBe(false);
+        expect(document.body.textContent).not.toContain('undefined');
+    });
+});
 
 describe('more', () => {
     [

--- a/tests/unit/js/search.test.js
+++ b/tests/unit/js/search.test.js
@@ -185,16 +185,20 @@ describe('initSearchFacets', () => {
         expect(document.body.textContent).not.toContain('Loading...');
     });
 
-    test('shows a fallback message instead of rendering an invalid sidebar payload', async() => {
+    test('shows a fallback message instead of rendering a plain-text sidebar payload', async() => {
         global.fetch = jest.fn().mockResolvedValue({
             ok: true,
-            json: jest.fn().mockResolvedValue({title: 'Search results'}),
+            json: jest.fn().mockResolvedValue({
+                title: 'Search results',
+                sidebar: 'Unable to render this page.',
+            }),
         });
 
         await initSearchFacets(document.getElementById('searchFacets'));
 
         expect(document.querySelector('.search-facets-error').classList.contains('ui-helper-hidden')).toBe(false);
         expect(document.body.textContent).not.toContain('undefined');
+        expect(document.body.textContent).not.toContain('Unable to render this page.');
     });
 });
 


### PR DESCRIPTION
Fixes #13377

## What changed
- Show a localized fallback when async search facets cannot be loaded.
- Guard against malformed partial responses that omit sidebar markup, avoiding an `undefined` sidebar.
- Remove loading placeholders while leaving selected facets unchanged.

## Testing
- `npm run test:js -- tests/unit/js/search.test.js`
- `pre-commit run --files openlibrary/plugins/openlibrary/js/search.js openlibrary/templates/search/work_search_facets.html tests/unit/js/search.test.js openlibrary/i18n/messages.pot`

## Screenshot
<img width="2851" height="1779" alt="image" src="https://github.com/user-attachments/assets/311e1840-e77c-4f5e-a325-35dc112ee1b4" />








<img width="2851" height="2067" alt="image" src="https://github.com/user-attachments/assets/a46096ae-a64c-4131-8a95-d444a972b148" />
