### PR TITLE
feat: add ITAN Global Publishing catalog import script

### DIFF
--- a/scripts/import_itan.py
+++ b/scripts/import_itan.py
@@ -94,10 +94,11 @@ def map_data(record: dict[str, Any]) -> dict[str, Any]:
     if subtitle := normalize_whitespace(record.get("subtitle", "")):
         import_record["subtitle"] = subtitle
 
-    if subjects := [normalize_whitespace(subject) for subject in record.get("subjects", [])]:
-        # ITAN repeats subjects with inconsistent spacing; dedupe while keeping order.
-        import_record["subjects"] = list(dict.fromkeys(subject for subject in subjects if subject))
-
+    subjects = [normalize_whitespace(subject) for subject in record.get("subjects", [])]
+    # ITAN repeats subjects with inconsistent spacing; dedupe while keeping order.
+    subjects = list(dict.fromkeys(subject for subject in subjects if subject))
+    if subjects:
+        import_record["subjects"] = subjects
     if contributions := [strip_author_role(name) for name in record.get("contributions", [])]:
         import_record["contributions"] = contributions
 

--- a/scripts/import_itan.py
+++ b/scripts/import_itan.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""Imports the ITAN Global Publishing catalog into Open Library.
+
+ITAN supplies their catalog as a JSONL dump, so unlike most providers there is
+nothing to scrape: each line is already close to our import schema and only
+needs cleaning up and remapping.
+"""
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from openlibrary.config import load_config
+from openlibrary.core.imports import Batch
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
+# ITAN packs a marketing blurb, an availability/price note, and an edition
+# statement into `notes`, separated by pipes, e.g.
+#   "<blurb> | Available on Itan Technologies. Ebook: N6,800. | Edition: 0"
+NOTES_SEPARATOR = "|"
+EDITION_RE = re.compile(r"^Edition:\s*(.*)$", re.IGNORECASE)
+AVAILABILITY_RE = re.compile(r"^Available on\b", re.IGNORECASE)
+# ITAN uses "0" as a placeholder for books with no distinct edition statement.
+# Other values are meaningful: "1", "2" and "3" appear alongside spelled-out
+# forms like "Second" and "Revised Edition".
+PLACEHOLDER_EDITIONS = {"0", "00"}
+ORDINALS = {
+    "1": "First",
+    "01": "First",
+    "1st": "First",
+    "first edition": "First",
+    "2": "Second",
+    "second edition": "Second",
+    "3": "Third",
+    "third edition": "Third",
+}
+
+
+def normalize_whitespace(value: str) -> str:
+    """Collapses runs of whitespace and strips the result.
+
+    ITAN's data has doubled inner spaces and trailing spaces in author names
+    and subjects, e.g. "Obinna Godswill  Chinegwu ".
+    """
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def strip_author_role(name: str) -> str:
+    """Strips a trailing role annotation, e.g. "Jane Doe (Illustrator)" -> "Jane Doe"."""
+    return normalize_whitespace(re.sub(r"\s*\([^)]*\)\s*$", "", name))
+
+
+def parse_notes(notes: str) -> tuple[str, str | None]:
+    """Splits ITAN's `notes` into a description and an edition name.
+
+    Returns the blurb and the edition statement, dropping ITAN's availability
+    and pricing segment. The edition is None when absent or a placeholder.
+    """
+    segments = [normalize_whitespace(segment) for segment in notes.split(NOTES_SEPARATOR)]
+    description = segments[0]
+
+    edition_name = None
+    for segment in segments[1:]:
+        if AVAILABILITY_RE.match(segment):
+            # Pricing is specific to ITAN's store and not worth importing.
+            continue
+        if match := EDITION_RE.match(segment):
+            edition = match.group(1).strip()
+            if edition.lower() not in PLACEHOLDER_EDITIONS:
+                # ITAN writes editions as bare numbers as often as words;
+                # normalize so we do not store an edition_name of just "2".
+                edition_name = ORDINALS.get(edition.lower(), edition)
+
+    return description, edition_name
+
+
+def map_data(record: dict[str, Any]) -> dict[str, Any]:
+    """Maps a raw ITAN catalog record to an Open Library import object."""
+    itan_id = record["identifiers"]["itan_technologies"][0]
+    description, edition_name = parse_notes(record.get("notes", ""))
+
+    import_record: dict[str, Any] = {
+        "title": normalize_whitespace(record["title"]),
+        "source_records": [f"itan_technologies:{itan_id}"],
+        "publishers": [normalize_whitespace(publisher) for publisher in record["publishers"]],
+        "publish_date": record["publish_date"],
+        "authors": [{"name": normalize_whitespace(author["name"])} for author in record["authors"]],
+        "languages": record["languages"],
+        "identifiers": {"itan_technologies": [itan_id]},
+    }
+
+    if subtitle := normalize_whitespace(record.get("subtitle", "")):
+        import_record["subtitle"] = subtitle
+
+    if subjects := [normalize_whitespace(subject) for subject in record.get("subjects", [])]:
+        # ITAN repeats subjects with inconsistent spacing; dedupe while keeping order.
+        import_record["subjects"] = list(dict.fromkeys(subject for subject in subjects if subject))
+
+    if contributions := [strip_author_role(name) for name in record.get("contributions", [])]:
+        import_record["contributions"] = contributions
+
+    if description:
+        import_record["description"] = description
+
+    if edition_name:
+        import_record["edition_name"] = edition_name
+
+    # ITAN sends 0 for books whose page count is unknown.
+    if number_of_pages := record.get("number_of_pages"):
+        import_record["number_of_pages"] = number_of_pages
+
+    # Book pages use a full slug that cannot be derived from the ITAN ID, so we
+    # keep the URL ITAN supplies rather than building one from the identifier.
+    if url := record.get("url"):
+        import_record["links"] = [{"url": url, "title": "Read on ITAN"}]
+
+    # `isbn_13` in ITAN's dump is a placeholder ("0" or "978"), never a real
+    # ISBN, so it is deliberately dropped.
+
+    return import_record
+
+
+def create_batch(records: list[dict[str, Any]]) -> None:
+    """Creates the ITAN batch import job.
+
+    Attempts to find an existing ITAN import batch. If nothing is found, a new
+    batch is created. All of the given import records are added to the batch
+    job as JSON strings.
+    """
+    now = time.gmtime(time.time())
+    batch_name = f"itan-{now.tm_year}{now.tm_mon:02}"
+    batch = Batch.find(batch_name) or Batch.new(batch_name)
+    batch.add_items([{"ia_id": r["source_records"][0], "data": r} for r in records])
+
+
+def import_job(
+    ol_config: str,
+    catalog: str,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> None:
+    """
+    :param str ol_config: Path to openlibrary.yml file
+    :param str catalog: Path to ITAN's itan_catalog.jsonl dump
+    :param bool dry_run: If true, only print out records to import
+    :param int limit: If set, only process the first N records (useful for testing)
+    """
+    load_config(ol_config)
+
+    lines = Path(catalog).read_text(encoding="utf-8").splitlines()
+    records = [map_data(json.loads(line)) for line in lines if line.strip()]
+    if limit:
+        records = records[:limit]
+
+    if not dry_run:
+        create_batch(records)
+        print(f"{len(records)} entries added to the batch import job.")
+    else:
+        for record in records:
+            print(json.dumps(record, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    print("Start: ITAN import job")
+    FnToCLI(import_job).run()
+    print("End: ITAN import job")

--- a/scripts/tests/test_import_itan.py
+++ b/scripts/tests/test_import_itan.py
@@ -1,0 +1,114 @@
+from scripts.import_itan import map_data, normalize_whitespace, parse_notes, strip_author_role
+
+SAMPLE_1 = {
+    "title": "Shadows Of The Continent",
+    "authors": [{"name": "Tolulope Taiwo"}],
+    "publishers": ["Itan Technologies"],
+    "publish_date": "2026",
+    "languages": ["eng"],
+    "subjects": ["African Literature & Fiction", " Contemporary Fiction", "romance"],
+    "source_records": ["itan_technologies:BOO1109"],
+    "identifiers": {"itan_technologies": ["BOO1109"]},
+    "ebook_access": "borrowable",
+    "url": "https://itan.app/bookstore/african-literature-fiction-shadows-of-the-continent-urunna-ikemefuna-boo1109",
+    "subtitle": "A Pan-African Romance Suspense Novel",
+    "number_of_pages": 189,
+    "notes": "Zara Osei never meant to uncover a murder. | Available on Itan Technologies. Ebook: ₦6,800. | Edition: 0",
+    "isbn_13": ["0"],
+}
+
+
+def test_normalize_whitespace():
+    assert normalize_whitespace("Obinna Godswill  Chinegwu ") == "Obinna Godswill Chinegwu"
+    assert normalize_whitespace(" Contemporary Fiction") == "Contemporary Fiction"
+    assert normalize_whitespace("Already Clean") == "Already Clean"
+
+
+def test_strip_author_role():
+    assert strip_author_role("Joshua Okoromodeke (Illustrator)") == "Joshua Okoromodeke"
+    assert strip_author_role("Okeke  Clement (Translator)") == "Okeke Clement"
+    assert strip_author_role("Jane Doe") == "Jane Doe"
+
+
+def test_parse_notes_drops_pricing_and_placeholder_edition():
+    description, edition_name = parse_notes("A gripping novel. | Available on Itan Technologies. Ebook: ₦6,800. | Edition: 0")
+    assert description == "A gripping novel."
+    assert edition_name is None
+
+
+def test_parse_notes_keeps_real_edition():
+    assert parse_notes("A blurb. | Available on Itan Technologies. Ebook: ₦4,900. | Edition: Second")[1] == "Second"
+    assert parse_notes("A blurb. | Available on Itan Technologies. Ebook: ₦4,900. | Edition: Revised Edition")[1] == "Revised Edition"
+
+
+def test_parse_notes_normalizes_numeric_editions():
+    assert parse_notes("A blurb. | Edition: 1")[1] == "First"
+    assert parse_notes("A blurb. | Edition: 01")[1] == "First"
+    assert parse_notes("A blurb. | Edition: 1st")[1] == "First"
+    assert parse_notes("A blurb. | Edition: 2")[1] == "Second"
+
+
+def test_parse_notes_without_edition_segment():
+    description, edition_name = parse_notes("Just a blurb. | Available on Itan Technologies. Ebook: ₦3,500.")
+    assert description == "Just a blurb."
+    assert edition_name is None
+
+
+def test_map_data():
+    assert map_data(SAMPLE_1) == {
+        "title": "Shadows Of The Continent",
+        "source_records": ["itan_technologies:BOO1109"],
+        "publishers": ["Itan Technologies"],
+        "publish_date": "2026",
+        "authors": [{"name": "Tolulope Taiwo"}],
+        "languages": ["eng"],
+        "identifiers": {"itan_technologies": ["BOO1109"]},
+        "subtitle": "A Pan-African Romance Suspense Novel",
+        "subjects": ["African Literature & Fiction", "Contemporary Fiction", "romance"],
+        "description": "Zara Osei never meant to uncover a murder.",
+        "number_of_pages": 189,
+        "links": [
+            {
+                "url": "https://itan.app/bookstore/african-literature-fiction-shadows-of-the-continent-urunna-ikemefuna-boo1109",
+                "title": "Read on ITAN",
+            }
+        ],
+    }
+
+
+def test_map_data_drops_placeholder_isbn_and_ebook_access():
+    record = map_data(SAMPLE_1)
+    assert "isbn_13" not in record
+    assert "isbn_13" not in record["identifiers"]
+    assert "ebook_access" not in record
+    assert "url" not in record
+
+
+def test_map_data_omits_optional_fields_when_absent():
+    record = map_data({**SAMPLE_1, "subtitle": "", "number_of_pages": 0, "subjects": [], "url": None})
+    assert "subtitle" not in record
+    assert "number_of_pages" not in record
+    assert "subjects" not in record
+    assert "links" not in record
+
+
+def test_map_data_normalizes_authors_and_contributions():
+    record = map_data(
+        {
+            **SAMPLE_1,
+            "authors": [{"name": "Obinna Godswill  Chinegwu "}],
+            "contributions": ["Joshua Okoromodeke (Illustrator)"],
+        }
+    )
+    assert record["authors"] == [{"name": "Obinna Godswill Chinegwu"}]
+    assert record["contributions"] == ["Joshua Okoromodeke"]
+
+
+def test_map_data_dedupes_subjects():
+    record = map_data({**SAMPLE_1, "subjects": ["romance", " romance ", "fiction"]})
+    assert record["subjects"] == ["romance", "fiction"]
+
+
+def test_parse_notes_normalizes_spelled_out_editions():
+    assert parse_notes("A blurb. | Edition: First Edition")[1] == "First"
+    assert parse_notes("A blurb. | Edition: First")[1] == "First"


### PR DESCRIPTION
ITAN supplies their catalog as a JSONL dump rather than a site to crawl, so this is a mapping job: scripts/import_itan.py reads the dump, reshapes each record for the import schema, and submits the result as a batch. Structurally it follows scripts/import_bookdash.py minus the scraping.

Four things in the dump need handling, all verified against the 102-record copy ITAN sent on #12091:

- isbn_13 is never a real ISBN. It carries "0" (43 records) or "978" (12), so the field is dropped rather than importing placeholder identifiers.
- notes packs three things into one pipe-delimited string: a blurb, an availability line with the ebook's naira price, and an edition statement. The blurb becomes description; the pricing is dropped as store-specific; the edition becomes edition_name unless it is ITAN's "0" placeholder. Editions are written as bare numbers as often as words, so "2" normalizes to "Second" rather than storing a digit.
- url and ebook_access are not import-schema fields. Book pages use a full slug that cannot be derived from the ITAN ID, so the supplied url is kept as a link rather than rebuilt from the identifier; ebook_access is not settable on import and is dropped.
- Author names, subjects and publishers carry doubled and trailing spaces ("Obinna Godswill  Chinegwu "), so all are whitespace-normalized and subjects deduped.

All 102 mapped records validate against openlibrary/schemata/import.schema.json with no errors.

<!-- What issue does this PR close? -->
Closes #13409

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
ITAN sent their catalog as a JSONL dump on #12091, so unlike most providers there is nothing to scrape. This adds \`scripts/import_itan.py\`, which maps the dump to our import schema and submits it as a batch, following \`scripts/import_bookdash.py\` minus the scraping.


### Technical
<!-- What should be noted about the implementation? -->
Handled in the mapping, all verified against the 102-record dump:

- **\`isbn_13\` is never a real ISBN** (\`0\` on 43 records, \`978\` on 12), so the field is dropped rather than importing placeholders.
- **\`notes\` packs a blurb, a naira price line, and an edition statement into one pipe-delimited string.** Blurb becomes \`description\`, pricing is dropped as store-specific, and the edition becomes \`edition_name\` unless it is ITAN's \`0\` placeholder. Bare numbers normalize (\`2\` to \`Second\`) so we do not store a digit.
- **\`url\` and \`ebook_access\` are not import-schema fields.** Book pages use a full slug that cannot be derived from the ITAN ID, so the supplied \`url\` is kept in \`links\`; \`ebook_access\` is not settable on import.
- **Whitespace** in author names, subjects and publishers is normalized, subjects deduped.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- 12 unit tests, one per data issue above
- All 102 mapped records validate against \`import.schema.json\` with zero errors

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

## Notes
Two follow-ups, both out of scope here: the \`itan_technologies\` identifier's \`url\` template from #12947 builds a bare-ID link that does not resolve, and covers will reuse whatever \`cover_url\` path lands for Bookdash."

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
