### PR TITLE
Report graphite stats for every fail2ban jail, not just nginx-429

### DIFF
--- a/scripts/monitoring/fail2ban_monitor.py
+++ b/scripts/monitoring/fail2ban_monitor.py
@@ -1,6 +1,20 @@
 from scripts.monitoring.utils import bash_run
 
 
+def get_jail_list() -> list[str]:
+    """
+    Returns the list of currently configured fail2ban jails.
+    """
+    result = bash_run(
+        "fail2ban-client status | grep 'Jail list'",
+        capture_output=True,
+    )
+    jails_str = result.stdout.strip().split(":", 1)[-1].strip()
+    if not jails_str:
+        return []
+    return [jail.strip() for jail in jails_str.split(",")]
+
+
 def get_fail2ban_counts(jail: str) -> tuple[int, int]:
     """
     Returns (currently_failed, currently_banned) counts for the given fail2ban jail.

--- a/scripts/monitoring/monitor.py
+++ b/scripts/monitoring/monitor.py
@@ -5,16 +5,16 @@ Defines various monitoring jobs, that check the health of the system.
 
 import asyncio
 import os
-import re
 import time
 
 import httpx
 
-from scripts.monitoring.fail2ban_monitor import get_fail2ban_counts
+from scripts.monitoring.fail2ban_monitor import get_fail2ban_counts, get_jail_list
 from scripts.monitoring.solr_updater_monitor import get_solr_updater_lag_event
 from scripts.monitoring.utils import (
     GraphiteEvent,
     bash_run,
+    graphite_safe,
     limit_server,
 )
 from scripts.utils.scheduler import OlAsyncIOScheduler
@@ -99,17 +99,6 @@ async def monitor_solr():
 @limit_server(["ol-www0"], scheduler)
 @scheduler.scheduled_job("interval", seconds=60)
 async def monitor_partner_useragents():
-
-    def graphite_safe(s: str) -> str:
-        """Normalize a string for safe use as a Graphite metric name."""
-        # Replace dots and spaces with underscores
-        s = s.replace(".", "_").replace(" ", "_")
-        # Remove or replace unsafe characters
-        s = re.sub(r"[^A-Za-z0-9_-]+", "_", s)
-        # Collapse multiple underscores
-        s = re.sub(r"_+", "_", s)
-        # Strip leading/trailing underscores or dots
-        return s.strip("._")
 
     def extract_agent_counts(ua_counts, allowed_names=None):
         agent_counts = {}
@@ -250,24 +239,27 @@ async def monitor_empty_homepage():
 @limit_server(["ol-www0"], scheduler)
 @scheduler.scheduled_job("interval", seconds=60)
 def monitor_fail2ban():
-    """Logs fail2ban nginx-429 jail stats (currently failed and banned counts)."""
-    failed, banned = get_fail2ban_counts("nginx-429")
+    """Logs fail2ban jail stats (currently failed and banned counts) for every configured jail."""
     ts = int(time.time())
-    GraphiteEvent.submit_many(
-        [
+    events = []
+    for jail in get_jail_list():
+        failed, banned = get_fail2ban_counts(jail)
+        jail_bucket = graphite_safe(jail)
+        events.append(
             GraphiteEvent(
-                path="stats.ol.fail2ban.nginx-429.failed",
+                path=f"stats.ol.fail2ban.{jail_bucket}.failed",
                 value=float(failed),
                 timestamp=ts,
-            ),
+            )
+        )
+        events.append(
             GraphiteEvent(
-                path="stats.ol.fail2ban.nginx-429.banned",
+                path=f"stats.ol.fail2ban.{jail_bucket}.banned",
                 value=float(banned),
                 timestamp=ts,
-            ),
-        ],
-        GRAPHITE_URL,
-    )
+            )
+        )
+    GraphiteEvent.submit_many(events, GRAPHITE_URL)
 
 
 @limit_server(["ol-home0"], scheduler)

--- a/scripts/monitoring/tests/test_fail2ban_monitor.py
+++ b/scripts/monitoring/tests/test_fail2ban_monitor.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from scripts.monitoring.fail2ban_monitor import get_fail2ban_counts
+from scripts.monitoring.fail2ban_monitor import get_fail2ban_counts, get_jail_list
 
 FAKE_FAIL2BAN_OUTPUT = """
 Status for the jail: nginx-429
@@ -14,6 +14,13 @@ Status for the jail: nginx-429
    `- Banned IP list:   08.07.04.02 04.06.02.09
 """
 
+# `bash_run` greps for the "Jail list" line, so only that line survives in
+# `stdout`. Sampled from `fail2ban-client status` on prod:
+#   Status
+#   |- Number of jail:      3
+#   `- Jail list:   modsecurity-worldcat, nginx-429, sshd
+FAKE_FAIL2BAN_STATUS_OUTPUT = "`- Jail list:\tmodsecurity-worldcat, nginx-429, sshd\n"
+
 
 def test_get_fail2ban_counts():
     mock_result = MagicMock()
@@ -24,3 +31,23 @@ def test_get_fail2ban_counts():
 
     assert failed == 193
     assert banned == 141
+
+
+def test_get_jail_list():
+    mock_result = MagicMock()
+    mock_result.stdout = FAKE_FAIL2BAN_STATUS_OUTPUT
+
+    with patch("scripts.monitoring.fail2ban_monitor.bash_run", return_value=mock_result):
+        jails = get_jail_list()
+
+    assert jails == ["modsecurity-worldcat", "nginx-429", "sshd"]
+
+
+def test_get_jail_list_empty():
+    mock_result = MagicMock()
+    mock_result.stdout = "`- Jail list:\t\n"
+
+    with patch("scripts.monitoring.fail2ban_monitor.bash_run", return_value=mock_result):
+        jails = get_jail_list()
+
+    assert jails == []

--- a/scripts/monitoring/tests/test_utils_py.py
+++ b/scripts/monitoring/tests/test_utils_py.py
@@ -1,7 +1,14 @@
 from unittest.mock import patch
 
-from scripts.monitoring.utils import bash_run, limit_server
+from scripts.monitoring.utils import bash_run, graphite_safe, limit_server
 from scripts.utils.scheduler import OlAsyncIOScheduler
+
+
+def test_graphite_safe():
+    assert graphite_safe("nginx-429") == "nginx-429"
+    assert graphite_safe("Bontent/1.0") == "Bontent_1_0"
+    assert graphite_safe("a..b  c") == "a_b_c"
+    assert graphite_safe(".leading.and.trailing.") == "leading_and_trailing"
 
 
 def test_bash_run():

--- a/scripts/monitoring/utils.py
+++ b/scripts/monitoring/utils.py
@@ -1,6 +1,7 @@
 import fnmatch
 import os
 import pickle
+import re
 import socket
 import struct
 import subprocess
@@ -10,6 +11,18 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+
+def graphite_safe(s: str) -> str:
+    """Normalize a string for safe use as a Graphite metric path segment."""
+    # Replace dots and spaces with underscores
+    s = s.replace(".", "_").replace(" ", "_")
+    # Remove or replace unsafe characters
+    s = re.sub(r"[^A-Za-z0-9_-]+", "_", s)
+    # Collapse multiple underscores
+    s = re.sub(r"_+", "_", s)
+    # Strip leading/trailing underscores or dots
+    return s.strip("._")
 
 
 @dataclass


### PR DESCRIPTION
We were previously recording only the nginx-429 jail.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
