### PR TITLE
Remove unused template globals from helpers.py __all__ (#13422)

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -42,10 +42,7 @@ __all__ = [
     "format_decimal",
     "parse_datetime",  # function imported from elsewhere
     "percentage",
-    "private_collection_in",
-    "private_collections",
     "safeint",  # function imported from elsewhere
-    "safesort",
     "sanitize",
     "sprintf",
     "texsafe",


### PR DESCRIPTION
Part of #13422 — the **`openlibrary/core/helpers.py` `__all__`** section.

## What

`helpers.py` exposes helpers as Templetor template globals via its `__all__` list (consumed at `openlibrary/core/helpers.py:367`, `return web.storage((k, _globals[k]) for k in __all__)`). Three of those are never used by any template:

- `safesort`
- `private_collection_in`
- `private_collections`

This removes those three entries from `__all__`. The **function definitions stay** in `helpers.py`, and only their template-global registration is dropped.

## Why it's safe

- **Zero template/JS usage** — grepped `.py`, `.html`, `.js`, and `.md` across the repo; none of the three is referenced as a template global anywhere.
- **Internal callers are unaffected** — they use direct imports / module-attribute access, not the template-global path:
  - `safesort` → `openlibrary/core/models.py` (`from openlibrary.core.helpers import safesort`), `openlibrary/core/lists/model.py` (`h.safesort`), `openlibrary/tests/core/test_helpers.py` (`h.safesort`)
  - `private_collection_in` → `openlibrary/core/models.py` (direct import)
  - `private_collections` → called only within `helpers.py` by `private_collection_in()`
- **No `import *`** — there is no `from openlibrary.core.helpers import *` in the codebase, so `__all__` feeds only the template-global builder; removing entries can't break a star-import.

## Verification

- [x] Step 1 (grep `.py`/`.html`/`.js`) — done, zero references outside the registration (see above).
- [ ] Steps 2–3 (docker smoke test + `make test-py-uv`) — I don't have the full Docker environment locally (the import chain requires `infogami`), so I couldn't run these here. Flagging for a reviewer to confirm in CI.
- Per the issue's note: production also renders Infogami templates stored in the DB, which can't be grepped locally — worth watching error tracking for template-lookup errors mentioning these names after deploy.

Scoped to just this one section per the "one PR per section" guidance.
