### PR TITLE
Cache httpx AsyncClient per event loop to avoid cross-loop reuse crashes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,19 @@ repos:
     hooks:
     - id: cython-lint
 
+  - repo: local
+    hooks:
+      - id: no-bare-httpx-async-client
+        name: No bare httpx.AsyncClient() assignments
+        description: >
+          A directly-assigned httpx.AsyncClient() is unsafe to share across
+          this codebase's event loops -- see cache_per_event_loop in
+          openlibrary/utils/async_utils.py.
+        entry: python ./scripts/check_no_bare_httpx_async_client.py
+        language: python
+        types: [python]
+        exclude: (^|/)tests?/
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -11,6 +11,7 @@ import web
 from infogami import config
 from infogami.utils import stats
 from openlibrary.core import cache
+from openlibrary.utils.async_utils import cache_per_event_loop
 
 logger = logging.getLogger("openlibrary.ia")
 
@@ -18,7 +19,7 @@ IA_BASE_URL = "https://archive.org"
 VALID_READY_REPUB_STATES = ["4", "19", "20", "22"]
 EXEMPT_COLLECTIONS = ["collection:thoth-archiving-network"]
 session = httpx.Client()
-async_session = httpx.AsyncClient()
+get_async_session = cache_per_event_loop(httpx.AsyncClient)
 
 
 def setup(config):

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -202,7 +202,7 @@ async def get_groundtruth_availability_async(ocaid, s3_keys=None):
     url = config_ia_s3_loan_url or S3_LOAN_URL % config_bookreader_host
     timeout = 2 if os.getenv("LOCAL_DEV") else config_http_request_timeout
     try:
-        response = await ia.async_session.post(url + params, data=s3_keys, timeout=timeout)
+        response = await ia.get_async_session().post(url + params, data=s3_keys, timeout=timeout)
         response.raise_for_status()
     except httpx.TimeoutException:
         if os.getenv("LOCAL_DEV"):
@@ -240,7 +240,7 @@ async def s3_loan_api_async(s3_keys, ocaid=None, action="browse", **kwargs):
 
     data = s3_keys | kwargs
 
-    response = await ia.async_session.post(url + params, data=data, timeout=config_http_request_timeout)
+    response = await ia.get_async_session().post(url + params, data=data, timeout=config_http_request_timeout)
     # We want this to be just `409` but first
     # `www/common/Lending.inc#L111-114` needs to
     # be updated on petabox
@@ -302,7 +302,7 @@ async def get_available_async(
             "x-preferred-client-id": client_ip,
             "x-application-id": "openlibrary",
         }
-        response = await ia.async_session.get(url, headers=headers, timeout=config_http_request_timeout)
+        response = await ia.get_async_session().get(url, headers=headers, timeout=config_http_request_timeout)
         items = response.json().get("response", {}).get("docs", [])
         results = {}
         for item in items:
@@ -439,7 +439,7 @@ async def get_availability_async(
         }
         if config_ia_ol_metadata_write_s3:
             headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(**config_ia_ol_metadata_write_s3)
-        resp = await ia.async_session.get(
+        resp = await ia.get_async_session().get(
             config_ia_availability_api_v2_url,
             params={
                 id_type: ",".join(ids_to_fetch),

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -23,7 +23,7 @@ from openlibrary.catalog.add_book import load
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
 from openlibrary.utils import dateutil, uniq
-from openlibrary.utils.async_utils import async_bridge
+from openlibrary.utils.async_utils import async_bridge, cache_per_event_loop
 from openlibrary.utils.isbn import (
     isbn_10_to_isbn_13,
     isbn_13_to_isbn_10,
@@ -32,7 +32,7 @@ from openlibrary.utils.isbn import (
 
 logger = logging.getLogger("openlibrary.vendors")
 session = requests.Session()
-async_session = httpx.AsyncClient()
+get_async_session = cache_per_event_loop(httpx.AsyncClient)
 
 BETTERWORLDBOOKS_API_URL = "https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId="
 affiliate_server_url = None
@@ -605,11 +605,11 @@ async def get_amazon_metadata_async(
     https://webservices.amazon.com/paapi5/documentation/get-items.html
 
     Canonical async implementation: makes the HTTP round-trip to the affiliate
-    server with the shared httpx ``async_session`` so it never blocks the event
-    loop. Results are cached in memcache for a week; bare ``None`` results
-    (e.g. a 503 throttle from the affiliate server) are not cached, so the next
-    call retries — matching the historical "only the value None will cause
-    re-cache" behaviour.
+    server with a shared per-loop httpx client (see ``get_async_session``) so
+    it never blocks the event loop. Results are cached in memcache for a week;
+    bare ``None`` results (e.g. a 503 throttle from the affiliate server) are
+    not cached, so the next call retries — matching the historical "only the
+    value None will cause re-cache" behaviour.
 
     :param str id_: The item id: isbn (10/13), or Amazon ASIN.
     :param str id_type: 'isbn' or 'asin'.
@@ -639,7 +639,7 @@ async def get_amazon_metadata_async(
     try:
         priority = "true" if high_priority else "false"
         stage = "true" if stage_import else "false"
-        r = await async_session.get(
+        r = await get_async_session().get(
             f"http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}",
             timeout=timeout,
         )
@@ -814,7 +814,7 @@ async def _get_betterworldbooks_metadata(
     """
 
     url = BETTERWORLDBOOKS_API_URL + isbn
-    response = await async_session.get(url, timeout=3)
+    response = await get_async_session().get(url, timeout=3)
     if response.status_code != requests.codes.ok:
         return {"error": response.text, "code": response.status_code}
     text = response.text

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -8,6 +8,7 @@ import httpx
 from httpx import HTTPError, HTTPStatusError, TimeoutException
 
 from openlibrary import config
+from openlibrary.utils.async_utils import cache_per_event_loop
 from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 if TYPE_CHECKING:
@@ -18,7 +19,7 @@ logger = logging.getLogger("openlibrary.solr")
 
 solr_base_url = None
 solr_next: bool | None = None
-httpx_client = httpx.AsyncClient()
+get_httpx_client = cache_per_event_loop(httpx.AsyncClient)
 
 
 def load_config(c_config="conf/openlibrary.yml"):
@@ -135,7 +136,7 @@ async def solr_update(
     async def make_request():
         logger.debug(f"POSTing update to {solr_base_url}/update {params}")
         try:
-            resp = await httpx_client.post(
+            resp = await get_httpx_client().post(
                 f"{solr_base_url}/update",
                 # Large batches especially can take a decent chunk of time
                 timeout=300,
@@ -208,7 +209,7 @@ async def solr_insert_documents(
         params["update.chain"] = "tolerant-chain"
     logger.debug(f"POSTing update to {solr_base_url}/update {params}")
     try:
-        resp = await httpx_client.post(
+        resp = await get_httpx_client().post(
             f"{solr_base_url}/update",
             timeout=timeout,
             params=params,

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -55,7 +56,11 @@ class TestGetAvailability:
         req_context.reset(token)
 
     def test_cache(self):
-        with patch("openlibrary.core.ia.async_session.get") as mock_get:
+        mock_get = AsyncMock()
+        with patch(
+            "openlibrary.core.ia.get_async_session",
+            return_value=SimpleNamespace(get=mock_get),
+        ):
             mock_response = AsyncMock()
             mock_response.json = Mock(
                 return_value={

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -1,5 +1,6 @@
 import importlib
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -310,7 +311,10 @@ def test_get_amazon_metadata() -> None:
         return MockResponse()
 
     with (
-        patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
+        patch(
+            "openlibrary.core.vendors.get_async_session",
+            new=lambda: SimpleNamespace(get=mock_async_get),
+        ),
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),
     ):
         got = get_amazon_metadata(id_=isbn, id_type="isbn")
@@ -362,7 +366,10 @@ async def test_get_amazon_metadata_async() -> None:
     # Use the ISBN-13 form of the same book for a distinct cache key.
     isbn = "9780590353427"
     with (
-        patch("openlibrary.core.vendors.async_session.get", new=mock_async_get),
+        patch(
+            "openlibrary.core.vendors.get_async_session",
+            new=lambda: SimpleNamespace(get=mock_async_get),
+        ),
         patch("openlibrary.core.vendors.affiliate_server_url", new=True),
     ):
         got = await get_amazon_metadata_async(id_=isbn, id_type="isbn", timeout=5.0)

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -84,7 +84,7 @@ class TestSolrUpdate:
 
     async def test_successful_response(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(return_value=self.sample_response_200())
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -95,7 +95,7 @@ class TestSolrUpdate:
 
     async def test_non_json_solr_503(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(return_value=self.sample_response_503())
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -106,7 +106,7 @@ class TestSolrUpdate:
 
     async def test_solr_offline(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(side_effect=ConnectError("", request=MagicMock()))
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -117,7 +117,7 @@ class TestSolrUpdate:
 
     async def test_invalid_solr_request(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(return_value=self.sample_global_error())
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -128,7 +128,7 @@ class TestSolrUpdate:
 
     async def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(return_value=self.sample_individual_error())
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -139,7 +139,7 @@ class TestSolrUpdate:
 
     async def test_other_non_ok_status(self, monkeypatch, monkeytime):
         mock_post = AsyncMock(return_value=Response(500, request=MagicMock(), content="{}"))
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
+        monkeypatch.setattr(utils.get_httpx_client(), "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),

--- a/openlibrary/tests/utils/test_async_utils.py
+++ b/openlibrary/tests/utils/test_async_utils.py
@@ -1,0 +1,109 @@
+"""Regression coverage for cache_per_event_loop (openlibrary.utils.async_utils).
+
+A single process-wide httpx.AsyncClient is unsafe to share between
+AsyncBridge's persistent background-thread event loop and a caller running on
+a different event loop (e.g. FastAPI's): httpx/httpcore/anyio lazily bind a
+plain asyncio.Event to whichever event loop is running the first time a
+pooled connection is genuinely contended for, and reusing that connection
+from another loop later raises `RuntimeError: ... is bound to a different
+event loop`.
+
+This only reproduces with a real, kept-alive HTTP/1.1 connection under
+genuine read contention -- a mocked transport bypasses the real socket code
+entirely -- so these tests spin up an actual local HTTP/1.1 server.
+"""
+
+import asyncio
+import functools
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from openlibrary.utils.async_utils import AsyncBridge, cache_per_event_loop
+
+# openlibrary/conftest.py's `no_sleep` autouse fixture monkeypatches `time.sleep`
+# process-wide (including this handler's server thread) to catch slow tests.
+# Capturing the real function at import time, before that fixture runs, lets
+# the local test server use a genuine short delay to force a real cross-loop
+# read race, which is the whole point of this test.
+_real_sleep = time.sleep
+
+
+class _KeepAliveHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # enable keep-alive so httpx pools/reuses the connection
+
+    def do_GET(self):
+        _real_sleep(0.02)  # force the client's read() to genuinely await, not just poll a buffer
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def keep_alive_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _KeepAliveHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/"
+    finally:
+        server.shutdown()
+
+
+async def _burst(client: httpx.AsyncClient, url: str, n: int) -> list[httpx.Response]:
+    return await asyncio.gather(*[client.get(url, timeout=5) for _ in range(n)])
+
+
+@pytest.mark.asyncio
+async def test_sharing_one_async_client_across_loops_fails(keep_alive_server):
+    """Documents the bug cache_per_event_loop exists to fix."""
+    bridge = AsyncBridge()
+    client = httpx.AsyncClient(limits=httpx.Limits(max_connections=2))
+    try:
+        # Contending for a pooled keep-alive connection on the bridge's loop
+        # binds that connection's internal lock/event to it.
+        bridge.run(_burst(client, keep_alive_server, 3))
+
+        # Reusing the same (now loop-bound) pooled connection with genuine
+        # contention on *this* loop trips the cross-loop RuntimeError.
+        with pytest.raises(RuntimeError, match="different event loop"):
+            await _burst(client, keep_alive_server, 3)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cache_per_event_loop_avoids_cross_loop_reuse(keep_alive_server):
+    bridge = AsyncBridge()
+    get_client = cache_per_event_loop(functools.partial(httpx.AsyncClient, limits=httpx.Limits(max_connections=2)))
+
+    async def hit_via_cache():
+        return await _burst(get_client(), keep_alive_server, 3)
+
+    # Same sequence as the failing test above, but every call goes through
+    # get_client(), so the bridge loop and this loop each get their own client.
+    bridge.run(hit_via_cache())
+    responses = await hit_via_cache()
+    assert all(r.status_code == 200 for r in responses)
+
+
+@pytest.mark.asyncio
+async def test_cache_per_event_loop_returns_distinct_values_per_loop():
+    get_client = cache_per_event_loop(httpx.AsyncClient)
+    bridge = AsyncBridge()
+
+    main_client = get_client()
+    bridge_client = bridge.run(_call(get_client))
+
+    assert main_client is not bridge_client
+    assert get_client() is main_client  # stable within the same loop
+
+
+async def _call(get_client):
+    return get_client()

--- a/openlibrary/utils/async_utils.py
+++ b/openlibrary/utils/async_utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import contextvars
+import functools
 import threading
+import weakref
 from collections.abc import Callable, Coroutine
 from typing import Any, ParamSpec, TypeVar
 
@@ -54,3 +56,39 @@ class AsyncBridge:
 
 
 async_bridge = AsyncBridge()
+
+
+def cache_per_event_loop[T](factory: Callable[[], T]) -> Callable[[], T]:
+    """Cache a zero-arg factory's result once per running event loop.
+
+    Some resources (notably `httpx.AsyncClient`) lazily bind internal
+    `asyncio.Lock`/`asyncio.Event` primitives to whichever event loop is
+    running the first time a pooled connection is genuinely contended for,
+    and can't be safely reused from a different loop afterwards. `AsyncBridge`
+    above runs a persistent event loop on its own thread, separate from
+    whatever loop the caller is on (e.g. FastAPI's), so a single process-wide
+    client eventually raises `RuntimeError: ... is bound to a different event
+    loop` once a connection created on one loop gets reused on the other.
+
+    Caching per-loop preserves connection pooling/keep-alive/DNS-caching
+    *within* a loop while keeping different loops fully isolated.
+    `WeakKeyDictionary` lets cached values for short-lived loops (e.g. a
+    `pytest-asyncio` per-test loop) get garbage collected instead of piling
+    up for the life of the process.
+
+    Each call to this function returns an independent cache, same as
+    `functools.lru_cache` -- wrapping the same factory twice gives you two
+    unrelated per-loop registries, not a shared one.
+    """
+    cached: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, T] = weakref.WeakKeyDictionary()
+
+    @functools.wraps(factory)
+    def get() -> T:
+        loop = asyncio.get_running_loop()
+        value = cached.get(loop)
+        if value is None:
+            value = factory()
+            cached[loop] = value
+        return value
+
+    return get

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode, urlsplit
 import httpx
 import web
 
-from openlibrary.utils.async_utils import async_bridge
+from openlibrary.utils.async_utils import async_bridge, cache_per_event_loop
 
 logger = logging.getLogger("openlibrary.logger")
 
@@ -60,7 +60,7 @@ class Solr:
         """
         self.base_url = base_url
         self.host = urlsplit(self.base_url)[1]
-        self.async_session = httpx.AsyncClient()
+        self.get_async_session = cache_per_event_loop(httpx.AsyncClient)
 
     @staticmethod
     def escape(query):
@@ -83,7 +83,7 @@ class Solr:
         """Get a specific item from solr"""
         logger.debug(f"solr /get: {key}, {fields}")
         resp = (
-            await self.async_session.get(
+            await self.get_async_session().get(
                 f"{self.base_url}/get",
                 # It's unclear how field=None is getting in here; a better fix would be at the source.
                 params={
@@ -109,7 +109,7 @@ class Solr:
             return []
         logger.debug(f"solr /get: {ids}, {fields}")
         resp = (
-            await self.async_session.post(
+            await self.get_async_session().post(
                 f"{self.base_url}/get",
                 data={
                     "ids": ",".join(ids),
@@ -127,7 +127,7 @@ class Solr:
         _timeout: int | None = DEFAULT_SOLR_TIMEOUT_SECONDS,
     ):
         resp = (
-            await self.async_session.post(
+            await self.get_async_session().post(
                 f"{self.base_url}/update?update.partial.requireInPlace=true&commit={commit}",
                 json=request,
                 timeout=_timeout,
@@ -231,11 +231,11 @@ class Solr:
             sep = "&" if "?" in url else "?"
             url = url + sep + payload
             logger.debug("solr request: %s", url)
-            return await self.async_session.get(url, timeout=_timeout)
+            return await self.get_async_session().get(url, timeout=_timeout)
         else:
             logger.debug("solr request: %s ...", url)
             headers = {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
-            return await self.async_session.post(url, data=payload, headers=headers, timeout=_timeout)
+            return await self.get_async_session().post(url, data=payload, headers=headers, timeout=_timeout)
 
     def _parse_solr_result(self, result, doc_wrapper, facet_wrapper):
         response = result["response"]

--- a/scripts/check_no_bare_httpx_async_client.py
+++ b/scripts/check_no_bare_httpx_async_client.py
@@ -17,22 +17,24 @@ PATTERN = re.compile(r"=\s*httpx\.AsyncClient\(")
 
 
 def main(files: list[str]) -> int:
-    hits: list[str] = []
+    found = False
     for filename in files:
         with open(filename, encoding="utf-8") as f:
-            hits += (f"{filename}:{i}:{line.rstrip()}" for i, line in enumerate(f, 1) if PATTERN.search(line))
+            for i, line in enumerate(f, 1):
+                if PATTERN.search(line):
+                    found = True
+                    sys.stderr.write(f"{filename}:{i}:{line.rstrip()}\n")
 
-    if not hits:
-        return 0
+    if found:
+        sys.stderr.write(
+            "\nhttpx.AsyncClient() assigned directly is unsafe to share across "
+            "this codebase's event loops (AsyncBridge's background loop vs. a "
+            "caller's own loop). Wrap it with cache_per_event_loop instead, e.g.:\n"
+            "    get_async_session = cache_per_event_loop(httpx.AsyncClient)\n"
+        )
+        return 1
 
-    sys.stderr.write("\n".join(hits))
-    sys.stderr.write(
-        "\nhttpx.AsyncClient() assigned directly is unsafe to share across "
-        "this codebase's event loops (AsyncBridge's background loop vs. a "
-        "caller's own loop). Wrap it with cache_per_event_loop instead, e.g.:\n"
-        "    get_async_session = cache_per_event_loop(httpx.AsyncClient)\n"
-    )
-    return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/check_no_bare_httpx_async_client.py
+++ b/scripts/check_no_bare_httpx_async_client.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Pre-commit hook: fail if any given file assigns httpx.AsyncClient() directly.
+
+A directly-assigned httpx.AsyncClient() (as opposed to a scoped
+`async with httpx.AsyncClient() as client:`, which closes before it could
+ever be reused from another loop) is unsafe to share across this codebase's
+event loops -- AsyncBridge's persistent background-thread loop vs. a caller's
+own loop (e.g. FastAPI's). See cache_per_event_loop in
+openlibrary/utils/async_utils.py for why, and wrap the constructor with it
+instead.
+"""
+
+import re
+import sys
+
+PATTERN = re.compile(r"=\s*httpx\.AsyncClient\(")
+
+
+def main(files: list[str]) -> int:
+    hits: list[str] = []
+    for filename in files:
+        with open(filename, encoding="utf-8") as f:
+            hits += (f"{filename}:{i}:{line.rstrip()}" for i, line in enumerate(f, 1) if PATTERN.search(line))
+
+    if not hits:
+        return 0
+
+    sys.stderr.write("\n".join(hits))
+    sys.stderr.write(
+        "\nhttpx.AsyncClient() assigned directly is unsafe to share across "
+        "this codebase's event loops (AsyncBridge's background loop vs. a "
+        "caller's own loop). Wrap it with cache_per_event_loop instead, e.g.:\n"
+        "    get_async_session = cache_per_event_loop(httpx.AsyncClient)\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
We regularly get production `RuntimeError: <asyncio.locks.Event object at 0x7f5816726ed0 [unset]> is bound to a different event loop` errors while we do our migration to fastapi when the syncified version of an async method is called from fastapi. These should be removed/remedied, but it's not always possible to migrate everything in one fell swoop. This fix ensures that httpx.AsyncClient never crosses event loops so that these errors never happen, and we can migrate without having sporadic surprise errors on production.

A single shared httpx.AsyncClient used from both AsyncBridge's persistent background-thread event loop and a caller's own loop (e.g. FastAPI's) occasionally raised "RuntimeError: ... is bound to a different event loop", since httpx/httpcore/anyio lazily bind pooled-connection internals to whichever loop first contends for them. cache_per_event_loop() keeps one client per loop instead, preserving connection pooling/keep-alive/DNS caching within a loop while keeping different loops isolated.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
