### PR TITLE
Fix: Move safe imports to top-level for PLC0415 compliance

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -12,7 +12,10 @@ import web
 
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.infobase import client, common  # noqa: F401 side effects may be needed
-from infogami.utils import stats  # noqa: F401 side effects may be needed
+from infogami.utils import (
+    stats,  # noqa: F401 side effects may be needed
+    types,
+)
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
 from openlibrary.core.models import (
@@ -330,8 +333,6 @@ class List(Thing):
                 return cover.id
 
     def get_default_cover(self):
-        from openlibrary.core.models import Image
-
         cover_id = self._get_default_cover_id()
         return Image(self._site, "b", cover_id)
 
@@ -693,7 +694,5 @@ def register_models():
 
 
 def register_types():
-    from infogami.utils import types
-
     types.register_type(r"^(/people/[^/]+)?/lists/OL\d+L$", "/type/list")
     types.register_type(r"^/series/OL\d+L$", "/type/series")

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -13,6 +13,7 @@ import requests
 import web
 
 from infogami.infobase import client
+from infogami.utils import types
 
 # TODO: fix this. openlibrary.core should not import plugins.
 from openlibrary import accounts
@@ -1287,9 +1288,7 @@ class Tag(Thing):
         key = site.get().new_key("/type/tag")
         tag["key"] = key
 
-        from openlibrary.accounts import RunAs
-
-        with RunAs(patron):
+        with accounts.RunAs(patron):
             web.ctx.ip = web.ctx.ip or ip
             t = site.get().save(tag, comment=comment, action="create-tag")
             return t
@@ -1347,8 +1346,6 @@ def register_models():
 
 def register_types():
     """Register default types for various path patterns used in OL."""
-    from infogami.utils import types
-
     types.register_type("^/authors/[^/]*$", "/type/author")
     types.register_type("^/books/[^/]*$", "/type/edition")
     types.register_type("^/works/[^/]*$", "/type/work")

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -2,6 +2,7 @@ from os.path import abspath, dirname, exists, join, pardir
 
 import pytest
 import web
+from PIL import Image
 
 from openlibrary.coverstore import config, coverlib, utils
 
@@ -55,8 +56,6 @@ def test_bad_image(image_dir):
 
 def test_resize_image_aspect_ratio():
     """make sure the aspect-ratio is maintained"""
-    from PIL import Image
-
     img = Image.new("RGB", (100, 200))
 
     img2 = coverlib.resize_image(img, (40, 40))

--- a/openlibrary/plugins/openlibrary/tests/test_verification.py
+++ b/openlibrary/plugins/openlibrary/tests/test_verification.py
@@ -1,8 +1,11 @@
 """Tests for human verification challenge functionality."""
 
+import pytest
 import web
 
 from infogami import config
+from openlibrary.accounts import model
+from openlibrary.accounts.model import generate_login_code_for_user
 from openlibrary.plugins.openlibrary.processors import CookieValidationProcessor
 from openlibrary.utils.request_context import RequestContextVars, req_context
 
@@ -53,8 +56,6 @@ class TestCookieValidationProcessor:
         assert called
 
     def test_valid_vf_cookie_calls_handler(self, monkeypatch):
-        from openlibrary.accounts import model
-
         valid_cookie = model.create_verification_cookie_value()
         monkeypatch.setattr(web, "cookies", lambda: {"vf": valid_cookie})
         handler, called = self._make_handler()
@@ -63,8 +64,6 @@ class TestCookieValidationProcessor:
         assert called
 
     def test_invalid_vf_cookie_returns_403(self, monkeypatch):
-        import pytest
-
         headers = {}
         cleared = []
         monkeypatch.setattr(web, "cookies", lambda: {"vf": "spoofed_value"})
@@ -87,8 +86,6 @@ class TestCookieValidationProcessor:
         assert called
 
     def test_nginx_header_redirects(self, monkeypatch):
-        import pytest
-
         class FakeSeeOther(Exception):
             def __init__(self, url):
                 self.url = url
@@ -112,8 +109,6 @@ class TestCookieValidationProcessor:
         assert called
 
     def test_valid_session_cookie_calls_handler(self, monkeypatch):
-        from openlibrary.accounts.model import generate_login_code_for_user
-
         valid_session = generate_login_code_for_user("testuser")
         monkeypatch.setattr(web, "cookies", lambda: {"session": valid_session})
         handler, called = self._make_handler()
@@ -122,8 +117,6 @@ class TestCookieValidationProcessor:
         assert called
 
     def test_invalid_session_cookie_returns_403(self, monkeypatch):
-        import pytest
-
         headers = {}
         cleared = []
         monkeypatch.setattr(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,6 @@ max-statements = 70
 "openlibrary/catalog/add_book/__init__.py" = ["PLC0415"]
 "openlibrary/code.py" = ["PLC0415"]
 "openlibrary/core/lists/model.py" = ["PLC0415"]
-"openlibrary/coverstore/tests/test_coverstore.py" = ["PLC0415"]
 "openlibrary/mocks/mock_infobase.py" = ["PLC0415"]
 "openlibrary/solr/data_provider.py" = ["PLC0415"]
 "openlibrary/views/showmarc.py" = ["PLC0415"]


### PR DESCRIPTION
Moves trivially-safe imports to top-level:

- PIL.Image in coverstore test (test file, no ordering concerns)
- pytest and accounts imports in verification test (test file)
- infogami.utils.types in core/models.py and core/lists/model.py (no side effects, infogami already loaded)

All changes verified with ruff and pytest.