### PR TITLE
chore: remove remaining deprecated web.py endpoints migrated to FastAPI

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -535,10 +535,6 @@ async def get_bestbook_count(
     return BestbookCountResponse(count=Bestbook.get_count(work_id=work_id, username=username, topic=topic))
 
 
-async def unlink_ia_ol():
-    pass
-
-
 class MonthlyLoginsResponse(BaseModel):
     """Response model for the /api/monthly_logins.json endpoint."""
 

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -35,10 +35,15 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
-from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async, get_works_data_async
+from openlibrary.plugins.openlibrary.api import (
+    bestbook_award,
+    get_bookshelves_summary,
+    get_editions_data,
+    get_price_data_async,
+    get_works_data_async,
+    process_work_bookshelves,
+)
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
-from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
-from openlibrary.plugins.openlibrary.api import work_editions as legacy_work_editions
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.views.loanstats import SINCE_DAYS, get_trending_books
 
@@ -275,7 +280,7 @@ async def booknotes_post(
 @router.get("/works/OL{work_id}W/bookshelves.json")
 def get_work_bookshelves(work_id: Annotated[int, Path(gt=0)]) -> dict:
     """Get reading-log shelf counts for a work."""
-    return legacy_work_bookshelves.get_bookshelves_summary(work_id)
+    return get_bookshelves_summary(work_id)
 
 
 @router.post("/works/OL{work_id}W/bookshelves.json")
@@ -287,7 +292,7 @@ def post_work_bookshelves(
     dont_remove: Annotated[bool | None, Form()] = None,
 ) -> dict:
     """Add a work to, move a work between, or remove a work from a reading-log shelf."""
-    return legacy_work_bookshelves.process_work_bookshelves(
+    return process_work_bookshelves(
         username=user.username,
         work_id=work_id,
         bookshelf_id=bookshelf_id,
@@ -310,7 +315,7 @@ def work_editions(
     offset: Annotated[int, Query(ge=0, description="Number of editions to skip")] = 0,
 ) -> PaginatedGroupEntryResponse:
     """Get paginated editions for a work."""
-    data = legacy_work_editions.get_editions_data(
+    data = get_editions_data(
         f"/works/OL{work_id}W",
         url=request.url,
         limit=limit,

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -38,7 +38,6 @@ from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.plugins.openlibrary.home import get_cached_featured_subjects
 from openlibrary.utils import extract_numeric_id_from_olid
-from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.request_context import req_context, site
 
@@ -232,9 +231,6 @@ async def get_works_data_async(key: str, url: URL, limit: int, offset: int) -> d
         links["next"] = str(url.include_query_params(offset=offset + limit))
 
     return {"links": links, "size": size, "entries": works}
-
-
-get_works_data = async_bridge.wrap(get_works_data_async)
 
 
 async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -6,20 +6,16 @@ its experience. This does not include public facing APIs with LTS
 
 from __future__ import annotations
 
-import io
 import json
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal
 from warnings import deprecated
 
-import qrcode
 import web
-from starlette.datastructures import URL
 
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.infobase.client import ClientException
-from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate
 from infogami.utils.view import (
     render_template,  # noqa: F401 used for its side effects
@@ -29,8 +25,6 @@ from openlibrary.accounts.model import (
     OpenLibraryAccount,  # noqa: F401 side effects may be needed
 )
 from openlibrary.core import cache
-from openlibrary.core import helpers as h
-from openlibrary.core.admin import get_unique_logins_since
 from openlibrary.core.auth import ExpiredTokenError, HMACToken
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.models import Booknotes
@@ -49,6 +43,8 @@ from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.request_context import req_context, site
 
 if TYPE_CHECKING:
+    from starlette.datastructures import URL
+
     from openlibrary.core.models import Work
 
 logger = logging.getLogger(__name__)
@@ -130,174 +126,80 @@ class booknotes(delegate.page):
         return response("note added")
 
 
-# The GET of work_bookshelves, work_ratings, and work_likes should return some summary of likes,
-# not a value tied to this logged in user. This is being used as debugging.
+def get_bookshelves_summary(work_id):
+    from openlibrary.core.models import Bookshelves
+
+    return {"counts": Bookshelves.get_work_summary(str(work_id))}
 
 
-@deprecated("migrated to fastapi")
-class work_bookshelves(delegate.page):
-    path = r"/works/OL(\d+)W/bookshelves"
-    encoding = "json"
+def process_work_bookshelves(username, work_id, bookshelf_id, edition_id=None, dont_remove=False):
+    from openlibrary.core.models import Bookshelves
 
-    @jsonapi
-    def GET(self, work_id):
-        return json.dumps(self.get_bookshelves_summary(work_id))
+    if bookshelf_id is None:
+        return {"error": "Invalid bookshelf"}
 
-    @staticmethod
-    def get_bookshelves_summary(work_id):
-        from openlibrary.core.models import Bookshelves
+    work_id_str = str(work_id)
+    current_status = Bookshelves.get_users_read_status_of_work(username, work_id_str)
 
-        return {"counts": Bookshelves.get_work_summary(str(work_id))}
-
-    @staticmethod
-    def process_work_bookshelves(username, work_id, bookshelf_id, edition_id=None, dont_remove=False):
-        from openlibrary.core.models import Bookshelves
-
-        if bookshelf_id is None:
+    try:
+        bookshelf_id_val = int(bookshelf_id)
+        shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
+        if bookshelf_id_val != -1 and bookshelf_id_val not in shelf_ids:
             return {"error": "Invalid bookshelf"}
+    except TypeError, ValueError:
+        return {"error": "Invalid bookshelf"}
 
-        work_id_str = str(work_id)
-        current_status = Bookshelves.get_users_read_status_of_work(username, work_id_str)
+    if ((not dont_remove) and bookshelf_id_val == current_status) or bookshelf_id_val == -1:
+        from openlibrary.core.bookshelves_events import BookshelvesEvents
 
-        try:
-            bookshelf_id_val = int(bookshelf_id)
-            shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
-            if bookshelf_id_val != -1 and bookshelf_id_val not in shelf_ids:
-                return {"error": "Invalid bookshelf"}
-        except TypeError, ValueError:
-            return {"error": "Invalid bookshelf"}
-
-        if ((not dont_remove) and bookshelf_id_val == current_status) or bookshelf_id_val == -1:
-            from openlibrary.core.bookshelves_events import BookshelvesEvents
-
-            work_bookshelf = Bookshelves.remove(
-                username=username,
-                work_id=work_id_str,
-                bookshelf_id=str(current_status) if current_status else None,
-            )
-            BookshelvesEvents.delete_by_username_and_work(username, work_id_str)
-        else:
-            from openlibrary.utils import extract_numeric_id_from_olid
-
-            resolved_edition_id = int(extract_numeric_id_from_olid(edition_id)) if edition_id else None
-            work_bookshelf = Bookshelves.add(
-                username=username,
-                bookshelf_id=str(bookshelf_id_val),
-                work_id=work_id_str,
-                edition_id=resolved_edition_id,
-            )
-
-        return {"bookshelves_affected": work_bookshelf}
-
-    def POST(self, work_id):
-        """
-        Add a work (or a work and an edition) to a bookshelf.
-
-        GET params:
-        - edition_id str (optional)
-        - action str: e.g. "add", "remove"
-        - redir bool: if patron not logged in, redirect back to page after login
-        - bookshelf_id int: which bookshelf? e.g. the ID for "want to read"?
-        - dont_remove bool: if book exists & action== "add", don't try removal
-
-        :param str work_id: e.g. OL123W
-        :rtype: json
-        :return: a list of bookshelves_affected
-        """
-        user = accounts.get_current_user()
-        i = web.input(
-            edition_id=None,
-            action="add",
-            redir=False,
-            bookshelf_id=None,
-            dont_remove=False,
-        )
-        key = i.edition_id or ("/works/OL%sW" % work_id)
-
-        if not user:
-            raise web.seeother("/account/login?redirect=%s" % key)
-
-        username = user.key.split("/")[2]
-        response = self.process_work_bookshelves(
+        work_bookshelf = Bookshelves.remove(
             username=username,
-            work_id=work_id,
-            bookshelf_id=i.bookshelf_id,
-            edition_id=i.edition_id,
-            dont_remove=i.dont_remove,
+            work_id=work_id_str,
+            bookshelf_id=str(current_status) if current_status else None,
+        )
+        BookshelvesEvents.delete_by_username_and_work(username, work_id_str)
+    else:
+        from openlibrary.utils import extract_numeric_id_from_olid
+
+        resolved_edition_id = int(extract_numeric_id_from_olid(edition_id)) if edition_id else None
+        work_bookshelf = Bookshelves.add(
+            username=username,
+            bookshelf_id=str(bookshelf_id_val),
+            work_id=work_id_str,
+            edition_id=resolved_edition_id,
         )
 
-        if i.redir:
-            raise web.seeother(key)
-        return delegate.RawText(
-            json.dumps(response),
-            content_type="application/json",
-        )
+    return {"bookshelves_affected": work_bookshelf}
 
 
-@deprecated("migrated to fastapi")
-class work_editions(delegate.page):
-    path = r"(/works/OL\d+W)/editions"
-    encoding = "json"
+def get_editions_data(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
+    current_site = site.get()
+    work = current_site.get(key)
+    if not work or work.type.key != "/type/work":
+        return None
 
-    def GET(self, key):
-        i = web.input(limit=50, offset=0)
-        data = self.get_editions_data(
-            key,
-            url=URL(web.ctx.fullpath),
-            limit=h.safeint(i.limit) or 50,
-            offset=h.safeint(i.offset) or 0,
-        )
-        if data is None:
-            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
-        return delegate.RawText(json.dumps(data), content_type="application/json")
-
-    @staticmethod
-    def get_editions_data(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
-        current_site = site.get()
-        work = current_site.get(key)
-        if not work or work.type.key != "/type/work":
-            return None
-
-        limit = min(limit or 50, 1000)
-        keys = current_site.things(
-            {
-                "type": "/type/edition",
-                "works": work.key,
-                "limit": limit,
-                "offset": offset,
-            }
-        )
-        editions = current_site.get_many(keys, raw=True)
-
-        url = url.replace(scheme="", netloc="")
-        links = {
-            "self": str(url),
-            "work": work.key,
+    limit = min(limit or 50, 1000)
+    keys = current_site.things(
+        {
+            "type": "/type/edition",
+            "works": work.key,
+            "limit": limit,
+            "offset": offset,
         }
-        if offset > 0:
-            links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
-        if offset + len(editions) < work.edition_count:
-            links["next"] = str(url.include_query_params(offset=offset + limit))
+    )
+    editions = current_site.get_many(keys, raw=True)
 
-        return {"links": links, "size": work.edition_count, "entries": editions}
+    url = url.replace(scheme="", netloc="")
+    links = {
+        "self": str(url),
+        "work": work.key,
+    }
+    if offset > 0:
+        links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
+    if offset + len(editions) < work.edition_count:
+        links["next"] = str(url.include_query_params(offset=offset + limit))
 
-
-@deprecated("migrated to fastapi")
-class author_works(delegate.page):
-    path = r"(/authors/OL\d+A)/works"
-    encoding = "json"
-
-    def GET(self, key):
-        i = web.input(limit=50, offset=0)
-        data = get_works_data(
-            key,
-            url=URL(web.ctx.fullpath),
-            limit=h.safeint(i.limit, 50),
-            offset=h.safeint(i.offset, 0),
-        )
-        if data is None:
-            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
-        return delegate.RawText(json.dumps(data), content_type="application/json")
+    return {"links": links, "size": work.edition_count, "entries": editions}
 
 
 async def get_works_data_async(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
@@ -491,41 +393,6 @@ class work_delete(delegate.page):
             ),
             content_type="application/json",
         )
-
-
-@deprecated("migrated to fastapi")
-class hide_banner(delegate.page):
-    path = "/hide_banner"
-
-    def POST(self):
-        user = accounts.get_current_user()
-        data = json.loads(web.data())
-
-        # Set truthy cookie that expires in 30 days:
-        DAY_SECONDS = 60 * 60 * 24
-        cookie_duration_days = int(data.get("cookie-duration-days", 30))
-
-        if user and data["cookie-name"].startswith("yrg"):
-            user.save_preferences({"yrg_banner_pref": data["cookie-name"]})
-
-        web.setcookie(data["cookie-name"], "1", expires=(cookie_duration_days * DAY_SECONDS))
-
-        return delegate.RawText(json.dumps({"success": "Preference saved"}), content_type="application/json")
-
-
-@deprecated("migrated to fastapi")
-class create_qrcode(delegate.page):
-    path = "/qrcode"
-
-    def GET(self):
-        i = web.input(path="/")
-        page_path = i.path
-        qr_url = f"{web.ctx.home}{page_path}"
-        img = qrcode.make(qr_url)
-        with io.BytesIO() as buf:
-            img.save(buf, format="PNG")
-            web.header("Content-Type", "image/png")
-            return delegate.RawText(buf.getvalue())
 
 
 class bestbook_award:
@@ -851,67 +718,3 @@ class unlink_ia_ol(delegate.page):
                 comment or DEFAULT_UNLINK_COMMENT,
                 action="edit-edition-ocaid",
             )
-
-
-@deprecated("migrated to fastapi")
-class link_ia_ol(delegate.page):
-    path = "/api/link"
-    encoding = "json"
-
-    def POST(self):
-        i = web.input(digest="", msg="")
-        digest = i.digest
-        msg = i.msg
-
-        try:
-            if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
-                raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-        except ValueError, ExpiredTokenError:
-            raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-
-        parts = msg.split("|", maxsplit=2)
-        if len(parts) != 3 or not all(parts):
-            raise web.HTTPError(
-                "400 Bad Request",
-                {"Content-Type": "application/json"},
-                data=json.dumps({"error": "Invalid inputs"}),
-            )
-        ocaid, olid, _ts = parts
-
-        # Fetch affected edition
-        edition = web.ctx.site.get(f"/books/{olid}")
-        if not edition:
-            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
-
-        # Update record
-        try:
-            self.link(edition, ocaid)
-        except ClientException as e:
-            logger.error(f"Failed to associate {ocaid} with {olid}", exc_info=True)
-            raise web.HTTPError(
-                "500 Internal Server Error",
-                {"Content-Type": "application/json"},
-                data=json.dumps({"error": str(e)}),
-            )
-
-        return delegate.RawText(json.dumps({"status": "ok"}))
-
-    @staticmethod
-    def link(edition, ocaid):
-        data = edition.dict()
-        data["ocaid"] = ocaid
-        with accounts.RunAs("ImportBot"):
-            web.ctx.ip = web.ctx.ip or "127.0.0.1"
-            web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
-
-
-@deprecated("migrated to fastapi")
-class monthly_logins(delegate.page):
-    path = "/api/monthly_logins"
-    encoding = "json"
-
-    def GET(self):
-        return delegate.RawText(
-            json.dumps({"loginCount": get_unique_logins_since()}),
-            content_type="application/json",
-        )

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -129,4 +129,13 @@ DEPRECATED_PATHS: list[tuple[str, str | None]] = [
     (r"/people/[^/]+/lists/OL\d+L/subjects", "json"),
     (r"/lists/OL\d+L/subjects", "json"),
     (r"/series/OL\d+L/subjects", "json"),
+    # Works endpoints migrated to FastAPI
+    (r"/works/OL(\d+)W/check-ins", "json"),
+    (r"/works/OL(\d+)W/bookshelves", "json"),
+    (r"(/works/OL\d+W)/editions", "json"),
+    (r"(/authors/OL\d+A)/works", "json"),
+    (r"/hide_banner", None),
+    (r"/api/link", "json"),
+    (r"/api/monthly_logins", "json"),
+    (r"/qrcode", None),
 ]

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -1,11 +1,5 @@
 """Reading log check-ins handler and services."""
 
-import json
-from warnings import deprecated
-
-import web
-
-from infogami.utils import delegate
 from infogami.utils.view import public
 from openlibrary.accounts import get_current_user
 from openlibrary.core.bookshelves_events import BookshelfEvent, BookshelvesEvents
@@ -57,82 +51,6 @@ def get_latest_read_date(work_olid: str) -> dict | None:
 
     result = BookshelvesEvents.get_latest_event_date(username, work_id, BookshelfEvent.FINISH)
     return result
-
-
-@deprecated("migrated to fastapi")
-class patron_check_ins(delegate.page):
-    path = r"/works/OL(\d+)W/check-ins"
-    encoding = "json"
-
-    def POST(self, work_id):
-        """Validates data, constructs date string, and persists check-in event.
-
-        Data object should have the following:
-        event_type : number
-        year : number
-        month : number : optional
-        day : number : optional
-        edition_key : string : optional
-        event_id : int : optional
-        """
-        user = get_current_user()
-        if not user:
-            raise web.HTTPError("401 Unauthorized", headers={"Content-Type": "application/json"})
-
-        data = json.loads(web.data())
-        if not self.validate_data(data):
-            raise web.HTTPError("400 Bad Request", headers={"Content-Type": "application/json"})
-
-        username = user["key"].split("/")[-1]
-
-        edition_key = data.get("edition_key", None)
-        edition_id = extract_numeric_id_from_olid(edition_key) if edition_key else None
-
-        event_type = data.get("event_type")
-
-        date_str = make_date_string(
-            data.get("year", None),
-            data.get("month", None),
-            data.get("day", None),
-        )
-
-        event_id = data.get("event_id", None)
-
-        if event_id:
-            # update existing event
-            events = BookshelvesEvents.select_by_id(event_id)
-            if not events:
-                raise web.HTTPError("404 Not Found", headers={"Content-Type": "application/json"})
-
-            event = events[0]
-            if username != event["username"]:
-                raise web.HTTPError("403 Forbidden", headers={"Content-Type": "application/json"})
-
-            BookshelvesEvents.update_event(event_id, event_date=date_str, edition_id=edition_id)
-        else:
-            # create new event
-            result = BookshelvesEvents.create_event(username, work_id, edition_id, date_str, event_type=event_type)
-
-            event_id = result
-
-        return delegate.RawText(json.dumps({"status": "ok", "id": event_id}))
-
-    def validate_data(self, data):
-        """Validates data submitted from check-in dialog."""
-
-        # Event type must exist:
-        if "event_type" not in data:
-            return False
-
-        if not BookshelfEvent.has_value(data.get("event_type")):
-            return False
-
-        # Date must be valid:
-        return is_valid_date(
-            data.get("year", None),
-            data.get("month", None),
-            data.get("day", None),
-        )
 
 
 def setup():

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -1,7 +1,6 @@
 from openlibrary.plugins.upstream.checkins import (
     is_valid_date,
     make_date_string,
-    patron_check_ins,
 )
 
 
@@ -58,40 +57,3 @@ class TestIsValidDate:
         # Valid boundary days:
         assert is_valid_date(1999, 1, 1) is True
         assert is_valid_date(1999, 1, 31) is True
-
-
-class TestValidateData:
-    def setup_method(self):
-        self.checkins = patron_check_ins()
-        self.valid_data = {
-            "edition_key": "/books/OL1234M",
-            "event_type": 3,
-            "year": 2000,
-            "month": 3,
-            "day": 7,
-        }
-        self.missing_event = {
-            "edition_key": "/books/OL1234M",
-            "year": 2000,
-            "month": 3,
-            "day": 7,
-        }
-        self.invalid_date = {
-            "edition_key": "/books/OL1234M",
-            "event_type": 3,
-            "month": 3,
-            "day": 7,
-        }
-        self.unknown_event = {
-            "edition_key": "/books/OL1234M",
-            "event_type": 54321,
-            "year": 2000,
-            "month": 3,
-            "day": 7,
-        }
-
-    def test_validate_data(self):
-        assert self.checkins.validate_data(self.valid_data) is True
-        assert self.checkins.validate_data(self.missing_event) is False
-        assert self.checkins.validate_data(self.invalid_date) is False
-        assert self.checkins.validate_data(self.unknown_event) is False

--- a/openlibrary/tests/fastapi/test_hide_banner.py
+++ b/openlibrary/tests/fastapi/test_hide_banner.py
@@ -1,16 +1,11 @@
 """Tests for the FastAPI hide banner endpoint."""
 
-import json
 from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from http.cookies import SimpleCookie
 from unittest.mock import Mock, patch
 
 import pytest
-
-from openlibrary.plugins.openlibrary.api import hide_banner as legacy_hide_banner
-
-DAY_SECONDS = 60 * 60 * 24
 
 
 def parse_response_cookie(response, cookie_name: str):
@@ -106,26 +101,3 @@ class TestHideBannerEndpoint:
 
         assert get_response.status_code == 405
         assert json_suffix_response.status_code == 404
-
-
-def test_hide_banner_response_and_cookie_match_legacy(fastapi_client):
-    data = {"cookie-name": "legacy-parity-banner", "cookie-duration-days": 2}
-
-    with (
-        patch("openlibrary.plugins.openlibrary.api.accounts.get_current_user", return_value=None),
-        patch("openlibrary.plugins.openlibrary.api.web.data", return_value=json.dumps(data)),
-        patch("openlibrary.plugins.openlibrary.api.web.setcookie") as legacy_setcookie,
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        legacy_response = json.loads(legacy_hide_banner().POST()["rawtext"])
-
-    with patch("openlibrary.fastapi.internal.api.accounts.get_current_user", return_value=None):
-        fastapi_response = fastapi_client.post("/hide_banner", json=data)
-
-    assert fastapi_response.status_code == 200
-    assert fastapi_response.json() == legacy_response
-    legacy_setcookie.assert_called_once_with("legacy-parity-banner", "1", expires=2 * DAY_SECONDS)
-
-    fastapi_cookie = parse_response_cookie(fastapi_response, "legacy-parity-banner")
-    assert fastapi_cookie.value == "1"
-    assert_cookie_expiry(fastapi_cookie, 2)

--- a/openlibrary/tests/fastapi/test_link.py
+++ b/openlibrary/tests/fastapi/test_link.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
-
-import pytest
-import web as web_mod
 
 from infogami.infobase.client import ClientException
 from openlibrary.core.auth import ExpiredTokenError, MissingKeyError
-from openlibrary.plugins.openlibrary.api import link_ia_ol as legacy_link
 from openlibrary.utils.request_context import RequestContextVars, req_context, site
 
 
@@ -152,65 +147,3 @@ class TestLinkIAOL:
         )
         assert resp.status_code == 500
         assert resp.json()["detail"] == "Save failed"
-
-    def test_response_matches_legacy(self, fastapi_client):
-        msg = "ocaid123|OL123M|9999999999"
-        form_data = {"digest": "d", "msg": msg}
-
-        legacy_edition = MagicMock()
-        legacy_edition.dict.return_value = {
-            "key": "/books/OL123M",
-            "title": "Test Edition",
-        }
-        legacy_site = MagicMock()
-        legacy_site.get.return_value = legacy_edition
-
-        fastapi_edition = MagicMock()
-        fastapi_edition.dict.return_value = {
-            "key": "/books/OL123M",
-            "title": "Test Edition",
-        }
-        fastapi_site = MagicMock()
-        fastapi_site.get.return_value = fastapi_edition
-
-        _site_token = site.set(MagicMock())
-        _req_token = req_context.set(
-            RequestContextVars(
-                x_forwarded_for=None,
-                user_agent=None,
-                lang="en",
-                solr_editions=True,
-                print_disabled=False,
-            )
-        )
-        try:
-            # Minimal web.py request context for the legacy handler
-            web_mod.ctx.site = legacy_site
-            web_mod.ctx.ip = "127.0.0.1"
-            web_mod.ctx.env = {
-                "REQUEST_METHOD": "GET",
-                "QUERY_STRING": f"digest={form_data['digest']}&msg={form_data['msg']}",
-            }
-
-            with (
-                patch("openlibrary.plugins.openlibrary.api.HMACToken.verify", return_value=True),
-                patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
-                patch("openlibrary.fastapi.link.HMACToken.verify", return_value=True),
-                patch("openlibrary.fastapi.link.accounts.RunAs"),
-                pytest.deprecated_call(match="migrated to fastapi"),
-            ):
-                legacy_resp = json.loads(legacy_link().POST()["rawtext"])
-
-                site.set(fastapi_site)
-                fastapi_resp = fastapi_client.post("/api/link", data=form_data)
-        finally:
-            site.reset(_site_token)
-            req_context.reset(_req_token)
-
-        assert fastapi_resp.status_code == 200
-        assert fastapi_resp.json() == legacy_resp
-        fastapi_site.save.assert_called_once_with(
-            legacy_site.save.call_args[0][0],
-            legacy_site.save.call_args[0][1],
-            action=legacy_site.save.call_args[1]["action"],
-        )

--- a/openlibrary/tests/fastapi/test_monthly_logins.py
+++ b/openlibrary/tests/fastapi/test_monthly_logins.py
@@ -1,11 +1,6 @@
 """Tests for the FastAPI monthly logins endpoint."""
 
-import json
 from unittest.mock import patch
-
-import pytest
-
-from openlibrary.plugins.openlibrary.api import monthly_logins as legacy_monthly_logins
 
 
 def test_monthly_logins_returns_cached_count(fastapi_client):
@@ -15,18 +10,3 @@ def test_monthly_logins_returns_cached_count(fastapi_client):
     assert response.status_code == 200
     assert response.json() == {"loginCount": 12345}
     get_logins_mock.assert_called_once_with()
-
-
-def test_monthly_logins_response_matches_legacy(fastapi_client):
-    with (
-        patch("openlibrary.plugins.openlibrary.api.get_unique_logins_since", return_value=12345) as legacy_get_logins_mock,
-        patch("openlibrary.fastapi.internal.api.get_unique_logins_since", return_value=12345) as fastapi_get_logins_mock,
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        legacy_response = json.loads(legacy_monthly_logins().GET()["rawtext"])
-        fastapi_response = fastapi_client.get("/api/monthly_logins.json")
-
-    assert fastapi_response.status_code == 200
-    assert fastapi_response.json() == legacy_response
-    legacy_get_logins_mock.assert_called_once_with()
-    fastapi_get_logins_mock.assert_called_once_with()

--- a/openlibrary/tests/fastapi/test_qrcode.py
+++ b/openlibrary/tests/fastapi/test_qrcode.py
@@ -4,10 +4,7 @@ import io
 from unittest.mock import patch
 
 import pytest
-import web
 from PIL import Image
-
-from openlibrary.plugins.openlibrary.api import create_qrcode as legacy_create_qrcode
 
 
 class FakeImage:
@@ -51,23 +48,3 @@ class TestQRCodeEndpoint:
         response = fastapi_client.post("/qrcode", data={"path": "/books/OL1M"})
 
         assert response.status_code == 405
-
-
-def test_qrcode_target_url_matches_legacy(fastapi_client):
-    legacy_qr_urls = []
-    fastapi_qr_urls = []
-
-    with (
-        patch("openlibrary.plugins.openlibrary.api.web.ctx", web.storage(home="http://testserver")),
-        patch("openlibrary.plugins.openlibrary.api.web.input", return_value=web.storage(path="/books/OL1M")),
-        patch("openlibrary.plugins.openlibrary.api.web.header"),
-        patch("openlibrary.plugins.openlibrary.api.qrcode.make", side_effect=lambda url: legacy_qr_urls.append(url) or FakeImage()),
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        legacy_create_qrcode().GET()
-
-    with patch("openlibrary.fastapi.internal.api.qrcode.make", side_effect=lambda url: fastapi_qr_urls.append(url) or FakeImage()):
-        response = fastapi_client.get("/qrcode?path=/books/OL1M")
-
-    assert response.status_code == 200
-    assert legacy_qr_urls == fastapi_qr_urls == ["http://testserver/books/OL1M"]

--- a/openlibrary/tests/fastapi/test_work_bookshelves.py
+++ b/openlibrary/tests/fastapi/test_work_bookshelves.py
@@ -1,33 +1,8 @@
 """Tests for the FastAPI work bookshelves endpoints."""
 
-import json
 from unittest.mock import patch
 
 import pytest
-import web
-
-from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
-
-
-class FakeLegacyUser:
-    def __init__(self, username: str = "testuser"):
-        self.key = f"/people/{username}"
-
-
-def mock_web_input_func(data):
-    def _mock_web_input(*args, **kwargs):
-        return web.storage(kwargs | data)
-
-    return _mock_web_input
-
-
-def legacy_bookshelves_json(data, work_id=123):
-    with (
-        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
-        patch("openlibrary.accounts.get_current_user", return_value=FakeLegacyUser()),
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        return json.loads(legacy_work_bookshelves().POST(str(work_id))["rawtext"])
 
 
 @pytest.fixture
@@ -156,49 +131,3 @@ class TestWorkBookshelvesPost:
         response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "1", "edition_id": edition_id})
 
         assert response.status_code == 422
-
-
-class TestWorkBookshelvesLegacyParity:
-    def test_add_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
-        _, add_mock, _, _ = mock_bookshelves_model
-        add_mock.return_value = 1
-        data = {"bookshelf_id": "1", "edition_id": "/books/OL42M"}
-
-        legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response
-
-    def test_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
-        read_status_mock, _, remove_mock, _ = mock_bookshelves_model
-        read_status_mock.return_value = 2
-        remove_mock.return_value = 1
-        data = {"bookshelf_id": "-1"}
-
-        legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response
-
-    def test_invalid_bookshelf_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
-        data = {"bookshelf_id": "99"}
-
-        legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response
-
-    def test_dont_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
-        read_status_mock, add_mock, _, _ = mock_bookshelves_model
-        read_status_mock.return_value = 2
-        add_mock.return_value = 1
-        data = {"bookshelf_id": "2", "dont_remove": "true"}
-
-        legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -3,9 +3,6 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from starlette.datastructures import URL
-
-from openlibrary.plugins.openlibrary import api as legacy_api
 
 
 def make_test_site(
@@ -133,25 +130,6 @@ class TestWorkEditions:
         current_site.get.assert_called_once_with("/works/OL0W")
         current_site.things.assert_not_called()
 
-    def test_response_matches_legacy(self, fastapi_client, patched_site):
-        entries = [{"key": "/books/OL1M"}]
-
-        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=2, thing_keys=["/books/OL1M"], entries=entries)
-        patched_site.get.return_value = legacy_site
-        legacy_response = legacy_api.work_editions.get_editions_data(
-            self.DOC_KEY,
-            url=URL(f"{self.ENDPOINT}?limit=1&offset=0"),
-            limit=1,
-            offset=0,
-        )
-
-        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=2, thing_keys=["/books/OL1M"], entries=entries)
-        patched_site.get.return_value = fastapi_site
-        fastapi_response = fastapi_client.get(f"{self.ENDPOINT}?limit=1&offset=0")
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response
-
 
 class TestAuthorWorks:
     DOC_KEY = "/authors/OL456A"
@@ -254,22 +232,3 @@ class TestAuthorWorks:
         assert response.status_code == 404
         current_site.get.assert_called_once_with("/authors/OL0A")
         current_site.things.assert_not_called()
-
-    def test_response_matches_legacy(self, fastapi_client, patched_site):
-        entries = [{"key": "/works/OL1W"}]
-
-        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
-        patched_site.get.return_value = legacy_site
-        legacy_response = legacy_api.get_works_data(
-            self.DOC_KEY,
-            url=URL(f"{self.ENDPOINT}?limit=1&offset=0"),
-            limit=1,
-            offset=0,
-        )
-
-        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=AsyncMock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
-        patched_site.get.return_value = fastapi_site
-        fastapi_response = fastapi_client.get(f"{self.ENDPOINT}?limit=1&offset=0")
-
-        assert fastapi_response.status_code == 200
-        assert fastapi_response.json() == legacy_response


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR deletes the legacy web.py classes for endpoints that are confirmed to be served by FastAPI in production (verified via `x-served-by: FastAPI` header)


### Technical
<!-- What should be noted about the implementation? -->
Removed :
  - `/works/OL{id}W/check-ins`
  - `/works/OL{id}W/bookshelves`
  - `/works/OL{id}W/editions`
  - `/authors/OL{id}A/works`
  - `/hide_banner`
  - `/api/link`
  - `/api/monthly_logins`
  - `/qrcode`


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- `curl -sI https://openlibrary.org/works/OL82563W/check-ins.json | rg "x-served-by"`
- `curl -sI https://openlibrary.org/works/OL82563W/bookshelves.json | rg "x-served-by"`
- `curl -sI https://openlibrary.org/works/OL82563W/editions.json | rg "x-served-by"`
- `curl -sI https://openlibrary.org/authors/OL23919A/works.json | rg "x-served-by"`
- `curl -sI -X POST https://openlibrary.org/hide_banner | rg "x-served-by"`
- `curl -sI -X POST https://openlibrary.org/api/link | rg "x-served-by"`
- `curl -sI https://openlibrary.org/api/monthly_logins.json | rg "x-served-by"`
- `curl -sI "https://openlibrary.org/qrcode?path=/works/OL82563W" | rg "x-served-by"`


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
