### PR TITLE
fix: add FastAPI route alias for .json note POSTs to match legacy web…

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -242,6 +242,7 @@ class BooknoteResponse(BaseModel):
 
 
 @router.post("/works/OL{work_id}W/notes", response_model=BooknoteResponse)
+@router.post("/works/OL{work_id}W/notes.json", response_model=BooknoteResponse)
 async def booknotes_post(
     work_id: Annotated[int, Path(gt=0)],
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],

--- a/openlibrary/tests/fastapi/test_booknotes.py
+++ b/openlibrary/tests/fastapi/test_booknotes.py
@@ -78,6 +78,32 @@ class TestBooknotesPost:
         assert response.json() == {"success": "removed note"}
         remove_mock.assert_called_once_with("testuser", 123, edition_id=-1)
 
+    def test_add_note_via_json_url(self, fastapi_client, mock_authenticated_user, mock_booknotes):
+        add_mock, remove_mock = mock_booknotes
+        response = fastapi_client.post(
+            "/works/OL123W/notes.json",
+            data={"notes": "Great book!"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"success": "note added"}
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            notes="Great book!",
+            edition_id=-1,
+        )
+        remove_mock.assert_not_called()
+
+    def test_remove_note_via_json_url(self, fastapi_client, mock_authenticated_user, mock_booknotes):
+        _, remove_mock = mock_booknotes
+        response = fastapi_client.post(
+            "/works/OL123W/notes.json",
+            data={},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"success": "removed note"}
+        remove_mock.assert_called_once_with("testuser", 123, edition_id=-1)
+
     def test_invalid_edition_id_returns_422(self, fastapi_client, mock_authenticated_user):
         """Invalid edition_id format (not OL{number}M) returns 422 validation error."""
         response = fastapi_client.post(


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds the `.json` route to `/works/OL{id}W/notes` as #12007  migrated the notes endpoint to FastAPI and registered
`POST /works/OL{id}W/notes` without the `.json` alias, but the frontend (NotesModal + work-page
modal, `modals/index.js`) still POSTs to `/works/OL{id}W/notes.json`. 


### Technical
<!-- What should be noted about the implementation? -->
- Adds the `.json` route alias to the **existing** `booknotes_post` handler.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Regression test added in `test_booknotes.py`: add + remove via `POST /works/OL123W/notes.json`
- 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
