### PR TITLE
Add --skip-ia-metadata flag to solr_builder

### DIFF
--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -103,6 +103,7 @@ class DataProvider:
 
     def __init__(self) -> None:
         self.ia_cache: dict[str, dict | None] = {}
+        self.skip_ia_metadata = False
 
     @staticmethod
     async def _get_lite_metadata(ocaids: Sequence[str], _recur_depth=0, _max_recur_depth=3):
@@ -178,6 +179,9 @@ class DataProvider:
         raise NotImplementedError
 
     def get_metadata(self, identifier: str):
+        if self.skip_ia_metadata:
+            logger.debug("IA metadata fetching disabled")
+            return None
         if identifier in self.ia_cache:
             logger.debug("IA metadata cache hit")
             return self.ia_cache[identifier]

--- a/openlibrary/tests/solr/test_data_provider.py
+++ b/openlibrary/tests/solr/test_data_provider.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from infogami.infobase.client import Thing
-from openlibrary.solr.data_provider import DatabaseDataProvider
+from openlibrary.solr.data_provider import DatabaseDataProvider, DataProvider
 
 
 class TestDatabaseDataProvider:
@@ -53,3 +53,26 @@ class TestDatabaseDataProvider:
         dp.clear_cache()
         await dp.get_document("/works/OL1W")
         assert mock_site.get_many.call_count == 2
+
+
+class TestGetMetadataSkipIA:
+    def test_skip_ia_metadata_returns_none_without_fetching(self, monkeypatch):
+        dp = DataProvider()
+        dp.skip_ia_metadata = True
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("get_metadata_direct should not be called when skipping IA metadata")
+
+        monkeypatch.setattr("openlibrary.solr.data_provider.ia.get_metadata_direct", _fail)
+        assert dp.get_metadata("foo00bar") is None
+
+    def test_skip_ia_metadata_disabled_still_uses_cache(self):
+        dp = DataProvider()
+        dp.ia_cache["foo00bar"] = {"identifier": "foo00bar", "collection": ["inlibrary"]}
+        assert dp.get_metadata("foo00bar") == {"identifier": "foo00bar", "collection": ["inlibrary"]}
+
+    def test_skip_ia_metadata_enabled_ignores_cache(self):
+        dp = DataProvider()
+        dp.skip_ia_metadata = True
+        dp.ia_cache["foo00bar"] = {"identifier": "foo00bar", "collection": ["inlibrary"]}
+        assert dp.get_metadata("foo00bar") is None

--- a/openlibrary/tests/solr/updater/test_work.py
+++ b/openlibrary/tests/solr/updater/test_work.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 
 from openlibrary.book_providers import IALiteMetadata
+from openlibrary.solr.data_provider import DataProvider
 from openlibrary.solr.updater.work import (
     WorkSolrBuilder,
     WorkSolrUpdater,
@@ -18,7 +19,6 @@ from openlibrary.tests.solr.test_update import (
 if TYPE_CHECKING:
     from openlibrary.core.lists.model import SeriesDict
     from openlibrary.core.models import WorkSeriesEdge
-    from openlibrary.solr.data_provider import DataProvider
 
 
 def sorted_split_semicolon(s):
@@ -66,6 +66,71 @@ class TestWorkSolrUpdater:
 
         req, _ = await WorkSolrUpdater(FakeDataProvider([work, make_edition(work), make_edition(work)])).update_key(work)
         assert req.adds[0]["edition_count"] == 2
+
+
+class TestSkipIAMetadata:
+    """
+    Verifies the --skip-ia-metadata flag end-to-end through the per-document
+    update path: get_ia_collection_and_box_id() -> data_provider.get_metadata().
+
+    FakeDataProvider stubs get_metadata to return {} unconditionally, so this
+    test uses a provider that calls the real base-class implementation (which
+    short-circuits when skip_ia_metadata is set) to prove no network call to
+    ia.get_metadata_direct happens during update_key.
+    """
+
+    class RealMetadataProvider(FakeDataProvider):
+        """FakeDataProvider but with the real base-class get_metadata, so the
+        skip_ia_metadata short-circuit (or the get_metadata_direct fallback) is
+        actually exercised instead of the stubbed {} return."""
+
+        def __init__(self, docs=None, skip_ia_metadata=False):
+            super().__init__(docs)
+            self.ia_cache = {}
+            self.skip_ia_metadata = skip_ia_metadata
+
+        def get_metadata(self, identifier):
+            return DataProvider.get_metadata(self, identifier)
+
+    @pytest.mark.asyncio
+    async def test_update_key_skips_ia_metadata_fetch(self, monkeypatch):
+        work = make_work()
+        edition = make_edition(work, ocaid="foo00bar")
+        dp = self.RealMetadataProvider([work, edition], skip_ia_metadata=True)
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("get_metadata_direct should not be called when skip_ia_metadata is set")
+
+        monkeypatch.setattr("openlibrary.solr.data_provider.ia.get_metadata_direct", _fail)
+
+        req, _ = await WorkSolrUpdater(dp).update_key(work)
+        assert len(req.adds) == 1
+        doc = req.adds[0]
+        # With no IA metadata fetched, ia_collection is empty and ia_box_id
+        # only comes from the edition record itself (none here).
+        assert doc.get("ia_collection", []) == []
+        assert "ia_box_id" not in doc
+
+    @pytest.mark.asyncio
+    async def test_update_key_fetches_ia_metadata_without_flag(self, monkeypatch):
+        """
+        Negative control: without skip_ia_metadata, the per-document path DOES
+        call get_metadata_direct. Proves the test above is sensitive to the flag.
+        """
+        work = make_work()
+        edition = make_edition(work, ocaid="foo00bar")
+        dp = self.RealMetadataProvider([work, edition], skip_ia_metadata=False)
+
+        calls = []
+        monkeypatch.setattr(
+            "openlibrary.solr.data_provider.ia.get_metadata_direct",
+            lambda itemid: calls.append(itemid) or {"collection": ["inlibrary"], "identifier": itemid},
+        )
+
+        req, _ = await WorkSolrUpdater(dp).update_key(work)
+        assert len(req.adds) == 1
+        assert calls == ["foo00bar"]
+        assert sorted(req.adds[0]["ia_collection"]) == ["inlibrary"]
 
 
 def make_work_solr_builder(

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -414,7 +414,8 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
     :param last_modified: Limit results to those modifier >= this date
     :param progress: Where/if to save progress indicator to
     :param log_file: Redirect logs to file instead of stdout
-    :param skip_ia_metadata: If true, skip fetching Internet Archive metadata for editions.
+    :param skip_ia_metadata: If true, skip fetching Internet Archive metadata for editions
+    (both the bulk pre-caching step and any per-document fallback fetches).
     ia_collection, ia_box_id, and related fields will be empty in the Solr documents.
     """
 
@@ -517,6 +518,8 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
 
     # load the contents of the config?
     with LocalPostgresDataProvider(postgres) as db:
+        db.skip_ia_metadata = skip_ia_metadata
+
         # Check to see where we should be starting from
         if cmd == "fetch-end":
             next_start_query = build_job_query(job, start_at, limit, last_modified, 1)
@@ -564,6 +567,7 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
             plog.update(next=keys[0], cached=len(db.cache), ia_cache=0)
 
             with LocalPostgresDataProvider(postgres) as db2:
+                db2.skip_ia_metadata = skip_ia_metadata
                 key_range = [keys[0], keys[-1]]
 
                 if job == "works":

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -399,6 +399,7 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
     log_file: str | None = None,
     log_level=logging.INFO,
     dry_run: bool = False,
+    skip_ia_metadata: bool = False,
 ) -> None:
     """
     :param cmd: Whether to do the index or just fetch end of the chunk
@@ -413,6 +414,8 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
     :param last_modified: Limit results to those modifier >= this date
     :param progress: Where/if to save progress indicator to
     :param log_file: Redirect logs to file instead of stdout
+    :param skip_ia_metadata: If true, skip fetching Internet Archive metadata for editions.
+    ia_collection, ia_box_id, and related fields will be empty in the Solr documents.
     """
 
     logging.basicConfig(
@@ -572,11 +575,12 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
                     )
 
                     # cache editions' ocaid metadata
-                    ocaids_time, _ = await simple_timeit_async(db2.cache_cached_editions_ia_metadata())
-                    plog.update(
-                        q_ia=plog.last_entry.q_ia + ocaids_time,
-                        ia_cache=len(db2.ia_cache),
-                    )
+                    if not skip_ia_metadata:
+                        ocaids_time, _ = await simple_timeit_async(db2.cache_cached_editions_ia_metadata())
+                        plog.update(
+                            q_ia=plog.last_entry.q_ia + ocaids_time,
+                            ia_cache=len(db2.ia_cache),
+                        )
 
                     # cache authors
                     authors_time, _ = simple_timeit(lambda: db2.cache_work_authors(*key_range))
@@ -590,11 +594,12 @@ async def main(  # noqa: PLR0917 - CLI entrypoint with many optional flags
                     db2.cache_work_reading_logs(*key_range)
                 elif job == "orphans":
                     # cache editions' ocaid metadata
-                    ocaids_time, _ = await simple_timeit_async(db2.cache_cached_editions_ia_metadata())
-                    plog.update(
-                        q_ia=plog.last_entry.q_ia + ocaids_time,
-                        ia_cache=len(db2.ia_cache),
-                    )
+                    if not skip_ia_metadata:
+                        ocaids_time, _ = await simple_timeit_async(db2.cache_cached_editions_ia_metadata())
+                        plog.update(
+                            q_ia=plog.last_entry.q_ia + ocaids_time,
+                            ia_cache=len(db2.ia_cache),
+                        )
 
                     # cache authors
                     authors_time, _ = simple_timeit(lambda: db2.cache_edition_authors(*key_range))


### PR DESCRIPTION
Adds a `--skip-ia-metadata` CLI flag to `solr_builder.py` that skips fetching Internet Archive metadata (collection, box ID, access-restricted status) for editions during indexing.

This is useful for local testing of the Solr index, where network access to archive.org may be slow or unavailable. The core bibliographic data (titles, authors, subjects, ISBNs, etc.) is still indexed; only the IA-specific fields (`ia_collection`, `ia_box_id`, ebook access) will be empty.

Pass `--skip-ia-metadata` when running locally:
```
python solr_builder/solr_builder.py index works --skip-ia-metadata --limit 10000
```

Default is `false`, so production behavior is unchanged.