### PR TITLE
Enable useColdSearcher for Solr

### DIFF
--- a/conf/solr/conf/solrconfig.xml
+++ b/conf/solr/conf/solrconfig.xml
@@ -546,7 +546,7 @@
          warming searcher and use it.  If "false" then all requests
          will block until the first searcher is done warming.
       -->
-    <useColdSearcher>false</useColdSearcher>
+    <useColdSearcher>true</useColdSearcher>
     <maxWarmingSearchers>4</maxWarmingSearchers>
   </query>
 

--- a/docs/ai/solr/index.md
+++ b/docs/ai/solr/index.md
@@ -362,7 +362,7 @@ On every new searcher open, Solr runs warming queries from the `newSearcher` lis
 fq=type:work&facet=true&facet.field=language&facet.field=subject_facet&facet.limit=25&rows=0
 ```
 
-`useColdSearcher=false` — blocks all requests until the new searcher finishes warming (protects against cold-cache spikes at the cost of momentary queuing on commit).
+`useColdSearcher=true` — immediately registers a still-warming searcher and uses it for incoming requests instead of blocking (avoids request queuing on commit at the cost of momentarily colder caches).
 
 `maxWarmingSearchers=4` — up to 4 searchers can warm in parallel.
 


### PR DESCRIPTION
## TL;DR

Every 60 seconds Solr takes a fresh snapshot of new/changed records so they show up in search. Each snapshot swap forces a short re-warm-up, and our current setting (`useColdSearcher=false`) makes **every search during that window wait in line** until warming finishes — 🛒 like closing the checkout lanes every minute while shelves get restocked (I love this analogy ).

Measured on a full-scale copy of the index (111.8M docs): commits cost us **−24% throughput** under load with the current setting. Flipping one word in `solrconfig.xml` recovers most of it (**−6%**). Users would occasionally see results that are one snapshot old (~60s stale worst case); nobody will notice, but everyone feels the stalls.

This is a one-line, instantly reversible config change.

## What happens today (plain English)

1. Records change all day (edits, new books, imports).
2. Every 60 seconds (`autoSoftCommit.maxTime=60000`) Solr swaps in an updated "snapshot" of the index so those changes become searchable.
3. Each swap makes the search "engine" reload and re-warm.
4. With `useColdSearcher=false`, incoming searches **block** while warming runs.
5. Bonus pain: each swap also erases Solr's internal caches, so the minutes right after a swap are slower even once blocking stops.

## How long is the warm-up, actually?

Measured from live metrics on the full-scale test instance:

| Warm-up phase | Average | Notes |
|---|---|---|
| Opening the new snapshot | ~120 ms | cheap |
| Running the 3 warming queries | **~5.3 s** | real production-shaped searches over 41M works |
| **Total stall per commit** | **~5–5.5 s** | every 60 seconds |

That's roughly **8–9% of wall-clock time spent making users wait**.

## Measured results (load test, identical conditions)

Simulated prod's commit-every-60s cycle as a commit-every-15s storm under a realistic diverse search load (c=25, 2-minute runs, verified real searcher reopens):

| Scenario | Throughput | p99 latency |
|---|---|---|
| No commits (ideal) | 453 req/s | 288 ms |
| Commits + current setting (`false`) | 342 req/s | 502 ms |
| **Commits + `useColdSearcher=true`** | **424 req/s** | **420 ms** |

One flag recovers most of the loss.

## The trade-off

With `true`, during the ~5s warm-up window users may get results from the *previous* snapshot — i.e., up to ~60s stale in the worst case. For book search this is invisible: a just-edited record appearing 60s later is already accepted behavior (it's exactly what the commit interval implies anyway).

Secondary effect worth knowing: `maxWarmingSearchers=4`. If commits stack up faster than warms finish (busy node), extra reopens currently get *rejected* — another failure mode the flag helps smooth over, since requests stop piling up behind warmups.

## Proposed experiment

1. Merge the one-line change to `conf/solr/conf/solrconfig.xml` (line ~549): `<useColdSearcher>false</useColdSearcher>` → `true`.
2. Deploy to a single Solr node first if feasible; else fleet-wide (reversible).
3. Watch for 24–48h:
   - `/select` handler QTime p95/p99 (Graphite `ol.label` buckets already scrape these)
   - error rates around commit boundaries
   - any user reports of staleness (expected: none)
4. Compare against the prior week's same-hour baselines.

**Success criteria:** p99 improvement around commit cycles, no increase in errors/staleness complaints.

## Related follow-ups (separate PRs, not in scope here)

- **Reconsider the 60s cadence:** every commit wipes internal caches fleet-wide. If search can tolerate 2–5 minute freshness, lengthening `autoSoftCommit.maxTime` removes most of the remaining −6%.
- **Trim the warming queries:** the facet-heavy warmer is a large share of the 5.3s; fewer/cheaper warmers shrink the window regardless of the flag.
- Bigger Solr caches + app-layer facet caching (measured separately: +70% throughput and 7–14× cost avoidance respectively) — see `solr_performance_findings.md`.

## Rollback

Flip the word back to `false` and redeploy. No reindex, no data migration, no downtime beyond normal deploys.