### PR TITLE
fix cover uploads blocked by ModSecurity

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -154,6 +154,25 @@ server {
         return 429;
     }
 
+    # Cover/photo upload endpoints — exempt from ModSecurity so that
+    # multipart file uploads larger than SecRequestBodyNoFilesLimit (default 1 MB)
+    # are not blocked by the WAF before reaching the application.
+    # The app itself enforces a 10 MB cap and validates file type/content in
+    # openlibrary/plugins/upstream/covers.py.
+    location ~ ^/(books/OL\d+M/add-cover|works/OL\d+W/add-cover|authors/OL\d+A/add-photo)$ {
+        modsecurity off;
+
+        limit_req zone=web_limit burst=100 delay=10;
+        limit_req zone=ua_rate_limit burst=25 delay=10;
+        limit_req zone=global_crawler_limit nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://web_haproxy:7072;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+    }
+
     location / {
         limit_req zone=web_limit burst=100 delay=10;
         limit_req zone=ua_rate_limit burst=25 delay=10;


### PR DESCRIPTION
## What issue does this PR close?

Closes #13232 

## What does this PR achieve?

Fixes cover/photo uploads larger than ~1 MB being rejected by ModSecurity with an HTTP 460 response.

### Root cause

ModSecurity's `SecRequestBodyNoFilesLimit` defaults to 1 MB. The following upload endpoints are currently handled by the generic nginx `location /` block, where ModSecurity is enabled:

* `/books/.../add-cover`
* `/works/.../add-cover`
* `/authors/.../add-photo`

As a result, multipart uploads larger than 1 MB are rejected by the WAF before reaching the Python application. This causes the upload iframe to receive an empty 460 response, resulting in a blank upload dialog and the cover/photo not being saved.

This is not caused by `client_max_body_size`, which is already set to 50 MB, or the application's upload validation, which allows files up to 10 MB.

### Fix

Added a targeted nginx `location` block for the three upload endpoints and disabled ModSecurity only for these paths.

The existing rate limiting and proxy configuration are preserved:

```nginx
location ~ ^/(books/OL\d+M/add-cover|works/OL\d+W/add-cover|authors/OL\d+A/add-photo)$ {
    modsecurity off;

    limit_req zone=web_limit burst=100 delay=10;
    limit_req zone=ua_rate_limit burst=25 delay=10;
    limit_req zone=global_crawler_limit nodelay;
    limit_req_status 429;

    proxy_pass http://web_haproxy:7072;
    proxy_set_header Host $http_host;
    proxy_set_header X-Forwarded-For $remote_addr;
    proxy_set_header X-Scheme $scheme;
}
```

All other routes continue to use ModSecurity normally.

### Why is this safe?

* The application enforces a 10 MB upload limit.
* Uploaded files are validated as images using PIL's `image.verify()`.
* File type is validated using both the extension and file contents.
* Rate limiting remains enabled for the upload endpoints.
* ModSecurity remains enabled for all other routes.
* This follows the existing pattern of disabling ModSecurity for specific locations in `docker/web_nginx.conf`.

### Alternative considered

Another option would be increasing `SecRequestBodyNoFilesLimit` in `olsystem/etc/nginx/modsecurity_openlibrary.conf`. That would keep ModSecurity enabled for the uploads, but it would require a change in the private `olsystem` repository.

I chose the targeted nginx change here so that the fix is visible and reviewable in this repository. I'm happy to adjust the approach if the team prefers handling the limit through `olsystem` instead.

### Testing

* Confirmed that the upload request was being rejected with HTTP 460 before reaching the application.
* Confirmed that the existing application-side 10 MB limit and image validation remain in place.
* Confirmed that the new nginx location preserves the existing rate limiting and proxy configuration.
