### PR TITLE
Add a parallel FastAPI /borrow endpoint alongside the legacy web.py one

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -106,29 +106,10 @@ def decrypt_s3_keys(token: str) -> tuple[str, str]:
     return access, secret
 
 
-def get_s3_cookie() -> str | None:
-    """Read the raw "s3" cookie value from the current web.py request.
-
-    Must be called synchronously, on the request's own thread: web.ctx is
-    thread-local, so this returns nothing useful if called from a different
-    thread than the one handling the request -- e.g. after hopping through
-    openlibrary.utils.async_utils.AsyncBridge, which runs coroutines on its
-    own dedicated background thread. Callers that might run there (or aren't
-    running under web.py at all, e.g. FastAPI) must read the cookie
-    themselves, on the right thread, and pass the raw value to
-    parse_s3_cookie() -- a plain string -> dict function, with no thread or
-    framework dependency of its own.
-    """
-    return web.cookies().get("s3")
-
-
 def parse_s3_cookie(s3_cookie: str | None) -> dict | None:
-    """Decrypt an "s3" cookie value (from get_s3_cookie(), or a FastAPI
-    request's cookies) into {"access": ..., "secret": ...}.
+    """Decrypt an "s3" cookie value into {"access": ..., "secret": ...}.
 
-    Returns None if there's no cookie, or it's tampered/stale -- callers
-    should fall back to get_s3_keys(account) in that case, for sessions
-    that predate the cookie-based approach.
+    Returns None if there's no cookie, or it's tampered/stale.
     """
     if not s3_cookie:
         return None
@@ -139,15 +120,6 @@ def parse_s3_cookie(s3_cookie: str | None) -> dict | None:
         return {"access": access, "secret": secret}
     except InvalidToken:
         return None
-
-
-def get_s3_keys(account) -> dict | None:
-    """Return S3 keys from the account store.
-
-    This is the fallback for sessions that predate the cookie-based
-    approach; try parse_s3_cookie() on the request's "s3" cookie first.
-    """
-    return site.get().store.get(account._key, {}).get("s3_keys")
 
 
 def create_verification_cookie_value() -> str:

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -106,26 +106,47 @@ def decrypt_s3_keys(token: str) -> tuple[str, str]:
     return access, secret
 
 
-def get_s3_keys(account, s3_cookie: str | None = None) -> dict | None:
-    """Return S3 keys from the session cookie, falling back to the account store.
+def get_s3_cookie() -> str | None:
+    """Read the raw "s3" cookie value from the current web.py request.
 
-    New logins set an encrypted ``s3`` cookie; this fallback handles sessions
-    that predate the cookie-based approach.
-
-    :param s3_cookie: The raw "s3" cookie value, for callers that don't run
-        under a web.py request (e.g. FastAPI, where web.cookies() can't be
-        read). web.py callers can omit this -- it defaults to web.cookies().
+    Must be called synchronously, on the request's own thread: web.ctx is
+    thread-local, so this returns nothing useful if called from a different
+    thread than the one handling the request -- e.g. after hopping through
+    openlibrary.utils.async_utils.AsyncBridge, which runs coroutines on its
+    own dedicated background thread. Callers that might run there (or aren't
+    running under web.py at all, e.g. FastAPI) must read the cookie
+    themselves, on the right thread, and pass the raw value to
+    parse_s3_cookie() -- a plain string -> dict function, with no thread or
+    framework dependency of its own.
     """
-    if s3_cookie is None:
-        s3_cookie = web.cookies().get("s3")
-    if s3_cookie:
-        try:
-            from cryptography.fernet import InvalidToken
+    return web.cookies().get("s3")
 
-            access, secret = decrypt_s3_keys(s3_cookie)
-            return {"access": access, "secret": secret}
-        except InvalidToken:
-            pass  # tampered or stale cookie; fall through to store
+
+def parse_s3_cookie(s3_cookie: str | None) -> dict | None:
+    """Decrypt an "s3" cookie value (from get_s3_cookie(), or a FastAPI
+    request's cookies) into {"access": ..., "secret": ...}.
+
+    Returns None if there's no cookie, or it's tampered/stale -- callers
+    should fall back to get_s3_keys(account) in that case, for sessions
+    that predate the cookie-based approach.
+    """
+    if not s3_cookie:
+        return None
+    try:
+        from cryptography.fernet import InvalidToken
+
+        access, secret = decrypt_s3_keys(s3_cookie)
+        return {"access": access, "secret": secret}
+    except InvalidToken:
+        return None
+
+
+def get_s3_keys(account) -> dict | None:
+    """Return S3 keys from the account store.
+
+    This is the fallback for sessions that predate the cookie-based
+    approach; try parse_s3_cookie() on the request's "s3" cookie first.
+    """
     return site.get().store.get(account._key, {}).get("s3_keys")
 
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -106,21 +106,27 @@ def decrypt_s3_keys(token: str) -> tuple[str, str]:
     return access, secret
 
 
-def get_s3_keys(account) -> dict | None:
+def get_s3_keys(account, s3_cookie: str | None = None) -> dict | None:
     """Return S3 keys from the session cookie, falling back to the account store.
 
     New logins set an encrypted ``s3`` cookie; this fallback handles sessions
     that predate the cookie-based approach.
+
+    :param s3_cookie: The raw "s3" cookie value, for callers that don't run
+        under a web.py request (e.g. FastAPI, where web.cookies() can't be
+        read). web.py callers can omit this -- it defaults to web.cookies().
     """
-    if token := web.cookies().get("s3"):
+    if s3_cookie is None:
+        s3_cookie = web.cookies().get("s3")
+    if s3_cookie:
         try:
             from cryptography.fernet import InvalidToken
 
-            access, secret = decrypt_s3_keys(token)
+            access, secret = decrypt_s3_keys(s3_cookie)
             return {"access": access, "secret": secret}
         except InvalidToken:
             pass  # tampered or stale cookie; fall through to store
-    return web.ctx.site.store.get(account._key, {}).get("s3_keys")
+    return site.get().store.get(account._key, {}).get("s3_keys")
 
 
 def create_verification_cookie_value() -> str:

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -223,6 +223,7 @@ def create_app() -> FastAPI | None:
 
     from openlibrary.fastapi.account import router as account_router
     from openlibrary.fastapi.books import router as books_router
+    from openlibrary.fastapi.borrow import router as borrow_router
     from openlibrary.fastapi.cdn import router as cdn_router
     from openlibrary.fastapi.checkins import router as checkins_router
     from openlibrary.fastapi.importapi import router as importapi_router
@@ -244,6 +245,7 @@ def create_app() -> FastAPI | None:
     # Include routers
     app.include_router(account_router)
     app.include_router(books_router)
+    app.include_router(borrow_router)
     app.include_router(cdn_router)
     app.include_router(checkins_router)
     app.include_router(importapi_router)

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -195,14 +195,14 @@ def get_cached_groundtruth_availability(ocaid):
     return get_groundtruth_availability(ocaid)
 
 
-def get_groundtruth_availability(ocaid, s3_keys=None):
+async def get_groundtruth_availability_async(ocaid, s3_keys=None):
     """temporary stopgap to get ground-truth availability of books
     including 1-hour borrows"""
     params = "?action=availability&identifier=" + ocaid
     url = config_ia_s3_loan_url or S3_LOAN_URL % config_bookreader_host
     timeout = 2 if os.getenv("LOCAL_DEV") else 5
     try:
-        response = httpx.post(url + params, data=s3_keys, timeout=timeout)
+        response = await ia.async_session.post(url + params, data=s3_keys, timeout=timeout)
         response.raise_for_status()
     except httpx.TimeoutException:
         if os.getenv("LOCAL_DEV"):
@@ -222,7 +222,10 @@ def get_groundtruth_availability(ocaid, s3_keys=None):
     return data
 
 
-def s3_loan_api(s3_keys, ocaid=None, action="browse", **kwargs):
+get_groundtruth_availability = async_bridge.wrap(get_groundtruth_availability_async)
+
+
+async def s3_loan_api_async(s3_keys, ocaid=None, action="browse", **kwargs):
     """Uses patrons s3 credentials to initiate or return a browse or
     borrow loan on Archive.org.
 
@@ -237,7 +240,7 @@ def s3_loan_api(s3_keys, ocaid=None, action="browse", **kwargs):
 
     data = s3_keys | kwargs
 
-    response = requests.post(url + params, data=data)
+    response = await ia.async_session.post(url + params, data=data)
     # We want this to be just `409` but first
     # `www/common/Lending.inc#L111-114` needs to
     # be updated on petabox
@@ -245,6 +248,9 @@ def s3_loan_api(s3_keys, ocaid=None, action="browse", **kwargs):
         raise PatronAccessException
     response.raise_for_status()
     return response
+
+
+s3_loan_api = async_bridge.wrap(s3_loan_api_async)
 
 
 async def get_available_async(

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -200,7 +200,7 @@ async def get_groundtruth_availability_async(ocaid, s3_keys=None):
     including 1-hour borrows"""
     params = "?action=availability&identifier=" + ocaid
     url = config_ia_s3_loan_url or S3_LOAN_URL % config_bookreader_host
-    timeout = 2 if os.getenv("LOCAL_DEV") else 5
+    timeout = 2 if os.getenv("LOCAL_DEV") else config_http_request_timeout
     try:
         response = await ia.async_session.post(url + params, data=s3_keys, timeout=timeout)
         response.raise_for_status()
@@ -240,7 +240,7 @@ async def s3_loan_api_async(s3_keys, ocaid=None, action="browse", **kwargs):
 
     data = s3_keys | kwargs
 
-    response = await ia.async_session.post(url + params, data=data)
+    response = await ia.async_session.post(url + params, data=data, timeout=config_http_request_timeout)
     # We want this to be just `409` but first
     # `www/common/Lending.inc#L111-114` needs to
     # be updated on petabox

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -17,7 +17,7 @@ from simplejson.errors import JSONDecodeError
 
 from infogami.utils import delegate
 from infogami.utils.view import public
-from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
+from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys, parse_s3_cookie
 from openlibrary.core import cache, stats
 from openlibrary.core.env import get_ol_env
 from openlibrary.plugins.upstream.utils import urlencode
@@ -1154,7 +1154,7 @@ def get_loan_history_data(username: str, page: int) -> dict:
     if not (account := OpenLibraryAccount.get_by_username(username)):
         raise render.notfound("Account not found for %s" % username, create=False)
 
-    s3_keys = get_s3_keys(account)
+    s3_keys = parse_s3_cookie(web.cookies().get("s3")) or get_s3_keys(account)
     limit = RESULTS_PER_PAGE
     offset = page * limit - limit
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -17,7 +17,7 @@ from simplejson.errors import JSONDecodeError
 
 from infogami.utils import delegate
 from infogami.utils.view import public
-from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys, parse_s3_cookie
+from openlibrary.accounts.model import OpenLibraryAccount, parse_s3_cookie
 from openlibrary.core import cache, stats
 from openlibrary.core.env import get_ol_env
 from openlibrary.plugins.upstream.utils import urlencode
@@ -1151,17 +1151,16 @@ def get_loan_history_data(username: str, page: int) -> dict:
     """
     from infogami.utils.view import render
 
-    if not (account := OpenLibraryAccount.get_by_username(username)):
+    if not OpenLibraryAccount.get_by_username(username):
         raise render.notfound("Account not found for %s" % username, create=False)
 
-    s3_keys = parse_s3_cookie(web.cookies().get("s3")) or get_s3_keys(account)
+    s3_keys = parse_s3_cookie(web.cookies().get("s3"))
     limit = RESULTS_PER_PAGE
     offset = page * limit - limit
 
-    # get_s3_keys() is `dict | None`: it returns None for a patron with no `s3`
-    # session cookie and no `s3_keys` in the account store. s3_loan_api() would
-    # then evaluate `s3_keys | kwargs` and raise
-    # `TypeError: unsupported operand type(s) for |: 'NoneType' and 'dict'`.
+    # parse_s3_cookie() is `dict | None`: it returns None for a patron with no
+    # `s3` session cookie. s3_loan_api() would then evaluate `s3_keys | kwargs`
+    # and raise `TypeError: unsupported operand type(s) for |: 'NoneType' and 'dict'`.
     # /account/loans renders this history inline with no try/except of its own,
     # so that TypeError takes down the whole page -- including the active-loans
     # table, which has nothing to do with IA history. Degrade to an empty

--- a/openlibrary/fastapi/borrow.py
+++ b/openlibrary/fastapi/borrow.py
@@ -43,12 +43,12 @@ async def borrow(
     params: Annotated[BorrowParams, Depends(_borrow_params_from_request)],
 ) -> Response:
     """Called when the user wants to borrow the edition. Mirrors the legacy
-    web.py borrow.GET/POST handler, including the interstitial render branch
-    (see handle_borrow_async's docstring for why that branch's behavior here is
-    unverified).
+    web.py borrow.GET/POST handler, passing fastapi=True so the interstitial
+    render branch knows to render itself for a standalone page (no site
+    stylesheet/JS bundle loaded) rather than for the web.py request cycle.
     """
     key = f"/books/{olid}"
-    result = await handle_borrow_async(key, params, s3_cookie=request.cookies.get("s3"))
+    result = await handle_borrow_async(key, params, s3_cookie=request.cookies.get("s3"), fastapi=True)
 
     match result:
         case BorrowNotFound():
@@ -73,8 +73,8 @@ async def borrow(
                 response.set_cookie("flash", quote(flash_json, safe=""))
             return response
         case _:
-            # The interstitial render_template() result, returned as-is. No
-            # FastAPI route renders a Templetor/Jinja template yet, so
-            # whether this works correctly outside the web.py request cycle
-            # is unverified.
+            # The interstitial render_template() result, returned as-is --
+            # its own inline style/script (from fastapi=True above) is all
+            # the presentation it gets, since no site stylesheet/JS bundle
+            # is loaded here.
             return HTMLResponse(str(result))

--- a/openlibrary/fastapi/borrow.py
+++ b/openlibrary/fastapi/borrow.py
@@ -21,7 +21,7 @@ from openlibrary.plugins.upstream.borrow import (
     BorrowNotFound,
     BorrowParams,
     BorrowRedirect,
-    borrow_post_core,
+    borrow_post_core_async,
 )
 
 router = APIRouter()
@@ -37,6 +37,7 @@ def _borrow_params_from_request(request: Request) -> BorrowParams:
 @router.get("/books/{key_suffix:path}/borrow")
 @router.post("/books/{key_suffix:path}/borrow")
 async def borrow(
+    request: Request,
     key_suffix: str,
     params: Annotated[BorrowParams, Depends(_borrow_params_from_request)],
 ) -> Response:
@@ -52,7 +53,7 @@ async def borrow(
     """
     olid = key_suffix.split("/", 1)[0]
     key = f"/books/{olid}"
-    result = borrow_post_core(key, params)
+    result = await borrow_post_core_async(key, params, s3_cookie=request.cookies.get("s3"))
 
     match result:
         case BorrowNotFound():

--- a/openlibrary/fastapi/borrow.py
+++ b/openlibrary/fastapi/borrow.py
@@ -3,7 +3,7 @@ FastAPI endpoint for /books/{key}/borrow.
 
 This is a parallel implementation alongside the legacy web.py version in
 openlibrary/plugins/upstream/borrow.py, which stays in place until this one
-is fully validated in production. Both share the borrow_post_core() outcome
+is fully validated in production. Both share the handle_borrow_async() outcome
 logic; only the redirect/flash/cookie/404 handling differs per framework.
 """
 
@@ -21,7 +21,7 @@ from openlibrary.plugins.upstream.borrow import (
     BorrowNotFound,
     BorrowParams,
     BorrowRedirect,
-    borrow_post_core_async,
+    handle_borrow_async,
 )
 
 router = APIRouter()
@@ -34,26 +34,21 @@ def _borrow_params_from_request(request: Request) -> BorrowParams:
     return BorrowParams.model_validate(request.query_params)
 
 
-@router.get("/books/{key_suffix:path}/borrow")
-@router.post("/books/{key_suffix:path}/borrow")
+@router.get("/books/{olid}/{slug}/borrow")
+@router.post("/books/{olid}/{slug}/borrow")
 async def borrow(
     request: Request,
-    key_suffix: str,
+    olid: str,
+    slug: str,
     params: Annotated[BorrowParams, Depends(_borrow_params_from_request)],
 ) -> Response:
     """Called when the user wants to borrow the edition. Mirrors the legacy
     web.py borrow.GET/POST handler, including the interstitial render branch
-    (see borrow_post_core's docstring for why that branch's behavior here is
+    (see handle_borrow_async's docstring for why that branch's behavior here is
     unverified).
-
-    web.py strips a URL's title slug (e.g. /books/OL1M/Some_Title -> /books/OL1M)
-    before dispatch, via ReadableUrlProcessor. Nothing does that for FastAPI
-    requests yet, so it's done here for editions specifically -- the OLID is
-    always the first path segment after /books/.
     """
-    olid = key_suffix.split("/", 1)[0]
     key = f"/books/{olid}"
-    result = await borrow_post_core_async(key, params, s3_cookie=request.cookies.get("s3"))
+    result = await handle_borrow_async(key, params, s3_cookie=request.cookies.get("s3"))
 
     match result:
         case BorrowNotFound():

--- a/openlibrary/fastapi/borrow.py
+++ b/openlibrary/fastapi/borrow.py
@@ -1,0 +1,84 @@
+"""
+FastAPI endpoint for /books/{key}/borrow.
+
+This is a parallel implementation alongside the legacy web.py version in
+openlibrary/plugins/upstream/borrow.py, which stays in place until this one
+is fully validated in production. Both share the borrow_post_core() outcome
+logic; only the redirect/flash/cookie/404 handling differs per framework.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from infogami import config
+from openlibrary.plugins.upstream.borrow import (
+    BorrowNotFound,
+    BorrowParams,
+    BorrowRedirect,
+    borrow_post_core,
+)
+
+router = APIRouter()
+
+
+def _borrow_params_from_request(request: Request) -> BorrowParams:
+    """FastAPI dependency: builds BorrowParams from the request's query
+    params, the same way openlibrary.fastapi.models.SolrInternalsParams is
+    built via its own from_request()."""
+    return BorrowParams.model_validate(request.query_params)
+
+
+@router.get("/books/{key_suffix:path}/borrow")
+@router.post("/books/{key_suffix:path}/borrow")
+async def borrow(
+    key_suffix: str,
+    params: Annotated[BorrowParams, Depends(_borrow_params_from_request)],
+) -> Response:
+    """Called when the user wants to borrow the edition. Mirrors the legacy
+    web.py borrow.GET/POST handler, including the interstitial render branch
+    (see borrow_post_core's docstring for why that branch's behavior here is
+    unverified).
+
+    web.py strips a URL's title slug (e.g. /books/OL1M/Some_Title -> /books/OL1M)
+    before dispatch, via ReadableUrlProcessor. Nothing does that for FastAPI
+    requests yet, so it's done here for editions specifically -- the OLID is
+    always the first path segment after /books/.
+    """
+    olid = key_suffix.split("/", 1)[0]
+    key = f"/books/{olid}"
+    result = borrow_post_core(key, params)
+
+    match result:
+        case BorrowNotFound():
+            raise HTTPException(status_code=404)
+        case BorrowRedirect():
+            response = RedirectResponse(
+                url=result.url,
+                status_code=301 if result.permanent else 303,
+            )
+            if result.clear_login_cookie:
+                response.delete_cookie(config.login_cookie_name)
+            if result.flash:
+                flash_type, flash_message = result.flash
+                flash_json = json.dumps([{"type": flash_type, "message": flash_message}])
+                # web.py's flash cookie reader (infogami.utils.flash / web.cookies())
+                # unconditionally percent-decodes the raw cookie value, symmetric with
+                # web.setcookie()'s percent-encoding on write. Starlette's default
+                # cookie quoting instead backslash-escapes values containing commas
+                # (RFC 2109 style), which web.py's decoder can't reverse -- so the
+                # flash message would silently vanish unless we percent-encode it
+                # ourselves here to match web.py's wire format.
+                response.set_cookie("flash", quote(flash_json, safe=""))
+            return response
+        case _:
+            # The interstitial render_template() result, returned as-is. No
+            # FastAPI route renders a Templetor/Jinja template yet, so
+            # whether this works correctly outside the web.py request cycle
+            # is unverified.
+            return HTMLResponse(str(result))

--- a/openlibrary/fastapi/borrow.py
+++ b/openlibrary/fastapi/borrow.py
@@ -23,6 +23,7 @@ from openlibrary.plugins.upstream.borrow import (
     BorrowRedirect,
     handle_borrow_async,
 )
+from openlibrary.utils.request_context import site
 
 router = APIRouter()
 
@@ -32,6 +33,16 @@ def _borrow_params_from_request(request: Request) -> BorrowParams:
     params, the same way openlibrary.fastapi.models.SolrInternalsParams is
     built via its own from_request()."""
     return BorrowParams.model_validate(request.query_params)
+
+
+def _resolve_ocaid_to_olid(ocaid: str) -> str | None:
+    """Resolves an IA identifier to its canonical OL edition OLID, or None
+    if there's no such edition."""
+    ia_edition = site.get().get(f"/books/ia:{ocaid}")
+    if not ia_edition:
+        return None
+    edition = site.get().get(ia_edition.location)
+    return edition.key.removeprefix("/books/")
 
 
 @router.get("/books/{olid}/{slug}/borrow")
@@ -78,3 +89,35 @@ async def borrow(
             # the presentation it gets, since no site stylesheet/JS bundle
             # is loaded here.
             return HTMLResponse(str(result))
+
+
+@router.get("/borrow/ia/{ocaid}")
+async def checkout_with_ocaid_get(ocaid: str, request: Request) -> Response:
+    """Redirect shim: translates an IA identifier into the canonical OL
+    /borrow URL. Mirrors the legacy web.py checkout_with_ocaid.GET, which
+    redirects rather than forwarding in-process -- unlike POST below, this
+    is browser-navigable, so it should land on (and become bookmarkable at)
+    the canonical URL rather than staying on this one.
+    """
+    olid = _resolve_ocaid_to_olid(ocaid)
+    if olid is None:
+        raise HTTPException(status_code=404)
+    url = f"/books/{olid}/x/borrow"
+    query = str(request.query_params)
+    if query:
+        url += f"?{query}"
+    return RedirectResponse(url=url, status_code=303)
+
+
+@router.post("/borrow/ia/{ocaid}")
+async def checkout_with_ocaid_post(ocaid: str, request: Request) -> Response:
+    """Forwards a borrow request to the canonical /borrow route above.
+    Mirrors the legacy web.py checkout_with_ocaid.POST, which does the same
+    in-process (calling borrow().POST(...) directly) rather than
+    redirecting -- a POST isn't bookmarked, so there's nothing to gain by
+    round-tripping through the browser first.
+    """
+    olid = _resolve_ocaid_to_olid(ocaid)
+    if olid is None:
+        raise HTTPException(status_code=404)
+    return await borrow(request, olid=olid, slug="x", params=_borrow_params_from_request(request))

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -8,10 +8,12 @@ import json
 import logging
 import time
 import urllib
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
 import web
+from pydantic import BaseModel, Field
 
 from infogami import config
 from infogami.infobase.utils import parse_datetime
@@ -99,6 +101,207 @@ class checkout_with_ocaid(delegate.page):
         borrow().POST(ia_edition.location)
 
 
+class BorrowParams(BaseModel):
+    """Framework-agnostic /borrow request params, so that borrow_post_core()'s
+    body doesn't need to know whether it's being called from web.py or
+    FastAPI. Built via from_web_input() on the web.py side and via
+    model_validate() against the query params on the FastAPI side (see
+    openlibrary/fastapi/borrow.py), the same way openlibrary.fastapi.models.
+    SolrInternalsParams is built from a request.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    action: str = "borrow"
+    format: str | None = None
+    # web.input()/query param name is "_autoReadAloud" (matches the URL param
+    # BookReader itself uses); aliased here so the Python-side name doesn't
+    # start with an underscore.
+    auto_read_aloud: str | None = Field(default=None, validation_alias="_autoReadAloud")
+    q: str = ""
+    redirect: str = ""
+
+    @staticmethod
+    def from_web_input(i) -> BorrowParams:
+        return BorrowParams(
+            action=i.action,
+            format=i.format,
+            auto_read_aloud=i._autoReadAloud,
+            q=i.q,
+            redirect=i.redirect,
+        )
+
+
+@dataclass
+class BorrowRedirect:
+    """A redirect outcome of borrow_post_core(). The actual redirect, flash
+    message, and cookie side effects are performed by whichever
+    framework-specific caller invoked it (web.py or FastAPI), since those are
+    done differently in each.
+    """
+
+    url: str
+    permanent: bool = False  # False -> 303 See Other, True -> 301 Moved Permanently
+    flash: tuple[str, str] | None = None  # (type, message), e.g. ("error", "...")
+    clear_login_cookie: bool = False
+
+
+@dataclass
+class BorrowNotFound:
+    pass
+
+
+BorrowOutcome = BorrowRedirect | BorrowNotFound
+
+
+def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
+    """Shared /borrow POST logic used by both the legacy web.py handler
+    (borrow.POST below) and the FastAPI route in openlibrary/fastapi/borrow.py.
+
+    Returns an outcome object describing what should happen next, rather than
+    performing redirects/flash messages/cookies directly, since those need to
+    be done differently by web.py (raise web.seeother(), add_flash_message(),
+    web.setcookie()) vs. FastAPI (return a RedirectResponse with cookies set
+    on it). The open-access "interstitial" render below is the one exception:
+    a render has no redirect/cookie side effect to bridge between frameworks,
+    so it calls render_template() directly and returns the result as-is.
+    """
+    action = i.action
+    edition = site.get().get(key)
+    if not edition:
+        return BorrowNotFound()
+
+    from openlibrary.book_providers import get_book_provider
+
+    if action == "locate":
+        return BorrowRedirect(edition.get_worldcat_url())
+
+    # Direct to the first web book if at least one is available.
+    if (
+        action in ["borrow", "read"]
+        and (provider := get_book_provider(edition))
+        and provider.short_name != "ia"
+        and (acquisitions := provider.get_acquisitions(edition))
+        and acquisitions[0].access == "open-access"
+    ):
+        stats.increment("ol.loans.webbook")
+        return render_template(
+            "interstitial",
+            url=acquisitions[0].url,
+            provider_name=acquisitions[0].provider_name,
+        )
+
+    archive_url = get_bookreader_stream_url(edition.ocaid) + "?ref=ol"
+    if i.auto_read_aloud is not None:
+        archive_url += "&_autoReadAloud=show"
+
+    if i.q:
+        _q = urllib.parse.quote(i.q, safe="")
+        return BorrowRedirect(archive_url + "#page/-/mode/2up/search/%s" % _q)
+
+    # Make a call to availability v2 update the subjects according
+    # to result if `open`, redirect to bookreader
+    response = lending.get_availability("identifier", [edition.ocaid])
+    availability = response.get(edition.ocaid)
+    if availability and availability["status"] == "open":
+        from openlibrary.plugins.openlibrary.code import is_bot
+
+        if not is_bot():
+            stats.increment("ol.loans.openaccess")
+        return BorrowRedirect(archive_url)
+
+    error_redirect = archive_url
+
+    # Strip scheme/host to prevent open-redirect attacks.
+    if i.redirect:
+        parsed = urllib.parse.urlsplit(i.redirect)
+        edition_redirect = urllib.parse.urlunsplit(("", "", parsed.path, parsed.query, parsed.fragment))
+    else:
+        edition_redirect = edition.url()
+
+    user = accounts.get_current_user()
+
+    if user:
+        account = OpenLibraryAccount.get_by_email(user.email)
+        ia_itemname = account.itemname if account else None
+        s3_keys = get_s3_keys(account)
+        lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
+    if not user or not ia_itemname or not s3_keys:
+        return_path = f"{edition_redirect}/borrow?action={action}"
+        redirect_url = f"/account/login?redirect={urllib.parse.quote(return_path, safe='')}"
+        if i.auto_read_aloud is not None:
+            redirect_url += "&_autoReadAloud=" + i.auto_read_aloud
+        return BorrowRedirect(redirect_url, clear_login_cookie=True)
+
+    if action == "return":
+        with contextlib.suppress(lending.PatronAccessException):
+            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="return_loan")
+
+        edition.update_loan_status()
+        user.update_loan_status()
+        title = edition.title or _("this book")
+
+        if user.has_borrowed(edition):
+            flash = ("error", _("Unable to return %s. Please try again later or contact info@archive.org.") % title)
+        else:
+            stats.increment("ol.loans.return")
+            flash = ("success", _("%s has been returned.") % title)
+        return BorrowRedirect(edition_redirect, flash=flash)
+    elif action == "join-waitinglist":
+        lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
+        lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="join_waitlist")
+        stats.increment("ol.loans.joinWaitlist")
+        return BorrowRedirect(edition_redirect, permanent=True)
+    elif action == "leave-waitinglist":
+        lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
+        lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="leave_waitlist")
+        stats.increment("ol.loans.leaveWaitlist")
+        return BorrowRedirect(edition_redirect, permanent=True)
+
+    elif action in ("borrow", "browse") and not user.has_borrowed(edition):
+        borrow_access = user_can_borrow_edition(user, edition)
+
+        if not (s3_keys and borrow_access):
+            stats.increment("ol.loans.outdatedAvailabilityStatus")
+            return BorrowRedirect(error_redirect)
+
+        try:
+            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="%s_book" % borrow_access)
+            stats.increment("ol.loans.bookreader")
+            stats.increment("ol.loans.%s" % borrow_access)
+        except lending.PatronAccessException:
+            stats.increment("ol.loans.blocked")
+            return BorrowRedirect(
+                key,
+                flash=(
+                    "error",
+                    _("Your account has hit a lending limit. Please try again later or contact info@archive.org."),
+                ),
+            )
+
+    if action in ("borrow", "browse", "read"):
+        bookPath = "/stream/" + edition.ocaid
+        if i.auto_read_aloud is not None:
+            bookPath += "?_autoReadAloud=show"
+
+        # Look for loans for this book
+        user.update_loan_status()
+        loans = get_loans(user)
+        for loan in loans:
+            if loan["book"] == edition.key:
+                return BorrowRedirect(
+                    make_bookreader_auth_link(
+                        loan["_key"],
+                        edition.ocaid,
+                        bookPath,
+                        ia_userid=ia_itemname,
+                    )
+                )
+
+    # Action not recognized
+    return BorrowRedirect(error_redirect)
+
+
 # Handler for /books/{bookid}/{title}/borrow
 class borrow(delegate.page):
     path = "(/books/.*)/borrow"
@@ -106,7 +309,7 @@ class borrow(delegate.page):
     def GET(self, key):
         return self.POST(key)
 
-    def POST(self, key):  # noqa: PLR0912, PLR0915
+    def POST(self, key):
         """Called when the user wants to borrow the edition"""
 
         i = web.input(
@@ -116,144 +319,21 @@ class borrow(delegate.page):
             q="",
             redirect="",
         )
+        params = BorrowParams.from_web_input(i)
+        result = borrow_post_core(key, params)
 
-        action = i.action
-        edition = site.get().get(key)
-        if not edition:
-            raise web.notfound()
-
-        from openlibrary.book_providers import get_book_provider
-
-        if action == "locate":
-            raise web.seeother(edition.get_worldcat_url())
-
-        # Direct to the first web book if at least one is available.
-        if (
-            action in ["borrow", "read"]
-            and (provider := get_book_provider(edition))
-            and provider.short_name != "ia"
-            and (acquisitions := provider.get_acquisitions(edition))
-            and acquisitions[0].access == "open-access"
-        ):
-            stats.increment("ol.loans.webbook")
-            return render_template(
-                "interstitial",
-                url=acquisitions[0].url,
-                provider_name=acquisitions[0].provider_name,
-            )
-
-        archive_url = get_bookreader_stream_url(edition.ocaid) + "?ref=ol"
-        if i._autoReadAloud is not None:
-            archive_url += "&_autoReadAloud=show"
-
-        if i.q:
-            _q = urllib.parse.quote(i.q, safe="")
-            raise web.seeother(archive_url + "#page/-/mode/2up/search/%s" % _q)
-
-        # Make a call to availability v2 update the subjects according
-        # to result if `open`, redirect to bookreader
-        response = lending.get_availability("identifier", [edition.ocaid])
-        availability = response[edition.ocaid] if response else {}
-        if availability and availability["status"] == "open":
-            from openlibrary.plugins.openlibrary.code import is_bot
-
-            if not is_bot():
-                stats.increment("ol.loans.openaccess")
-            raise web.seeother(archive_url)
-
-        error_redirect = archive_url
-
-        # Strip scheme/host to prevent open-redirect attacks.
-        if i.redirect:
-            parsed = urllib.parse.urlsplit(i.redirect)
-            edition_redirect = urllib.parse.urlunsplit(("", "", parsed.path, parsed.query, parsed.fragment))
-        else:
-            edition_redirect = edition.url()
-
-        user = accounts.get_current_user()
-
-        if user:
-            account = OpenLibraryAccount.get_by_email(user.email)
-            ia_itemname = account.itemname if account else None
-            s3_keys = get_s3_keys(account)
-            lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
-        if not user or not ia_itemname or not s3_keys:
-            web.setcookie(config.login_cookie_name, "", expires=-1)
-            return_path = f"{edition_redirect}/borrow?action={action}"
-            redirect_url = f"/account/login?redirect={urllib.parse.quote(return_path, safe='')}"
-            if i._autoReadAloud is not None:
-                redirect_url += "&_autoReadAloud=" + i._autoReadAloud
-            raise web.seeother(redirect_url)
-
-        if action == "return":
-            with contextlib.suppress(lending.PatronAccessException):
-                lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="return_loan")
-
-            edition.update_loan_status()
-            user.update_loan_status()
-            title = edition.title or _("this book")
-
-            if user.has_borrowed(edition):
-                add_flash_message(
-                    "error",
-                    _("Unable to return %s. Please try again later or contact info@archive.org.") % title,
-                )
-            else:
-                stats.increment("ol.loans.return")
-                add_flash_message("success", _("%s has been returned.") % title)
-            raise web.seeother(edition_redirect)
-        elif action == "join-waitinglist":
-            lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
-            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="join_waitlist")
-            stats.increment("ol.loans.joinWaitlist")
-            raise web.redirect(edition_redirect)
-        elif action == "leave-waitinglist":
-            lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
-            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="leave_waitlist")
-            stats.increment("ol.loans.leaveWaitlist")
-            raise web.redirect(edition_redirect)
-
-        elif action in ("borrow", "browse") and not user.has_borrowed(edition):
-            borrow_access = user_can_borrow_edition(user, edition)
-
-            if not (s3_keys and borrow_access):
-                stats.increment("ol.loans.outdatedAvailabilityStatus")
-                raise web.seeother(error_redirect)
-
-            try:
-                lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="%s_book" % borrow_access)
-                stats.increment("ol.loans.bookreader")
-                stats.increment("ol.loans.%s" % borrow_access)
-            except lending.PatronAccessException:
-                stats.increment("ol.loans.blocked")
-
-                add_flash_message(
-                    "error",
-                    _("Your account has hit a lending limit. Please try again later or contact info@archive.org."),
-                )
-                raise web.seeother(key)
-
-        if action in ("borrow", "browse", "read"):
-            bookPath = "/stream/" + edition.ocaid
-            if i._autoReadAloud is not None:
-                bookPath += "?_autoReadAloud=show"
-
-            # Look for loans for this book
-            user.update_loan_status()
-            loans = get_loans(user)
-            for loan in loans:
-                if loan["book"] == edition.key:
-                    raise web.seeother(
-                        make_bookreader_auth_link(
-                            loan["_key"],
-                            edition.ocaid,
-                            bookPath,
-                            ia_userid=ia_itemname,
-                        )
-                    )
-
-        # Action not recognized
-        raise web.seeother(error_redirect)
+        match result:
+            case BorrowNotFound():
+                raise web.notfound()
+            case BorrowRedirect():
+                if result.clear_login_cookie:
+                    web.setcookie(config.login_cookie_name, "", expires=-1)
+                if result.flash:
+                    add_flash_message(*result.flash)
+                raise (web.redirect if result.permanent else web.seeother)(result.url)
+            case _:
+                # The interstitial render_template() result, passed through as-is.
+                return result
 
 
 # Handler for /books/{bookid}/{title}/_borrow_status

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -23,7 +23,12 @@ from infogami.utils.view import (
     public,
 )
 from openlibrary import accounts
-from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
+from openlibrary.accounts.model import (
+    OpenLibraryAccount,
+    get_s3_cookie,
+    get_s3_keys,
+    parse_s3_cookie,
+)
 from openlibrary.app import render_template
 from openlibrary.core import (
     lending,
@@ -155,7 +160,7 @@ class BorrowNotFound:
 BorrowOutcome = BorrowRedirect | BorrowNotFound
 
 
-async def borrow_post_core_async(key: str, i: BorrowParams, s3_cookie: str | None = None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
+async def borrow_post_core_async(key: str, i: BorrowParams, *, s3_cookie: str | None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
     """Shared /borrow POST logic used by both the legacy web.py handler
     (borrow.POST below, via the borrow_post_core sync bridge) and the FastAPI
     route in openlibrary/fastapi/borrow.py (which awaits this directly).
@@ -168,9 +173,14 @@ async def borrow_post_core_async(key: str, i: BorrowParams, s3_cookie: str | Non
     a render has no redirect/cookie side effect to bridge between frameworks,
     so it calls render_template() directly and returns the result as-is.
 
-    :param s3_cookie: The raw "s3" cookie value, passed through to
-        get_s3_keys() for FastAPI callers, which can't use web.cookies().
-        web.py callers can omit this.
+    :param s3_cookie: The raw "s3" cookie value (or None if absent), decrypted
+        below via parse_s3_cookie(). Required (not defaulted to reading it
+        here) since this function runs on the caller's own thread when
+        awaited directly (the FastAPI route), but NOT when called via the
+        borrow_post_core sync bridge below -- that runs it on AsyncBridge's
+        dedicated background thread, where web.ctx (thread-local) was never
+        populated. Both callers must read the cookie themselves, on their
+        own real request thread, before it's too late to do so correctly.
     """
     action = i.action
     edition = site.get().get(key)
@@ -230,7 +240,7 @@ async def borrow_post_core_async(key: str, i: BorrowParams, s3_cookie: str | Non
     if user:
         account = OpenLibraryAccount.get_by_email(user.email)
         ia_itemname = account.itemname if account else None
-        s3_keys = get_s3_keys(account, s3_cookie=s3_cookie)
+        s3_keys = parse_s3_cookie(s3_cookie) or get_s3_keys(account)
         lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
     if not user or not ia_itemname or not s3_keys:
         return_path = f"{edition_redirect}/borrow?action={action}"
@@ -331,7 +341,11 @@ class borrow(delegate.page):
             redirect="",
         )
         params = BorrowParams.from_web_input(i)
-        result = borrow_post_core(key, params)
+        # Read on this (real request) thread, before borrow_post_core hops
+        # onto the async bridge's own background thread -- see
+        # borrow_post_core_async's s3_cookie docstring for why.
+        s3_cookie = get_s3_cookie()
+        result = borrow_post_core(key, params, s3_cookie=s3_cookie)
 
         match result:
             case BorrowNotFound():

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -33,6 +33,7 @@ from openlibrary.core import (
 )
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
+from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger("openlibrary.borrow")
@@ -154,9 +155,10 @@ class BorrowNotFound:
 BorrowOutcome = BorrowRedirect | BorrowNotFound
 
 
-def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
+async def borrow_post_core_async(key: str, i: BorrowParams, s3_cookie: str | None = None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
     """Shared /borrow POST logic used by both the legacy web.py handler
-    (borrow.POST below) and the FastAPI route in openlibrary/fastapi/borrow.py.
+    (borrow.POST below, via the borrow_post_core sync bridge) and the FastAPI
+    route in openlibrary/fastapi/borrow.py (which awaits this directly).
 
     Returns an outcome object describing what should happen next, rather than
     performing redirects/flash messages/cookies directly, since those need to
@@ -165,6 +167,10 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
     on it). The open-access "interstitial" render below is the one exception:
     a render has no redirect/cookie side effect to bridge between frameworks,
     so it calls render_template() directly and returns the result as-is.
+
+    :param s3_cookie: The raw "s3" cookie value, passed through to
+        get_s3_keys() for FastAPI callers, which can't use web.cookies().
+        web.py callers can omit this.
     """
     action = i.action
     edition = site.get().get(key)
@@ -201,7 +207,7 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
 
     # Make a call to availability v2 update the subjects according
     # to result if `open`, redirect to bookreader
-    response = lending.get_availability("identifier", [edition.ocaid])
+    response = await lending.get_availability_async("identifier", [edition.ocaid])
     availability = response.get(edition.ocaid)
     if availability and availability["status"] == "open":
         from openlibrary.plugins.openlibrary.code import is_bot
@@ -224,7 +230,7 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
     if user:
         account = OpenLibraryAccount.get_by_email(user.email)
         ia_itemname = account.itemname if account else None
-        s3_keys = get_s3_keys(account)
+        s3_keys = get_s3_keys(account, s3_cookie=s3_cookie)
         lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
     if not user or not ia_itemname or not s3_keys:
         return_path = f"{edition_redirect}/borrow?action={action}"
@@ -235,7 +241,7 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
 
     if action == "return":
         with contextlib.suppress(lending.PatronAccessException):
-            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="return_loan")
+            await lending.s3_loan_api_async(s3_keys, ocaid=edition.ocaid, action="return_loan")
 
         edition.update_loan_status()
         user.update_loan_status()
@@ -249,24 +255,24 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
         return BorrowRedirect(edition_redirect, flash=flash)
     elif action == "join-waitinglist":
         lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
-        lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="join_waitlist")
+        await lending.s3_loan_api_async(s3_keys, ocaid=edition.ocaid, action="join_waitlist")
         stats.increment("ol.loans.joinWaitlist")
         return BorrowRedirect(edition_redirect, permanent=True)
     elif action == "leave-waitinglist":
         lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
-        lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="leave_waitlist")
+        await lending.s3_loan_api_async(s3_keys, ocaid=edition.ocaid, action="leave_waitlist")
         stats.increment("ol.loans.leaveWaitlist")
         return BorrowRedirect(edition_redirect, permanent=True)
 
     elif action in ("borrow", "browse") and not user.has_borrowed(edition):
-        borrow_access = user_can_borrow_edition(user, edition)
+        borrow_access = await user_can_borrow_edition_async(user, edition)
 
         if not (s3_keys and borrow_access):
             stats.increment("ol.loans.outdatedAvailabilityStatus")
             return BorrowRedirect(error_redirect)
 
         try:
-            lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="%s_book" % borrow_access)
+            await lending.s3_loan_api_async(s3_keys, ocaid=edition.ocaid, action="%s_book" % borrow_access)
             stats.increment("ol.loans.bookreader")
             stats.increment("ol.loans.%s" % borrow_access)
         except lending.PatronAccessException:
@@ -300,6 +306,11 @@ def borrow_post_core(key: str, i: BorrowParams) -> BorrowOutcome:  # noqa: PLR09
 
     # Action not recognized
     return BorrowRedirect(error_redirect)
+
+
+# Sync wrapper so web.py's borrow.POST (below) can call this without needing
+# to be async itself; the FastAPI route awaits borrow_post_core_async directly.
+borrow_post_core = async_bridge.wrap(borrow_post_core_async)
 
 
 # Handler for /books/{bookid}/{title}/borrow
@@ -498,13 +509,13 @@ def is_loaned_out_from_status(status) -> bool:
     return status and status["returned"] != "T"
 
 
-def user_can_borrow_edition(user, edition) -> Literal["borrow", "browse", False]:
+async def user_can_borrow_edition_async(user, edition) -> Literal["borrow", "browse", False]:
     """Returns the type of borrow for which patron is eligible, favoring
     "browse" over "borrow" where available, otherwise return False if
     patron is not eligible.
 
     """
-    lending_st = lending.get_groundtruth_availability(edition.ocaid, {})
+    lending_st = await lending.get_groundtruth_availability_async(edition.ocaid, {})
 
     book_is_lendable = lending_st.get("is_lendable", False)
     book_is_waitlistable = lending_st.get("available_to_waitlist", False)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -147,13 +147,15 @@ class BorrowNotFound:
 BorrowOutcome = BorrowRedirect | BorrowNotFound
 
 
-async def handle_borrow_async(key: str, i: BorrowParams, *, s3_cookie: str | None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
+async def handle_borrow_async(key: str, i: BorrowParams, *, s3_cookie: str | None, fastapi: bool = False) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
     """Shared /borrow POST logic for both the web.py handler (via the
     handle_borrow sync bridge) and the FastAPI route (awaits directly).
 
     Returns an outcome object rather than performing the redirect/flash/
     cookie side effects itself, since those differ by framework -- except
-    the interstitial render, which has no such side effect to bridge.
+    the interstitial render, which has no such side effect to bridge, so
+    it's rendered directly here; `fastapi` tells it which framework this
+    is, since it's the one thing this function can't otherwise infer.
 
     :param s3_cookie: Required, not read here: callers must read it on
         their own real thread before this may hop onto AsyncBridge's
@@ -182,6 +184,7 @@ async def handle_borrow_async(key: str, i: BorrowParams, *, s3_cookie: str | Non
             "interstitial",
             url=acquisitions[0].url,
             provider_name=acquisitions[0].provider_name,
+            fastapi=fastapi,
         )
 
     archive_url = get_bookreader_stream_url(edition.ocaid) + "?ref=ol"

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -23,12 +23,7 @@ from infogami.utils.view import (
     public,
 )
 from openlibrary import accounts
-from openlibrary.accounts.model import (
-    OpenLibraryAccount,
-    get_s3_cookie,
-    get_s3_keys,
-    parse_s3_cookie,
-)
+from openlibrary.accounts.model import OpenLibraryAccount, parse_s3_cookie
 from openlibrary.app import render_template
 from openlibrary.core import (
     lending,
@@ -108,17 +103,9 @@ class checkout_with_ocaid(delegate.page):
 
 
 class BorrowParams(BaseModel):
-    """Framework-agnostic /borrow request params, so that borrow_post_core()'s
-    body doesn't need to know whether it's being called from web.py or
-    FastAPI. Built via from_web_input() on the web.py side and via
-    model_validate() against the query params on the FastAPI side (see
-    openlibrary/fastapi/borrow.py), the same way openlibrary.fastapi.models.
-    SolrInternalsParams is built from a request.
-    """
-
     model_config = {"populate_by_name": True}
 
-    action: str = "borrow"
+    action: Literal["borrow", "read", "locate", "return", "join-waitinglist", "leave-waitinglist", "browse"] = "borrow"
     format: str | None = None
     # web.input()/query param name is "_autoReadAloud" (matches the URL param
     # BookReader itself uses); aliased here so the Python-side name doesn't
@@ -140,7 +127,7 @@ class BorrowParams(BaseModel):
 
 @dataclass
 class BorrowRedirect:
-    """A redirect outcome of borrow_post_core(). The actual redirect, flash
+    """A redirect outcome of handle_borrow_async(). The actual redirect, flash
     message, and cookie side effects are performed by whichever
     framework-specific caller invoked it (web.py or FastAPI), since those are
     done differently in each.
@@ -160,27 +147,17 @@ class BorrowNotFound:
 BorrowOutcome = BorrowRedirect | BorrowNotFound
 
 
-async def borrow_post_core_async(key: str, i: BorrowParams, *, s3_cookie: str | None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
-    """Shared /borrow POST logic used by both the legacy web.py handler
-    (borrow.POST below, via the borrow_post_core sync bridge) and the FastAPI
-    route in openlibrary/fastapi/borrow.py (which awaits this directly).
+async def handle_borrow_async(key: str, i: BorrowParams, *, s3_cookie: str | None) -> BorrowOutcome:  # noqa: PLR0912, PLR0915
+    """Shared /borrow POST logic for both the web.py handler (via the
+    handle_borrow sync bridge) and the FastAPI route (awaits directly).
 
-    Returns an outcome object describing what should happen next, rather than
-    performing redirects/flash messages/cookies directly, since those need to
-    be done differently by web.py (raise web.seeother(), add_flash_message(),
-    web.setcookie()) vs. FastAPI (return a RedirectResponse with cookies set
-    on it). The open-access "interstitial" render below is the one exception:
-    a render has no redirect/cookie side effect to bridge between frameworks,
-    so it calls render_template() directly and returns the result as-is.
+    Returns an outcome object rather than performing the redirect/flash/
+    cookie side effects itself, since those differ by framework -- except
+    the interstitial render, which has no such side effect to bridge.
 
-    :param s3_cookie: The raw "s3" cookie value (or None if absent), decrypted
-        below via parse_s3_cookie(). Required (not defaulted to reading it
-        here) since this function runs on the caller's own thread when
-        awaited directly (the FastAPI route), but NOT when called via the
-        borrow_post_core sync bridge below -- that runs it on AsyncBridge's
-        dedicated background thread, where web.ctx (thread-local) was never
-        populated. Both callers must read the cookie themselves, on their
-        own real request thread, before it's too late to do so correctly.
+    :param s3_cookie: Required, not read here: callers must read it on
+        their own real thread before this may hop onto AsyncBridge's
+        background thread, where web.ctx isn't populated.
     """
     action = i.action
     edition = site.get().get(key)
@@ -240,7 +217,7 @@ async def borrow_post_core_async(key: str, i: BorrowParams, *, s3_cookie: str | 
     if user:
         account = OpenLibraryAccount.get_by_email(user.email)
         ia_itemname = account.itemname if account else None
-        s3_keys = parse_s3_cookie(s3_cookie) or get_s3_keys(account)
+        s3_keys = parse_s3_cookie(s3_cookie)
         lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
     if not user or not ia_itemname or not s3_keys:
         return_path = f"{edition_redirect}/borrow?action={action}"
@@ -319,8 +296,8 @@ async def borrow_post_core_async(key: str, i: BorrowParams, *, s3_cookie: str | 
 
 
 # Sync wrapper so web.py's borrow.POST (below) can call this without needing
-# to be async itself; the FastAPI route awaits borrow_post_core_async directly.
-borrow_post_core = async_bridge.wrap(borrow_post_core_async)
+# to be async itself; the FastAPI route awaits handle_borrow_async directly.
+handle_borrow = async_bridge.wrap(handle_borrow_async)
 
 
 # Handler for /books/{bookid}/{title}/borrow
@@ -341,11 +318,8 @@ class borrow(delegate.page):
             redirect="",
         )
         params = BorrowParams.from_web_input(i)
-        # Read on this (real request) thread, before borrow_post_core hops
-        # onto the async bridge's own background thread -- see
-        # borrow_post_core_async's s3_cookie docstring for why.
-        s3_cookie = get_s3_cookie()
-        result = borrow_post_core(key, params, s3_cookie=s3_cookie)
+        s3_cookie = web.cookies().get("s3")
+        result = handle_borrow(key, params, s3_cookie=s3_cookie)
 
         match result:
             case BorrowNotFound():

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -19,7 +19,7 @@ class TestBorrowPostCore:
     def test_not_found(self):
         with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
             mock_site.get.return_value.get.return_value = None
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert result == borrow.BorrowNotFound()
 
@@ -29,7 +29,7 @@ class TestBorrowPostCore:
 
         with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(action="locate"))
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(action="locate"), s3_cookie=None)
 
         assert result == borrow.BorrowRedirect("https://search.worldcat.org/title/1")
 
@@ -44,7 +44,7 @@ class TestBorrowPostCore:
             patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=None),
         ):
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert isinstance(result, borrow.BorrowRedirect)
         assert result.clear_login_cookie is True
@@ -72,7 +72,7 @@ class TestBorrowPostCore:
             ),
         ):
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert isinstance(result, borrow.BorrowRedirect)
         assert result.url == "/books/OL1M"

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -40,7 +40,7 @@ class TestBorrowPostCore:
         with (
             patch("openlibrary.plugins.upstream.borrow.site") as mock_site,
             patch("openlibrary.book_providers.get_book_provider", return_value=None),
-            patch("openlibrary.plugins.upstream.borrow.lending.get_availability", return_value={}),
+            patch("openlibrary.plugins.upstream.borrow.lending.get_availability_async", return_value={}),
             patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=None),
         ):
             mock_site.get.return_value.get.return_value = edition
@@ -61,13 +61,13 @@ class TestBorrowPostCore:
         with (
             patch("openlibrary.plugins.upstream.borrow.site") as mock_site,
             patch("openlibrary.book_providers.get_book_provider", return_value=None),
-            patch("openlibrary.plugins.upstream.borrow.lending.get_availability", return_value={}),
+            patch("openlibrary.plugins.upstream.borrow.lending.get_availability_async", return_value={}),
             patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=user),
             patch("openlibrary.plugins.upstream.borrow.OpenLibraryAccount.get_by_email", return_value=account),
             patch("openlibrary.plugins.upstream.borrow.get_s3_keys", return_value={"s3_key": "x"}),
-            patch("openlibrary.plugins.upstream.borrow.user_can_borrow_edition", return_value="borrow"),
+            patch("openlibrary.plugins.upstream.borrow.user_can_borrow_edition_async", return_value="borrow"),
             patch(
-                "openlibrary.plugins.upstream.borrow.lending.s3_loan_api",
+                "openlibrary.plugins.upstream.borrow.lending.s3_loan_api_async",
                 side_effect=borrow.lending.PatronAccessException,
             ),
         ):

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -19,7 +19,7 @@ class TestBorrowPostCore:
     def test_not_found(self):
         with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
             mock_site.get.return_value.get.return_value = None
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
+            result = borrow.handle_borrow("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert result == borrow.BorrowNotFound()
 
@@ -29,7 +29,7 @@ class TestBorrowPostCore:
 
         with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(action="locate"), s3_cookie=None)
+            result = borrow.handle_borrow("/books/OL1M", borrow.BorrowParams(action="locate"), s3_cookie=None)
 
         assert result == borrow.BorrowRedirect("https://search.worldcat.org/title/1")
 
@@ -44,7 +44,7 @@ class TestBorrowPostCore:
             patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=None),
         ):
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
+            result = borrow.handle_borrow("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert isinstance(result, borrow.BorrowRedirect)
         assert result.clear_login_cookie is True
@@ -64,7 +64,7 @@ class TestBorrowPostCore:
             patch("openlibrary.plugins.upstream.borrow.lending.get_availability_async", return_value={}),
             patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=user),
             patch("openlibrary.plugins.upstream.borrow.OpenLibraryAccount.get_by_email", return_value=account),
-            patch("openlibrary.plugins.upstream.borrow.get_s3_keys", return_value={"s3_key": "x"}),
+            patch("openlibrary.plugins.upstream.borrow.parse_s3_cookie", return_value={"s3_key": "x"}),
             patch("openlibrary.plugins.upstream.borrow.user_can_borrow_edition_async", return_value="borrow"),
             patch(
                 "openlibrary.plugins.upstream.borrow.lending.s3_loan_api_async",
@@ -72,7 +72,7 @@ class TestBorrowPostCore:
             ),
         ):
             mock_site.get.return_value.get.return_value = edition
-            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
+            result = borrow.handle_borrow("/books/OL1M", borrow.BorrowParams(), s3_cookie=None)
 
         assert isinstance(result, borrow.BorrowRedirect)
         assert result.url == "/books/OL1M"
@@ -100,7 +100,7 @@ class TestBorrowPostAdapter:
 
     def test_not_found_raises_404(self):
         with (
-            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=borrow.BorrowNotFound()),
+            patch("openlibrary.plugins.upstream.borrow.handle_borrow", return_value=borrow.BorrowNotFound()),
             pytest.raises(web.webapi.HTTPError),
         ):
             self._post()
@@ -110,7 +110,7 @@ class TestBorrowPostAdapter:
     def test_redirect_with_flash_sets_flash_and_seeothers(self):
         outcome = borrow.BorrowRedirect("/books/OL1M/Some_Title", flash=("success", "Returned!"))
         with (
-            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            patch("openlibrary.plugins.upstream.borrow.handle_borrow", return_value=outcome),
             patch("openlibrary.plugins.upstream.borrow.add_flash_message") as mock_flash,
             pytest.raises(web.webapi.HTTPError),
         ):
@@ -122,7 +122,7 @@ class TestBorrowPostAdapter:
     def test_permanent_redirect_uses_301(self):
         outcome = borrow.BorrowRedirect("/books/OL1M/Some_Title", permanent=True)
         with (
-            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            patch("openlibrary.plugins.upstream.borrow.handle_borrow", return_value=outcome),
             pytest.raises(web.webapi.HTTPError),
         ):
             self._post()
@@ -132,7 +132,7 @@ class TestBorrowPostAdapter:
     def test_clear_login_cookie_calls_setcookie(self):
         outcome = borrow.BorrowRedirect("/account/login?redirect=x", clear_login_cookie=True)
         with (
-            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            patch("openlibrary.plugins.upstream.borrow.handle_borrow", return_value=outcome),
             patch("openlibrary.plugins.upstream.borrow.web.setcookie") as mock_setcookie,
             pytest.raises(web.webapi.HTTPError),
         ):

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -1,0 +1,141 @@
+"""Tests for the shared /borrow logic and its legacy web.py adapter."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import web
+
+from openlibrary.plugins.upstream import borrow
+
+
+def _mock_edition(**attrs):
+    edition = MagicMock()
+    for name, value in attrs.items():
+        setattr(edition, name, value)
+    return edition
+
+
+class TestBorrowPostCore:
+    def test_not_found(self):
+        with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
+            mock_site.get.return_value.get.return_value = None
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+
+        assert result == borrow.BorrowNotFound()
+
+    def test_locate_action_redirects_to_worldcat(self):
+        edition = _mock_edition()
+        edition.get_worldcat_url.return_value = "https://search.worldcat.org/title/1"
+
+        with patch("openlibrary.plugins.upstream.borrow.site") as mock_site:
+            mock_site.get.return_value.get.return_value = edition
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams(action="locate"))
+
+        assert result == borrow.BorrowRedirect("https://search.worldcat.org/title/1")
+
+    def test_not_logged_in_redirects_to_login_and_clears_login_cookie(self):
+        edition = _mock_edition(ocaid="ocaid123", key="/books/OL1M")
+        edition.url.return_value = "/books/OL1M/Some_Title"
+
+        with (
+            patch("openlibrary.plugins.upstream.borrow.site") as mock_site,
+            patch("openlibrary.book_providers.get_book_provider", return_value=None),
+            patch("openlibrary.plugins.upstream.borrow.lending.get_availability", return_value={}),
+            patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=None),
+        ):
+            mock_site.get.return_value.get.return_value = edition
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+
+        assert isinstance(result, borrow.BorrowRedirect)
+        assert result.clear_login_cookie is True
+        assert result.url.startswith("/account/login?redirect=")
+        assert "action%3Dborrow" in result.url
+
+    def test_lending_limit_hit_returns_flash_and_redirect_to_key(self):
+        user = MagicMock()
+        user.has_borrowed.return_value = False
+        account = MagicMock(itemname="ia_item")
+        edition = _mock_edition(ocaid="ocaid123", key="/books/OL1M")
+        edition.url.return_value = "/books/OL1M/Some_Title"
+
+        with (
+            patch("openlibrary.plugins.upstream.borrow.site") as mock_site,
+            patch("openlibrary.book_providers.get_book_provider", return_value=None),
+            patch("openlibrary.plugins.upstream.borrow.lending.get_availability", return_value={}),
+            patch("openlibrary.plugins.upstream.borrow.accounts.get_current_user", return_value=user),
+            patch("openlibrary.plugins.upstream.borrow.OpenLibraryAccount.get_by_email", return_value=account),
+            patch("openlibrary.plugins.upstream.borrow.get_s3_keys", return_value={"s3_key": "x"}),
+            patch("openlibrary.plugins.upstream.borrow.user_can_borrow_edition", return_value="borrow"),
+            patch(
+                "openlibrary.plugins.upstream.borrow.lending.s3_loan_api",
+                side_effect=borrow.lending.PatronAccessException,
+            ),
+        ):
+            mock_site.get.return_value.get.return_value = edition
+            result = borrow.borrow_post_core("/books/OL1M", borrow.BorrowParams())
+
+        assert isinstance(result, borrow.BorrowRedirect)
+        assert result.url == "/books/OL1M"
+        assert result.flash is not None
+        assert result.flash[0] == "error"
+
+
+class TestBorrowPostAdapter:
+    """Tests the web.py `borrow.POST` translation of outcomes into
+    raises/flash-messages/cookies. Mirrors the minimal web.ctx setup used in
+    test_account_loans.py's legacy-handler tests."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_ctx(self):
+        web.ctx.headers = []
+        web.ctx.path = "/books/OL1M/borrow"
+        web.ctx.home = ""
+        web.ctx.realhome = ""
+        web.ctx.status = "200 OK"
+        web.ctx.query = ""
+        web.ctx.env = {"REQUEST_METHOD": "GET", "QUERY_STRING": ""}
+
+    def _post(self, key="/books/OL1M"):
+        return borrow.borrow().POST(key)
+
+    def test_not_found_raises_404(self):
+        with (
+            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=borrow.BorrowNotFound()),
+            pytest.raises(web.webapi.HTTPError),
+        ):
+            self._post()
+
+        assert web.ctx.status.startswith("404")
+
+    def test_redirect_with_flash_sets_flash_and_seeothers(self):
+        outcome = borrow.BorrowRedirect("/books/OL1M/Some_Title", flash=("success", "Returned!"))
+        with (
+            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            patch("openlibrary.plugins.upstream.borrow.add_flash_message") as mock_flash,
+            pytest.raises(web.webapi.HTTPError),
+        ):
+            self._post()
+
+        mock_flash.assert_called_once_with("success", "Returned!")
+        assert web.ctx.status.startswith("303")
+
+    def test_permanent_redirect_uses_301(self):
+        outcome = borrow.BorrowRedirect("/books/OL1M/Some_Title", permanent=True)
+        with (
+            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            pytest.raises(web.webapi.HTTPError),
+        ):
+            self._post()
+
+        assert web.ctx.status.startswith("301")
+
+    def test_clear_login_cookie_calls_setcookie(self):
+        outcome = borrow.BorrowRedirect("/account/login?redirect=x", clear_login_cookie=True)
+        with (
+            patch("openlibrary.plugins.upstream.borrow.borrow_post_core", return_value=outcome),
+            patch("openlibrary.plugins.upstream.borrow.web.setcookie") as mock_setcookie,
+            pytest.raises(web.webapi.HTTPError),
+        ):
+            self._post()
+
+        mock_setcookie.assert_called_once()

--- a/openlibrary/templates/interstitial.html
+++ b/openlibrary/templates/interstitial.html
@@ -1,7 +1,24 @@
-$def with(url, provider_name="", wait=5)
+$def with(url, provider_name="", wait=5, fastapi=False)
 
 $if provider_name is None:
   $ provider_name = ""
+
+$if fastapi:
+  <style>
+    #contentBody.interstitial {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+      color: hsl(41, 14%, 21%);
+      background: hsl(48, 32%, 94%);
+      max-width: 40em;
+      margin: 4em auto;
+      padding: 2em;
+      border-radius: 8px;
+      text-align: center;
+    }
+    #contentBody.interstitial a {
+      color: hsl(210, 84%, 31%);
+    }
+  </style>
 
 <div id="contentBody" class="interstitial" data-url="${url}" data-wait="${wait}">
   <h1>$_("You are being redirected to your book")</h1>
@@ -15,3 +32,33 @@ $if provider_name is None:
     <a href="${url}">$_("Continue without waiting")</a>
   </p>
 </div>
+
+$if fastapi:
+  <script>
+    // Copied from openlibrary/plugins/openlibrary/js/interstitial.js's
+    // initInterstitial(), rewritten with `var` instead of module-scoped
+    // let/const since this runs as a plain inline script, not a bundled
+    // ES module -- FastAPI-rendered pages don't load the site's JS bundle.
+    var interstitialElem = document.querySelector('.interstitial');
+    if (interstitialElem) {
+        var seconds = interstitialElem.dataset.wait;
+        var url = interstitialElem.dataset.url;
+        var timerElement = interstitialElem.querySelector('#timer');
+        var countdown = setInterval(() => {
+            seconds--;
+            timerElement.textContent = seconds;
+            if (seconds === 0) {
+                clearInterval(countdown);
+                window.location.href = url;
+            }
+        }, 1000); // 1 second interval
+
+        // Add cancel button handler
+        var cancelButton = interstitialElem.querySelector('.close-window');
+        if (cancelButton) {
+            cancelButton.addEventListener('click', () => {
+                window.close();
+            });
+        }
+    }
+  </script>

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -15,17 +15,6 @@ def test_verify_hash():
     assert model.verify_hash(secret_key, b"foo", hash)
 
 
-@mock.patch("openlibrary.accounts.model.web")
-def test_get_s3_cookie_reads_from_web_cookies(mock_web):
-    """get_s3_cookie() must be called on the request's own thread -- see its
-    docstring -- so it's a thin, directly-testable wrapper around
-    web.cookies()."""
-    mock_web.cookies.return_value.get.return_value = "encrypted-token"
-
-    assert model.get_s3_cookie() == "encrypted-token"
-    mock_web.cookies.return_value.get.assert_called_once_with("s3")
-
-
 @mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
 def test_parse_s3_cookie_decrypts_a_valid_token(mock_secret_key):
     token = model.encrypt_s3_keys("AKIA123", "secret456")
@@ -34,9 +23,6 @@ def test_parse_s3_cookie_decrypts_a_valid_token(mock_secret_key):
 
 
 def test_parse_s3_cookie_returns_none_when_absent():
-    """None is a legitimate "no cookie" result -- parse_s3_cookie() is a
-    plain string -> dict function with no thread or framework dependency,
-    so it's always safe to call with whatever a caller found (or didn't)."""
     assert model.parse_s3_cookie(None) is None
     assert model.parse_s3_cookie("") is None
 
@@ -44,21 +30,6 @@ def test_parse_s3_cookie_returns_none_when_absent():
 @mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
 def test_parse_s3_cookie_returns_none_for_tampered_token(mock_secret_key):
     assert model.parse_s3_cookie("not-a-real-token") is None
-
-
-@mock.patch("openlibrary.accounts.model.site")
-def test_get_s3_keys_reads_from_the_account_store(mock_site):
-    """get_s3_keys() is the account-store-only fallback and doesn't touch
-    cookies at all (see parse_s3_cookie() for that), so it has no thread
-    dependency and is safe to call from anywhere, including across
-    openlibrary.utils.async_utils.AsyncBridge's background thread."""
-    account = mock.Mock(_key="test/test")
-    mock_site.get.return_value.store.get.return_value = {"s3_keys": {"access": "stored", "secret": "stored-secret"}}
-
-    keys = model.get_s3_keys(account)
-
-    assert keys == {"access": "stored", "secret": "stored-secret"}
-    mock_site.get.return_value.store.get.assert_called_once_with("test/test", {})
 
 
 def test_xauth_http_error_without_json(monkeypatch):

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -15,43 +15,44 @@ def test_verify_hash():
     assert model.verify_hash(secret_key, b"foo", hash)
 
 
-@mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
-@mock.patch("openlibrary.accounts.model.site")
 @mock.patch("openlibrary.accounts.model.web")
-def test_get_s3_keys_uses_explicit_cookie_when_provided(mock_web, mock_site, mock_secret_key):
-    """An explicit s3_cookie (as FastAPI callers must pass, since they can't
-    use web.cookies()) takes precedence and skips web.cookies() entirely."""
-    account = mock.Mock(_key="test/test")
-    token = model.encrypt_s3_keys("AKIA123", "secret456")
+def test_get_s3_cookie_reads_from_web_cookies(mock_web):
+    """get_s3_cookie() must be called on the request's own thread -- see its
+    docstring -- so it's a thin, directly-testable wrapper around
+    web.cookies()."""
+    mock_web.cookies.return_value.get.return_value = "encrypted-token"
 
-    keys = model.get_s3_keys(account, s3_cookie=token)
-
-    assert keys == {"access": "AKIA123", "secret": "secret456"}
-    mock_web.cookies.assert_not_called()
+    assert model.get_s3_cookie() == "encrypted-token"
+    mock_web.cookies.return_value.get.assert_called_once_with("s3")
 
 
 @mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
-@mock.patch("openlibrary.accounts.model.site")
-@mock.patch("openlibrary.accounts.model.web")
-def test_get_s3_keys_defaults_to_web_cookies(mock_web, mock_site, mock_secret_key):
-    """web.py callers omit s3_cookie; it falls back to web.cookies()."""
-    account = mock.Mock(_key="test/test")
+def test_parse_s3_cookie_decrypts_a_valid_token(mock_secret_key):
     token = model.encrypt_s3_keys("AKIA123", "secret456")
-    mock_web.cookies.return_value.get.return_value = token
 
-    keys = model.get_s3_keys(account)
+    assert model.parse_s3_cookie(token) == {"access": "AKIA123", "secret": "secret456"}
 
-    assert keys == {"access": "AKIA123", "secret": "secret456"}
+
+def test_parse_s3_cookie_returns_none_when_absent():
+    """None is a legitimate "no cookie" result -- parse_s3_cookie() is a
+    plain string -> dict function with no thread or framework dependency,
+    so it's always safe to call with whatever a caller found (or didn't)."""
+    assert model.parse_s3_cookie(None) is None
+    assert model.parse_s3_cookie("") is None
+
+
+@mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
+def test_parse_s3_cookie_returns_none_for_tampered_token(mock_secret_key):
+    assert model.parse_s3_cookie("not-a-real-token") is None
 
 
 @mock.patch("openlibrary.accounts.model.site")
-@mock.patch("openlibrary.accounts.model.web")
-def test_get_s3_keys_falls_back_to_store_when_no_cookie(mock_web, mock_site):
-    """Sessions predating the cookie-based approach fall back to the account
-    store, read via the shared `site` contextvar (not web.ctx.site, which
-    isn't populated for FastAPI requests)."""
+def test_get_s3_keys_reads_from_the_account_store(mock_site):
+    """get_s3_keys() is now the account-store-only fallback -- it no longer
+    touches cookies at all (see parse_s3_cookie() for that), so it has no
+    thread dependency and is safe to call from anywhere, including across
+    openlibrary.utils.async_utils.AsyncBridge's background thread."""
     account = mock.Mock(_key="test/test")
-    mock_web.cookies.return_value.get.return_value = None
     mock_site.get.return_value.store.get.return_value = {"s3_keys": {"access": "stored", "secret": "stored-secret"}}
 
     keys = model.get_s3_keys(account)

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -15,6 +15,51 @@ def test_verify_hash():
     assert model.verify_hash(secret_key, b"foo", hash)
 
 
+@mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
+@mock.patch("openlibrary.accounts.model.site")
+@mock.patch("openlibrary.accounts.model.web")
+def test_get_s3_keys_uses_explicit_cookie_when_provided(mock_web, mock_site, mock_secret_key):
+    """An explicit s3_cookie (as FastAPI callers must pass, since they can't
+    use web.cookies()) takes precedence and skips web.cookies() entirely."""
+    account = mock.Mock(_key="test/test")
+    token = model.encrypt_s3_keys("AKIA123", "secret456")
+
+    keys = model.get_s3_keys(account, s3_cookie=token)
+
+    assert keys == {"access": "AKIA123", "secret": "secret456"}
+    mock_web.cookies.assert_not_called()
+
+
+@mock.patch("openlibrary.accounts.model.get_secret_key", return_value="test-secret-key")
+@mock.patch("openlibrary.accounts.model.site")
+@mock.patch("openlibrary.accounts.model.web")
+def test_get_s3_keys_defaults_to_web_cookies(mock_web, mock_site, mock_secret_key):
+    """web.py callers omit s3_cookie; it falls back to web.cookies()."""
+    account = mock.Mock(_key="test/test")
+    token = model.encrypt_s3_keys("AKIA123", "secret456")
+    mock_web.cookies.return_value.get.return_value = token
+
+    keys = model.get_s3_keys(account)
+
+    assert keys == {"access": "AKIA123", "secret": "secret456"}
+
+
+@mock.patch("openlibrary.accounts.model.site")
+@mock.patch("openlibrary.accounts.model.web")
+def test_get_s3_keys_falls_back_to_store_when_no_cookie(mock_web, mock_site):
+    """Sessions predating the cookie-based approach fall back to the account
+    store, read via the shared `site` contextvar (not web.ctx.site, which
+    isn't populated for FastAPI requests)."""
+    account = mock.Mock(_key="test/test")
+    mock_web.cookies.return_value.get.return_value = None
+    mock_site.get.return_value.store.get.return_value = {"s3_keys": {"access": "stored", "secret": "stored-secret"}}
+
+    keys = model.get_s3_keys(account)
+
+    assert keys == {"access": "stored", "secret": "stored-secret"}
+    mock_site.get.return_value.store.get.assert_called_once_with("test/test", {})
+
+
 def test_xauth_http_error_without_json(monkeypatch):
     xauth = InternetArchiveAccount.xauth
     resp = Response()

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -48,9 +48,9 @@ def test_parse_s3_cookie_returns_none_for_tampered_token(mock_secret_key):
 
 @mock.patch("openlibrary.accounts.model.site")
 def test_get_s3_keys_reads_from_the_account_store(mock_site):
-    """get_s3_keys() is now the account-store-only fallback -- it no longer
-    touches cookies at all (see parse_s3_cookie() for that), so it has no
-    thread dependency and is safe to call from anywhere, including across
+    """get_s3_keys() is the account-store-only fallback and doesn't touch
+    cookies at all (see parse_s3_cookie() for that), so it has no thread
+    dependency and is safe to call from anywhere, including across
     openlibrary.utils.async_utils.AsyncBridge's background thread."""
     account = mock.Mock(_key="test/test")
     mock_site.get.return_value.store.get.return_value = {"s3_keys": {"access": "stored", "secret": "stored-secret"}}

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -205,9 +205,9 @@ class TestGetLendingState:
 
 @pytest.mark.usefixtures("request_context_fixture")
 class TestGetLoanHistoryData:
-    """get_s3_keys() is annotated `dict | None` and legitimately returns None for
-    a patron with no `s3` cookie and no `s3_keys` in the account store.
-    s3_loan_api() then does `s3_keys | kwargs`, which raises
+    """parse_s3_cookie() is annotated `dict | None` and legitimately returns
+    None for a patron with no `s3` cookie. s3_loan_api() then does
+    `s3_keys | kwargs`, which raises
     TypeError: unsupported operand type(s) for |: 'NoneType' and 'dict'.
 
     This matters because /account/loans calls get_loan_history_data() directly
@@ -220,7 +220,8 @@ class TestGetLoanHistoryData:
         response.json.return_value = {"history": {"items": []}}
         with (
             patch.object(lending.OpenLibraryAccount, "get_by_username", return_value=Mock()),
-            patch("openlibrary.core.lending.get_s3_keys", return_value=None),
+            patch("openlibrary.core.lending.web.cookies", return_value={"s3": "irrelevant"}),
+            patch("openlibrary.core.lending.parse_s3_cookie", return_value=None),
             patch("openlibrary.core.lending.s3_loan_api", return_value=response) as mock_api,
             patch("openlibrary.core.lending.get_items_and_add_availability", return_value={}),
         ):
@@ -244,7 +245,8 @@ class TestGetLoanHistoryData:
         response.json.return_value = {"history": {"items": []}}
         with (
             patch.object(lending.OpenLibraryAccount, "get_by_username", return_value=Mock()),
-            patch("openlibrary.core.lending.get_s3_keys", return_value={"access": "a", "secret": "s"}),
+            patch("openlibrary.core.lending.web.cookies", return_value={"s3": "irrelevant"}),
+            patch("openlibrary.core.lending.parse_s3_cookie", return_value={"access": "a", "secret": "s"}),
             patch("openlibrary.core.lending.s3_loan_api", return_value=response) as mock_api,
             patch("openlibrary.core.lending.get_items_and_add_availability", return_value={}),
         ):

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -149,7 +149,8 @@ class TestAccountLoansJson:
 
         with (
             patch("openlibrary.core.lending.OpenLibraryAccount.get_by_username", return_value=mock_account),
-            patch("openlibrary.core.lending.get_s3_keys", return_value={"access": "acc", "secret": "sec"}),
+            patch("openlibrary.core.lending.web.cookies", return_value={"s3": "irrelevant"}),
+            patch("openlibrary.core.lending.parse_s3_cookie", return_value={"access": "acc", "secret": "sec"}),
             patch("openlibrary.core.lending.s3_loan_api", return_value=mock_response) as mock_s3_loan_api,
             patch("openlibrary.core.lending.get_items_and_add_availability", return_value={}) as mock_availability,
         ):

--- a/openlibrary/tests/fastapi/test_borrow.py
+++ b/openlibrary/tests/fastapi/test_borrow.py
@@ -9,15 +9,15 @@ from openlibrary.plugins.upstream.borrow import BorrowNotFound, BorrowRedirect
 
 class TestBorrowRoute:
     def test_not_found_returns_404(self, fastapi_client):
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=BorrowNotFound()):
-            response = fastapi_client.get("/books/OL999M/borrow", follow_redirects=False)
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=BorrowNotFound()):
+            response = fastapi_client.get("/books/OL999M/x/borrow", follow_redirects=False)
 
         assert response.status_code == 404
 
     def test_redirect_sets_flash_cookie_in_infogami_shape(self, fastapi_client):
         outcome = BorrowRedirect("/books/OL1M/Some_Title", flash=("success", "Returned!"))
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
-            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/x/borrow", follow_redirects=False)
 
         assert response.status_code == 303
         assert response.headers["location"] == "/books/OL1M/Some_Title"
@@ -28,35 +28,46 @@ class TestBorrowRoute:
 
     def test_permanent_redirect_uses_301(self, fastapi_client):
         outcome = BorrowRedirect("/books/OL1M/Some_Title", permanent=True)
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
-            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/x/borrow", follow_redirects=False)
 
         assert response.status_code == 301
 
     def test_clear_login_cookie_deletes_session_cookie(self, fastapi_client):
         outcome = BorrowRedirect("/account/login?redirect=x", clear_login_cookie=True)
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
-            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/x/borrow", follow_redirects=False)
 
         assert response.status_code == 303
         set_cookie_headers = response.headers.get_list("set-cookie")
         assert any("session=" in h for h in set_cookie_headers)
 
-    def test_title_slug_is_stripped_before_lookup(self, fastapi_client):
+    def test_slug_segment_is_ignored(self, fastapi_client):
+        """The slug is required by the route (always present in real links --
+        the real title slug, or a placeholder like "-"/"x"), but its value
+        doesn't affect the lookup key, which is derived from the olid alone."""
         outcome = BorrowRedirect("/some/target")
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome) as mock_core:
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome) as mock_core:
             fastapi_client.get("/books/OL1M/Some_Title/borrow", follow_redirects=False)
 
         called_key = mock_core.call_args.args[0]
         assert called_key == "/books/OL1M"
 
+    def test_missing_slug_404s(self, fastapi_client):
+        """The route requires a slug segment; a bare /books/{olid}/borrow
+        (no slug) doesn't match at all."""
+        response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+
+        assert response.status_code == 404
+
     def test_s3_cookie_is_passed_through(self, fastapi_client):
-        """get_s3_keys() can't use web.cookies() under FastAPI, so the route
-        must read the raw "s3" cookie itself and pass it through explicitly."""
+        """parse_s3_cookie() needs the raw cookie value, and nothing under
+        FastAPI can use web.cookies() to get it, so the route reads the "s3"
+        cookie itself and passes it through explicitly."""
         outcome = BorrowRedirect("/some/target")
-        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome) as mock_core:
+        with patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome) as mock_core:
             fastapi_client.get(
-                "/books/OL1M/borrow",
+                "/books/OL1M/x/borrow",
                 follow_redirects=False,
                 headers={"Cookie": "s3=encrypted-token"},
             )

--- a/openlibrary/tests/fastapi/test_borrow.py
+++ b/openlibrary/tests/fastapi/test_borrow.py
@@ -9,14 +9,14 @@ from openlibrary.plugins.upstream.borrow import BorrowNotFound, BorrowRedirect
 
 class TestBorrowRoute:
     def test_not_found_returns_404(self, fastapi_client):
-        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=BorrowNotFound()):
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=BorrowNotFound()):
             response = fastapi_client.get("/books/OL999M/borrow", follow_redirects=False)
 
         assert response.status_code == 404
 
     def test_redirect_sets_flash_cookie_in_infogami_shape(self, fastapi_client):
         outcome = BorrowRedirect("/books/OL1M/Some_Title", flash=("success", "Returned!"))
-        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
             response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
 
         assert response.status_code == 303
@@ -28,14 +28,14 @@ class TestBorrowRoute:
 
     def test_permanent_redirect_uses_301(self, fastapi_client):
         outcome = BorrowRedirect("/books/OL1M/Some_Title", permanent=True)
-        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
             response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
 
         assert response.status_code == 301
 
     def test_clear_login_cookie_deletes_session_cookie(self, fastapi_client):
         outcome = BorrowRedirect("/account/login?redirect=x", clear_login_cookie=True)
-        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome):
             response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
 
         assert response.status_code == 303
@@ -44,8 +44,21 @@ class TestBorrowRoute:
 
     def test_title_slug_is_stripped_before_lookup(self, fastapi_client):
         outcome = BorrowRedirect("/some/target")
-        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome) as mock_core:
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome) as mock_core:
             fastapi_client.get("/books/OL1M/Some_Title/borrow", follow_redirects=False)
 
         called_key = mock_core.call_args.args[0]
         assert called_key == "/books/OL1M"
+
+    def test_s3_cookie_is_passed_through(self, fastapi_client):
+        """get_s3_keys() can't use web.cookies() under FastAPI, so the route
+        must read the raw "s3" cookie itself and pass it through explicitly."""
+        outcome = BorrowRedirect("/some/target")
+        with patch("openlibrary.fastapi.borrow.borrow_post_core_async", return_value=outcome) as mock_core:
+            fastapi_client.get(
+                "/books/OL1M/borrow",
+                follow_redirects=False,
+                headers={"Cookie": "s3=encrypted-token"},
+            )
+
+        assert mock_core.call_args.kwargs["s3_cookie"] == "encrypted-token"

--- a/openlibrary/tests/fastapi/test_borrow.py
+++ b/openlibrary/tests/fastapi/test_borrow.py
@@ -1,0 +1,51 @@
+"""Tests for the FastAPI /borrow endpoint's outcome translation."""
+
+import json
+from unittest.mock import patch
+from urllib.parse import unquote
+
+from openlibrary.plugins.upstream.borrow import BorrowNotFound, BorrowRedirect
+
+
+class TestBorrowRoute:
+    def test_not_found_returns_404(self, fastapi_client):
+        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=BorrowNotFound()):
+            response = fastapi_client.get("/books/OL999M/borrow", follow_redirects=False)
+
+        assert response.status_code == 404
+
+    def test_redirect_sets_flash_cookie_in_infogami_shape(self, fastapi_client):
+        outcome = BorrowRedirect("/books/OL1M/Some_Title", flash=("success", "Returned!"))
+        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/books/OL1M/Some_Title"
+        # web.py's flash reader percent-decodes the raw cookie value (symmetric
+        # with web.setcookie()'s percent-encoding), so this must round-trip the
+        # same way rather than being valid JSON directly on the wire.
+        assert json.loads(unquote(response.cookies["flash"])) == [{"type": "success", "message": "Returned!"}]
+
+    def test_permanent_redirect_uses_301(self, fastapi_client):
+        outcome = BorrowRedirect("/books/OL1M/Some_Title", permanent=True)
+        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+
+        assert response.status_code == 301
+
+    def test_clear_login_cookie_deletes_session_cookie(self, fastapi_client):
+        outcome = BorrowRedirect("/account/login?redirect=x", clear_login_cookie=True)
+        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome):
+            response = fastapi_client.get("/books/OL1M/borrow", follow_redirects=False)
+
+        assert response.status_code == 303
+        set_cookie_headers = response.headers.get_list("set-cookie")
+        assert any("session=" in h for h in set_cookie_headers)
+
+    def test_title_slug_is_stripped_before_lookup(self, fastapi_client):
+        outcome = BorrowRedirect("/some/target")
+        with patch("openlibrary.fastapi.borrow.borrow_post_core", return_value=outcome) as mock_core:
+            fastapi_client.get("/books/OL1M/Some_Title/borrow", follow_redirects=False)
+
+        called_key = mock_core.call_args.args[0]
+        assert called_key == "/books/OL1M"

--- a/openlibrary/tests/fastapi/test_borrow.py
+++ b/openlibrary/tests/fastapi/test_borrow.py
@@ -73,3 +73,46 @@ class TestBorrowRoute:
             )
 
         assert mock_core.call_args.kwargs["s3_cookie"] == "encrypted-token"
+
+
+class TestCheckoutWithOcaidRoute:
+    def test_get_unresolvable_ocaid_returns_404(self, fastapi_client):
+        with patch("openlibrary.fastapi.borrow._resolve_ocaid_to_olid", return_value=None):
+            response = fastapi_client.get("/borrow/ia/nonexistent", follow_redirects=False)
+
+        assert response.status_code == 404
+
+    def test_get_redirects_to_canonical_borrow_url_with_query_preserved(self, fastapi_client):
+        with patch("openlibrary.fastapi.borrow._resolve_ocaid_to_olid", return_value="OL1M"):
+            response = fastapi_client.get("/borrow/ia/someocaid?action=read", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/books/OL1M/x/borrow?action=read"
+
+    def test_get_redirect_with_no_query_omits_question_mark(self, fastapi_client):
+        with patch("openlibrary.fastapi.borrow._resolve_ocaid_to_olid", return_value="OL1M"):
+            response = fastapi_client.get("/borrow/ia/someocaid", follow_redirects=False)
+
+        assert response.headers["location"] == "/books/OL1M/x/borrow"
+
+    def test_post_unresolvable_ocaid_returns_404(self, fastapi_client):
+        with patch("openlibrary.fastapi.borrow._resolve_ocaid_to_olid", return_value=None):
+            response = fastapi_client.post("/borrow/ia/nonexistent", follow_redirects=False)
+
+        assert response.status_code == 404
+
+    def test_post_delegates_to_the_canonical_borrow_route(self, fastapi_client):
+        """POST forwards in-process to borrow() (unlike GET, which redirects
+        the browser instead) -- same outcome/flash/cookie handling, just
+        resolved from an ocaid instead of an olid+slug in the URL."""
+        outcome = BorrowRedirect("/some/target", flash=("success", "Returned!"))
+        with (
+            patch("openlibrary.fastapi.borrow._resolve_ocaid_to_olid", return_value="OL1M"),
+            patch("openlibrary.fastapi.borrow.handle_borrow_async", return_value=outcome) as mock_core,
+        ):
+            response = fastapi_client.post("/borrow/ia/someocaid?action=return", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/some/target"
+        called_key = mock_core.call_args.args[0]
+        assert called_key == "/books/OL1M"


### PR DESCRIPTION
/borrow is a common culprit causing webpy saturation especially when IA is slow. If we can asyncify that, that removes a bottleneck in our stack.


### Technical
<!-- What should be noted about the implementation? -->

- Does not remove the old webpy /borrow for now
- There are still some IA requests this thing makes that are not covered here, namely get_loans , but that turned out to be a trickier refactor
- This renders the interstitial.html page entirely in fastapi! Although it sidesteps the issues of trying to render the OL frame and just copies the small amount of CSS/JS needed to make that page work into the template

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This is up on testing with the regex change, so try borrowing books on testing!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
