### PR TITLE
fix(eslint): ignore the gitignored docs/wiki clone

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -14,6 +14,12 @@ module.exports = [
       "conf/",
       "config/",
       "docker/",
+      // Gitignored MediaWiki/VitePress mirror that docker/ol-home-start.sh
+      // auto-clones (~460 MB, 12,652 JS files). ESLint v9 flat config does not
+      // read .gitignore, so without this any machine that has run
+      // `docker compose up` lints the clone's build output and dependency
+      // caches: ~566k problems, 58.5 MB of output, exit 1 (#13448).
+      "docs/wiki/",
       "infogami/",
       "node_modules/",
       "openlibrary/components/lit/icons.generated.js",

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -14,11 +14,6 @@ module.exports = [
       "conf/",
       "config/",
       "docker/",
-      // Gitignored MediaWiki/VitePress mirror that docker/ol-home-start.sh
-      // auto-clones (~460 MB, 12,652 JS files). ESLint v9 flat config does not
-      // read .gitignore, so without this any machine that has run
-      // `docker compose up` lints the clone's build output and dependency
-      // caches: ~566k problems, 58.5 MB of output, exit 1 (#13448).
       "docs/wiki/",
       "infogami/",
       "node_modules/",


### PR DESCRIPTION
Closes #13448. Part of epic #13447.

## The change

One entry added to the `ignores` array in `eslint.config.cjs`:

```js
"docs/wiki/",
```

## Why `docs/wiki/` and not `docs/`

The issue describes the `ignores` array as having "no `docs/` entry", but the narrower pattern is the right one, and I checked before choosing it:

- `git ls-files docs/` returns **20 tracked files, all Markdown** — zero `.js`, `.mjs`, `.cjs`, `.vue` or `.ts`. So ignoring `docs/` costs nothing *today*.
- But `.gitignore:65` scopes the problem exactly: `docs/wiki/` is the gitignored clone. Ignoring the whole of `docs/` would also silently un-lint any real JS someone adds under `docs/` later — a second, quieter version of the same class of bug this epic is closing.

Happy to widen it to `docs/` if you'd rather have the blunt instrument.

## Verified, not assumed

I don't have the 460 MB wiki clone locally, so I reproduced the mechanism in a scratch project with real ESLint 9 — a file under `docs/wiki/.vitepress/dist/` and a file under `openlibrary/plugins/`, same flat-config shape:

| Config | Files linted |
|---|---|
| `ignores: ["node_modules/"]` (control) | both — the wiki bundle **and** real source |
| `ignores: ["docs/wiki/", "node_modules/"]` | real source only |

That confirms both halves: the clone stops being linted, and code that should be linted still is.

`node --check eslint.config.cjs` passes.

## Note

CI never saw this — a fresh checkout has no clone — so there's no CI signal to point at. It only bites contributors who have run `docker compose up`, which is why it survived this long.
