### PR TITLE
Remove unused @public template-global registration (url_quote, get_borrow_status) (#13422)

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -386,7 +386,6 @@ class ia_loan_status(delegate.page):
         return delegate.RawText(json.dumps(d), content_type="application/json")
 
 
-@public
 def get_borrow_status(itemid):
     """Returns borrow status for this IA identifier."""
     loan = lending.get_loan(itemid)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -601,7 +601,6 @@ def add_metatag(tag: str = "meta", **attrs) -> None:
     context.metatags.append(Metatag(tag, **attrs))
 
 
-@public
 def url_quote(text: str | bytes) -> str:
     if isinstance(text, str):
         text = text.encode("utf8")


### PR DESCRIPTION
Part of #13422 — the **"Remove the `@public` decorator only (keep the function)"** section.

## What

`url_quote` (`openlibrary/plugins/upstream/utils.py`) and `get_borrow_status` (`openlibrary/plugins/upstream/borrow.py`) are exposed as Templetor template globals via the infogami `@public` decorator, but no template uses them. This removes the `@public` decorator from both. The **functions stay** — only their template-global registration is dropped.

## Why it's safe

- **Zero template/JS usage** — grepped `.py`, `.html`, `.js`, and `.md` across the repo; neither name is referenced as a template global anywhere.
- **Only direct callers, unaffected by removing `@public`:**
  - `url_quote` → called internally in `utils.py` (`set_share_links` calls `url_quote(...)`), and tested via `utils.url_quote(...)` in `openlibrary/plugins/upstream/tests/test_utils.py`.
  - `get_borrow_status` → called internally in `borrow.py` (`ia_loan_status`).
- **No orphaned import** — both files keep other `@public` decorators (utils.py has 33, borrow.py has 2 more), so the `public` import stays used; no new lint error (the pre-existing `I001` import-sort notices in these files are untouched by this change).

## Verification

- [x] Step 1 (grep `.py`/`.html`/`.js`) — done, zero references outside the registration.
- [ ] Steps 2–3 (docker smoke test + `make test-py-uv`) — I don't have the full Docker environment locally (the import chain needs `infogami`), so I couldn't run these here. Flagging for a reviewer to confirm in CI.
- Per the issue's note: production also renders Infogami templates stored in the DB, which can't be grepped locally — worth watching error tracking for template-lookup errors mentioning these names after deploy.

Scoped to just this one section per the "one PR per section" guidance. (My other section — `helpers.py __all__` — is #13426.)
