### PR TITLE
Remove solr aggregate `text` field

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -267,9 +267,6 @@
     <!-- Open Syllabus Project -->
     <field name="osp_count" type="pint"/>
 
-    <!-- TODO: This should probably be type text_international since it's the catchall -->
-    <field name="text" type="text_en_splitting" stored="false" multiValued="true"/>
-
     <field name="seed" type="string" multiValued="true"/>
 
 
@@ -358,36 +355,7 @@
     <copyField source="person" dest="person_facet"/>
     <copyField source="time" dest="time_facet"/>
 
-    <copyField source="key" dest="text"/>
-    <copyField source="redirects" dest="text"/>
-    <copyField source="title" dest="text"/>
-    <copyField source="subtitle" dest="text"/>
-    <copyField source="alternative_title" dest="text"/>
-    <copyField source="alternative_subtitle" dest="text"/>
-    <copyField source="edition_key" dest="text"/>
-    <copyField source="by_statement" dest="text"/>
-    <copyField source="lccn" dest="text"/>
-    <copyField source="ia" dest="text"/>
-    <copyField source="oclc" dest="text"/>
-    <copyField source="isbn" dest="text"/>
-    <copyField source="contributor" dest="text"/>
-    <copyField source="publisher" dest="text"/>
-    <copyField source="first_sentence" dest="text"/>
-    <copyField source="author_key" dest="text"/>
-    <copyField source="author_name" dest="text"/>
-    <copyField source="author_alternative_name" dest="text"/>
-    <copyField source="series_key" dest="text"/>
-    <copyField source="series_name" dest="text"/>
-    <copyField source="series_position" dest="text"/>
-    <copyField source="subject" dest="text"/>
-    <copyField source="place" dest="text"/>
-    <copyField source="person" dest="text"/>
-    <copyField source="time" dest="text"/>
-
-    <!-- Copy author search fields into default search field "text" -->
-    <copyField source="name" dest="text"/>
     <copyField source="name" dest="name_sort"/>
-    <copyField source="alternate_names" dest="text"/>
 
     <!-- *** END of OpenLibrary copyFields *** -->
 

--- a/conf/solr/conf/solrconfig.xml
+++ b/conf/solr/conf/solrconfig.xml
@@ -481,7 +481,7 @@
         <!-- Work search -->
         <lst>
           <str name="userWorkQuery">harry potter</str>
-          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
+          <str name="q">({!edismax q.op="AND" qf="alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
           <str name="fq">type:work</str>
           <str name="rows">20</str>
           <str name="facet">true</str>
@@ -498,7 +498,7 @@
         <!-- Author works search -->
         <lst>
           <str name="userWorkQuery">*:*</str>
-          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
+          <str name="q">({!edismax q.op="AND" qf="alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
           <str name="fq">type:work</str>
           <str name="fq">author_key:OL2162284A</str>
           <str name="sort">edition_count desc</str>
@@ -513,7 +513,7 @@
         <!-- Ebook only search for carousel -->
         <lst>
           <str name="userWorkQuery">subject:"Reading Level-Grade 6"</str>
-          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
+          <str name="q">({!edismax q.op="AND" qf="alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$userWorkQuery})</str>
           <str name="fq">type:work</str>
           <str name="fq">ebook_access:[printdisabled TO *]</str>
           <str name="rows">20</str>
@@ -651,8 +651,10 @@
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
-      <!-- Default search field -->
-      <str name="df">text</str>
+      <!-- Default search field for bare/unqualified terms. App code always
+           passes an explicit qf, so this only matters for ad-hoc/debug
+           queries against /select without one. -->
+      <str name="df">title</str>
     </lst>
   </requestHandler>
 
@@ -682,7 +684,7 @@
   <!-- Shared parameters for multiple Request Handlers -->
   <initParams path="/update/**,/query,/select,/spell">
     <lst name="defaults">
-      <str name="df">text</str>
+      <str name="df">title</str>
     </lst>
   </initParams>
 
@@ -704,7 +706,7 @@
     <!-- a spellchecker built from a field of the main index -->
     <lst name="spellchecker">
       <str name="name">default</str>
-      <str name="field">text</str>
+      <str name="field">title</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
       <str name="distanceMeasure">internal</str>

--- a/openlibrary/plugins/worksearch/schemes/lists.py
+++ b/openlibrary/plugins/worksearch/schemes/lists.py
@@ -76,9 +76,10 @@ class ListSearchScheme(SearchScheme):
             ("q.op", "AND"),  # use 'AND' for matching multiple words in search queries
             ("defType", "edismax"),  # use edismax parser for better full-text search
             # qf specifies which fields to search and their boost weights.
-            # Searching 'text' allows matching on subjects aggregated from the list's
-            # books, while boosting 'name' ensures title matches rank highest.
-            ("qf", "text name^10"),
+            # Searching subject/place/person/time allows matching on subjects
+            # aggregated from the list's books, while boosting 'name' ensures
+            # title matches rank highest.
+            ("qf", "subject place person time name^10"),
         ]
         # Default: exclude low-seed lists (issue #11905).
         # Lists with fewer than 2 seeds are likely spam. Series are exempt

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -57,4 +57,7 @@ class SubjectSearchScheme(SearchScheme):
             ("q", q),
             ("q.op", "AND"),
             ("defType", "edismax"),
+            # Without an explicit qf, edismax falls back to solrconfig's df,
+            # which isn't guaranteed to be a field subject docs populate.
+            ("qf", "name"),
         ]

--- a/openlibrary/plugins/worksearch/schemes/tests/test_lists.py
+++ b/openlibrary/plugins/worksearch/schemes/tests/test_lists.py
@@ -4,7 +4,7 @@ from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 def test_q_to_solr_params_includes_qf():
     s = ListSearchScheme()
     params = dict(s.q_to_solr_params("library journal", set(), []))
-    assert params["qf"] == "text name^10"
+    assert params["qf"] == "subject place person time name^10"
     assert params["defType"] == "edismax"
     assert params["q.op"] == "AND"
 

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -382,7 +382,6 @@ class WorkSearchScheme(SearchScheme):
             WORK_FIELD_TO_ED_FIELD: dict[str, str | Callable[[str], str]] = {
                 # Internals
                 "edition_key": "key",
-                "text": "text",
                 # Display data
                 "title": "title",
                 "title_suggest": "title_suggest",

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -540,7 +540,7 @@ class WorkSearchScheme(SearchScheme):
                 # See qf in work_query. Edition docs only carry a subset of
                 # the work-level fields (see EditionSolrBuilder.build()), so
                 # this only lists fields that are actually populated on them.
-                qf="title subtitle publisher isbn oclc lccn ia key alternative_title^4 author_name^4 chapter^4",
+                qf="title subtitle publisher isbn oclc lccn ia key author_key alternative_title^4 author_name^4 author_alternative_name^4 chapter^4",
                 # Reading from the url parameter userEdQuery. This lets us avoid
                 # having to try to escape the query in order to fit inside this
                 # other query.

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -537,8 +537,10 @@ class WorkSearchScheme(SearchScheme):
             new_params.append(("editions.ol.label", "EDITION_MATCH"))
 
             full_ed_query = '({{!edismax bq="{bq}" v={v} qf="{qf}"}})'.format(
-                # See qf in work_query
-                qf="text alternative_title^4 author_name^4 chapter^4",
+                # See qf in work_query. Edition docs only carry a subset of
+                # the work-level fields (see EditionSolrBuilder.build()), so
+                # this only lists fields that are actually populated on them.
+                qf="title subtitle publisher isbn oclc lccn ia key alternative_title^4 author_name^4 chapter^4",
                 # Reading from the url parameter userEdQuery. This lets us avoid
                 # having to try to escape the query in order to fit inside this
                 # other query.

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -127,7 +127,6 @@ class SolrDocument(TypedDict):
     already_read_count: Optional[int]
     stopped_reading_count: Optional[int]
     osp_count: Optional[int]
-    text: Optional[list[str]]
     seed: Optional[list[str]]
     name: Optional[str]
     name_sort: Optional[bytes]


### PR DESCRIPTION
This text field stores a sizable copy of all the data in solr. We see solr generally have very high disk **reads**, and AI suggests this is because the size of its largest segment (64GB of the total index size of 69GB) is much larger than can be fit into the RAM on that server (23GB, 13GB page cache). We already stopped hitting the text field for our main solr work queries ; if replacing the last instances of its use shows no negative performance impacts, we should delete the field entirely.

Locally this reduces the size of solr by 13% !

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Note this won't have much of an impact on the production solr instances ; we'll see it's impact after a full reindex runs.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Patch deployed switching from the text field in the last few spots and saw no difference in performance.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
