### PR TITLE
Remove unused template globals

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -54,7 +54,7 @@ from openlibrary.core.lending import get_availability
 from openlibrary.core.models import Edition
 from openlibrary.plugins.openlibrary import processors
 from openlibrary.plugins.openlibrary.stats import increment_error_count
-from openlibrary.utils.isbn import canonical, isbn_10_to_isbn_13, isbn_13_to_isbn_10
+from openlibrary.utils.isbn import canonical, isbn_13_to_isbn_10
 from openlibrary.utils.sentry import get_sentry
 
 
@@ -1108,14 +1108,10 @@ def setup_template_globals():
             "next": next,
             "sorted": sorted,
             "zip": zip,
-            "tuple": tuple,
             "hash": hash,
             "urlquote": quote,
             "isbn_13_to_isbn_10": isbn_13_to_isbn_10,
-            "isbn_10_to_isbn_13": isbn_10_to_isbn_13,
-            "NEWLINE": "\n",
             "random": random.Random(),
-            "choose_random_from": random.choice,
             "get_lang": lambda: web.ctx.lang,
             "get_supported_languages": get_supported_languages,
             "ceil": math.ceil,

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1672,7 +1672,6 @@ def setup() -> None:
         {
             "HTML": HTML,
             "request": Request(),
-            "logger": logging.getLogger("openlibrary.template"),
             "sum": sum,
             "websafe": web.websafe,
         }


### PR DESCRIPTION
### What does this PR do?

Completes the remaining template-global cleanup section of #13422.

Removes unused Templetor globals:

* `tuple`
* `NEWLINE`
* `choose_random_from`
* `isbn_10_to_isbn_13`
* `logger`

`isbn_10_to_isbn_13` remains defined and available to Python callers; only its template exposure is removed.

The `logger` registration lives in `openlibrary/plugins/upstream/utils.py`, rather than `openlibrary/plugins/openlibrary/code.py` as originally listed in the issue.

### Verification

* Confirmed no templates use any of the removed globals.
* `choose_random_from` has no remaining references; its former template usage was removed with the book-page maze banner in 2022.
* `NEWLINE` has no remaining references.
* `tuple` has no template callers.
* `logger` has no template callers.
* `isbn_10_to_isbn_13` remains actively used by Python code and was not modified or removed.
* `git diff --check` passes.
* Python syntax checks (`py_compile`) pass.
* `ruff format --check` passes.

Local full test limitations:

* `make test-py-uv` could not be run because `make` is unavailable in this Windows environment.
* Pre-commit hooks requiring `vendor/infogami` could not run because the submodule/dependency is not initialized locally.
* Ruff reports three pre-existing `I001` import-order findings in the two touched files; no unrelated import reordering was included in this intentionally minimal PR.

Production also renders Infogami templates stored in the database, which cannot be searched locally, so template lookup errors referencing these names should be monitored after deployment as noted in #13422.

### Scope

No unrelated globals, functions, or files were changed.

Completes the remaining section of #13422.

### Screenshot

N/A — no UI changes.

### Stakeholders

@RayBB

---

AI/tooling transparency: AI tooling (Claude Code) assisted with repository inspection, history research, command execution, and verification. The final diff and verification results were reviewed by the author before submission.