### PR TITLE
Use uvicorn --factory for fast_web — save ~100MB of RAM

### DIFF
--- a/docker/ol-web-fastapi-start.sh
+++ b/docker/ol-web-fastapi-start.sh
@@ -9,7 +9,7 @@ export OL_CONFIG="${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}"
 
 # In development, use uvicorn since gunicorn's auto-restart is unreliable with asgi
 if [ "${LOCAL_DEV:-false}" = "true" ]; then
-  # Factory keeps the reloader parent light (https://uvicorn.dev/#application-factories).
+  # --factory avoids importing openlibrary into the uvicorn reloader parent process (https://uvicorn.dev/#application-factories), which saves ~100 MB of RAM
   exec uvicorn \
     --factory \
     --reload \

--- a/docker/ol-web-fastapi-start.sh
+++ b/docker/ol-web-fastapi-start.sh
@@ -9,11 +9,13 @@ export OL_CONFIG="${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}"
 
 # In development, use uvicorn since gunicorn's auto-restart is unreliable with asgi
 if [ "${LOCAL_DEV:-false}" = "true" ]; then
+  # Factory keeps the reloader parent light (https://uvicorn.dev/#application-factories).
   exec uvicorn \
+    --factory \
     --reload \
     --host 0.0.0.0 \
     --port 8080 \
-    openlibrary.asgi_app:app
+    openlibrary.asgi_app:create_app
 else
   # Run ASGI app via gunicorn with uvicorn workers
   # Note: GUNICORN_OPTS may be provided via environment (compose.yaml)
@@ -23,5 +25,5 @@ else
     -k uvicorn.workers.UvicornWorker \
     ${GUNICORN_OPTS:- --reload --workers 4 --timeout 180} \
     --bind :8080 \
-    openlibrary.asgi_app:app
+    "openlibrary.asgi_app:create_app()"
 fi

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -263,5 +263,7 @@ def create_app() -> FastAPI | None:
     return app
 
 
-# The ASGI app instance Gunicorn/Uvicorn will serve
-app = create_app()
+# Use factory: ``uvicorn --factory openlibrary.asgi_app:create_app``
+# (keeps reloader parent light, per https://uvicorn.dev/#application-factories
+# For gunicorn prod, use ``openlibrary.asgi_app:create_app()`` (call via
+# gunicorn.util.import_app).


### PR DESCRIPTION
fast_web with --reload was importing the app in both parent and worker (172MB + 171MB).

Switch to factory `uvicorn --factory openlibrary.asgi_app:create_app` per https://fastapi.tiangolo.com/deployment/ and https://uvicorn.dev/#application-factories. Remove `app = create_app()` from `openlibrary/asgi_app.py`, update `docker/ol-web-fastapi-start.sh` (prod now `openlibrary.asgi_app:create_app()`).

Saves ~100MB overall, no compose changes.