### PR TITLE
pre-commit: Add zizmor security linter for GitHub Actions

### DIFF
--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -24,7 +24,7 @@ jobs:
       github.event.pull_request.user.login != 'openlibrary-bot'
     steps:
       - name: Request openlibrary-bot as reviewer if not already present
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/code_review_action.yml
+++ b/.github/workflows/code_review_action.yml
@@ -61,7 +61,7 @@ jobs:
       )
     steps:
       - name: Acknowledge trigger (placeholder -- no review logic yet)
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/docs_gh_pages.yml
+++ b/.github/workflows/docs_gh_pages.yml
@@ -30,23 +30,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: internetarchive/openlibrary.wiki
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: npm
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Install dependencies
         run: npm ci
       - name: Build with VitePress
         run: npm run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: .vitepress/dist
 
@@ -61,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/.github/workflows/issue_enrichment.yml
+++ b/.github/workflows/issue_enrichment.yml
@@ -32,7 +32,9 @@ jobs:
        github.event.issue.user.login != 'openlibrary-bot' &&
        !contains(github.event.issue.labels.*.name, 'agentic-workflows'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Enrich issue
         # Pinned deliberately -- do not restore the floating `@v1`.

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -23,12 +23,14 @@ jobs:
   javascript_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           # Should match what's in our Dockerfile
           node-version: '24' # Also update the `key` in the `with` map, below
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: npm-cache
         with:
           # Caching node_modules isn't recommended because it can break across
@@ -48,6 +50,6 @@ jobs:
       - run: npx concurrently --group 'make js' 'make css' 'make components'
       - run: npm run test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -43,8 +43,10 @@ jobs:
     outputs:
       exit_code: ${{ steps.run_bot.outputs.exit_code }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: pip install requests
@@ -89,7 +91,7 @@ jobs:
     if: ${{ needs.new_comment_digest.outputs.exit_code == 30 }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: pip install slack-sdk

--- a/.github/workflows/new_pr_labeler.yml
+++ b/.github/workflows/new_pr_labeler.yml
@@ -1,5 +1,5 @@
 name: new_pr_labeler
-on:
+on:  # zizmor: ignore[dangerous-triggers] -- FIX ME!
   pull_request_target:
     types:
       - opened
@@ -18,19 +18,22 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: cache-octokit
         with:
           path: 'node_modules'
           # Cache key shared across workflows
           key: ${{ runner.os }}-node${{ env.NODE_VERSION}}-octokit-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache-octokit.outputs.cache-hit != 'true'
-        run: npm install @octokit/action
-      - run: node scripts/gh_scripts/new_pr_labeler.mjs ${{ github.repository }} ${{ github.event.pull_request.user.login }} ${{ github.event.pull_request.number }} "$PR_BODY"
+        run: npm install @octokit/action  # zizmor: ignore[adhoc-packages]
+      - run: node scripts/gh_scripts/new_pr_labeler.mjs ${{ github.repository }} ${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN} ${{ github.event.pull_request.number }} "$PR_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -20,21 +20,22 @@ jobs:
       TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push amd64
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
@@ -50,21 +51,22 @@ jobs:
       TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
@@ -81,7 +83,7 @@ jobs:
 
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -89,12 +91,12 @@ jobs:
       - name: Combine the manifests of the amd and arm images in a manifest
         run: |
           # Pull out the digests
-          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ env.TAG_NAME }} | jq -r '.manifests[0].digest')
-          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ env.TAG_NAME }}-arm64 | jq -r '.manifests[0].digest')
+          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:${TAG_NAME} | jq -r '.manifests[0].digest')
+          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:${TAG_NAME}-arm64 | jq -r '.manifests[0].digest')
 
-          docker manifest create openlibrary/olbase:${{ env.TAG_NAME }} \
+          docker manifest create openlibrary/olbase:${TAG_NAME} \
             openlibrary/olbase@${AMD64_DIGEST} \
             openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest annotate openlibrary/olbase:${{ env.TAG_NAME }} openlibrary/olbase@${AMD64_DIGEST}
-          docker manifest annotate openlibrary/olbase:${{ env.TAG_NAME }} openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest push openlibrary/olbase:${{ env.TAG_NAME }}
+          docker manifest annotate openlibrary/olbase:${TAG_NAME} openlibrary/olbase@${AMD64_DIGEST}
+          docker manifest annotate openlibrary/olbase:${TAG_NAME} openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest push openlibrary/olbase:${TAG_NAME}

--- a/.github/workflows/pm_on_call_notification.yml
+++ b/.github/workflows/pm_on_call_notification.yml
@@ -12,9 +12,11 @@ jobs:
     if: ${{ github.repository == 'internetarchive/openlibrary' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - id: build_message
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           result-encoding: string
           script: |
@@ -38,7 +40,7 @@ jobs:
             }
             return '';
       - if: ${{ steps.build_message.outputs.result != '' }}
-        uses: slackapi/slack-github-action@v4.0.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/pm_stale_pr_messenger.yml
+++ b/.github/workflows/pm_stale_pr_messenger.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           only-pr-labels: "Needs: Submitter Input"
           days-before-issue-stale: -1 # disable issue stale

--- a/.github/workflows/pm_stale_ticket_labeler.yml
+++ b/.github/workflows/pm_stale_ticket_labeler.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           start-date: 2025-01-01
           exempt-issue-labels: 'no-automation,"Type: Epic"'

--- a/.github/workflows/pr_autoresponder.yml
+++ b/.github/workflows/pr_autoresponder.yml
@@ -33,7 +33,9 @@ jobs:
        github.event.pull_request.user.login != 'openlibrary-bot' &&
        !github.event.pull_request.draft)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: First-touch PR response
         # Pinned deliberately -- do not restore the floating `@v1`. Same upstream

--- a/.github/workflows/pr_changes_requested.yml
+++ b/.github/workflows/pr_changes_requested.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: 'Add "Needs: Submitter Input" label'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/pr_update_labeler.yml
+++ b/.github/workflows/pr_update_labeler.yml
@@ -1,5 +1,5 @@
 name: pr_update_labeler
-on:
+on:  # zizmor: ignore[dangerous-triggers] -- FIX ME!
   pull_request_target:
     types:
       - synchronize
@@ -13,7 +13,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/labeler@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           sync-labels: true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,13 +19,14 @@ jobs:
   python_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: pyproject.toml
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
@@ -35,7 +36,7 @@ jobs:
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Install dependencies
         env:
           UV_SYSTEM_PYTHON: 1
@@ -59,6 +60,6 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin master
           make test-py
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/weekly_status_report.yml
+++ b/.github/workflows/weekly_status_report.yml
@@ -15,17 +15,19 @@ jobs:
     if: github.repository_owner == 'internetarchive'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: cache-octokit
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node${{ env.NODE_VERSION}}-octokit-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache-octokit.outputs.cache-hit != 'true'
-        run: npm install @octokit/action
+        run: npm install @octokit/action  # zizmor: ignore[adhoc-packages]
       - run: node scripts/gh_scripts/weekly_status_report.mjs ${{ env.TEAM_ABC_CONFIG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  excessive-permissions:
+    disable: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,3 +188,8 @@ repos:
         # command which sqlfluff cannot parse.
         # See: https://github.com/internetarchive/openlibrary/issues/12245
         exclude: ^(scripts/dev-instance/patron_data\.sql|scripts/solr_builder/sql/import-partial\.sql)$
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

pre-commit: Add zizmor security linter for GitHub Actions
* https://docs.zizmor.sh

This PR fixes numerous CI security issues but marks others with 5 linter directives (see: `git grep zizmor`) and disables all [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions) (see: `cat .github/zizmor.yml`).  The codebase will be even safer when all of these zizmor violations are fixed, but this pull request moves things forward and puts guardrails in place.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Zizmor tests run in pre-commit.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
