### PR TITLE
Renovate: automate GitHub Actions SHA pin updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "helpers:githubDigestChangelogs"
   ],
   "minimumReleaseAge": "7 days",
   "schedule": ["before 9am on Monday"],


### PR DESCRIPTION
Fixes #13433

Adds the two digest helpers from the issue to the existing `renovate.json` so Renovate bumps each action's SHA and its `# vX.Y.Z` comment together (workflows were already pinned in this format by #13411, so no migration needed). The Renovate app is already installed on the repo.

Docs:
- [helpers:pinGitHubActionDigests](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests)
- [helpers:githubDigestChangelogs](https://docs.renovatebot.com/presets-helpers/#helpersgithubdigestchangelogs)
- [github-actions manager: digest pinning](https://docs.renovatebot.com/modules/manager/github-actions/)