### PR TITLE
feat: add audiences field to /type/work schema

### DIFF
--- a/openlibrary/plugins/openlibrary/types/work.type
+++ b/openlibrary/plugins/openlibrary/types/work.type
@@ -236,6 +236,16 @@
                 "key": "/type/property"
             },
             "name": "subgenres"
+        },
+        {
+            "expected_type": {
+                "key": "/type/tag"
+            },
+            "unique": false,
+            "type": {
+                "key": "/type/property"
+            },
+            "name": "audiences"
         }
     ],
     "revision": 14

--- a/openlibrary/schemata/work.schema.json
+++ b/openlibrary/schemata/work.schema.json
@@ -40,6 +40,7 @@
     "subjects":            { "$ref": "shared_definitions.json#/string_array" },
     "genres":              { "$ref": "shared_definitions.json#/string_array" },
     "subgenres":           { "$ref": "shared_definitions.json#/string_array" },
+    "audiences":           { "$ref": "shared_definitions.json#/string_array" },
 
     "first_publish_date": { "type": "string" },
 


### PR DESCRIPTION
Add `audiences` field to the Work type definition (`work.type`) and JSON schema (`work.schema.json`), so that audience tags can be stored on Work records.

This mirrors the pattern used to add `genres` and `subgenres` in PR #13151, and is the first step of Stage 3 (Schema & Work Processing) for the audience tag type.

## What this PR does
- `openlibrary/schemata/work.schema.json` - adds `"audiences": { "$ref": "shared_definitions.json#/string_array" }` alongside the existing `genres` and `subgenres` entries.
- `openlibrary/plugins/openlibrary/types/work.type` - adds an `audiences` property block with `"expected_type": "/type/tag"` and `"unique": false`, following the exact same structure as `genres` and `subgenres`.

## References
- Template PR: #13151 (genres and subgenres by @Chisomnwa )
- Parent tracking issue: Open-Book-Genome-Project/tags#52
- Task issue: Open-Book-Genome-Project/tags#53

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
