### PR TITLE
Normalize frozen GitHub Actions version skew (follow-up to #13411)

### DIFF
--- a/.github/workflows/issue_enrichment.yml
+++ b/.github/workflows/issue_enrichment.yml
@@ -32,7 +32,7 @@ jobs:
        github.event.issue.user.login != 'openlibrary-bot' &&
        !contains(github.event.issue.labels.*.name, 'agentic-workflows'))
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pm_on_call_notification.yml
+++ b/.github/workflows/pm_on_call_notification.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - id: build_message
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/pr_autoresponder.yml
+++ b/.github/workflows/pr_autoresponder.yml
@@ -33,7 +33,7 @@ jobs:
        github.event.pull_request.user.login != 'openlibrary-bot' &&
        !github.event.pull_request.draft)
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Closes #13436

Consolidates pinned SHA versions introduced by #13411 to a single version per action:

- `actions/checkout`: `v4.4.0` → `v7.0.1` (`3d3c42e...# v7.0.1`) in `issue_enrichment.yml` and `pr_autoresponder.yml` (2 lines)
- `actions/github-script`: `v7.1.0` → `v9.0.0` (`3a2844b...# v9.0.0`) in `pm_on_call_notification.yml` (1 line)

After this change all 13 `checkout` pins are `v7.0.1` and all 4 `github-script` pins are `v9.0.0`. The deliberately frozen `anthropics/claude-code-action` pin (with its extensive comment about upstream #1547) is left untouched per the issue scope.
