### PR TITLE
fix(tests): stop stylelint CLI output leaking into jest runs

### DIFF
--- a/tests/unit/js/import-at-top.test.js
+++ b/tests/unit/js/import-at-top.test.js
@@ -21,12 +21,8 @@ function lintImportAtTop(code) {
             '--allow-empty-input',
         ], {
             encoding: 'utf8',
-            // The fixtures deliberately fail lint, so stylelint's report and
-            // Node's deprecation warnings are expected output, not a problem
-            // to surface. execFileSync forwards the child's stderr to the
-            // parent by default, which printed ~59 lines of it into every
-            // `npm run test`. Piping both streams keeps them in the thrown
-            // error, which is where the assertion below already reads them.
+            // The fixtures fail lint on purpose; capture the report for the
+            // assertion below instead of letting execFileSync print it.
             stdio: ['ignore', 'pipe', 'pipe'],
         });
         return 0;

--- a/tests/unit/js/import-at-top.test.js
+++ b/tests/unit/js/import-at-top.test.js
@@ -19,7 +19,16 @@ function lintImportAtTop(code) {
             file,
             '--config', path.join(repoRoot, '.stylelintrc.json'),
             '--allow-empty-input',
-        ], { encoding: 'utf8' });
+        ], {
+            encoding: 'utf8',
+            // The fixtures deliberately fail lint, so stylelint's report and
+            // Node's deprecation warnings are expected output, not a problem
+            // to surface. execFileSync forwards the child's stderr to the
+            // parent by default, which printed ~59 lines of it into every
+            // `npm run test`. Piping both streams keeps them in the thrown
+            // error, which is where the assertion below already reads them.
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
         return 0;
     } catch (error) {
         const output = `${error.stdout || ''}${error.stderr || ''}`;


### PR DESCRIPTION
Closes #13449. Part of epic #13447.

## The change

`stdio: ['ignore', 'pipe', 'pipe']` on the `execFileSync` call in `lintImportAtTop()`.

The fixtures deliberately fail lint — that is the point of the test — so stylelint's report and Node's deprecation warnings are *expected* output, not a problem to surface. `execFileSync` forwards the child's stderr to the parent by default, so every `npm run test` printed ~59 lines of it mid-run, referencing temp paths that look alarming and mean nothing.

The `catch` block already reads `error.stdout` / `error.stderr`, so the assertion is untouched.

## Verified, not assumed

I could not run the suite itself here (it needs `node_modules/.bin/stylelint`), so I verified the *mechanism* directly with Node — a child that writes to both streams and exits non-zero:

| Options | Leaks to parent terminal | `error.stdout` | `error.stderr` |
|---|---|---|---|
| `{ encoding: 'utf8' }` (current) | **yes** — stderr printed | `"OUT-MARKER\n"` | `"ERR-MARKER\n"` |
| `+ stdio: ['ignore','pipe','pipe']` | no | `"OUT-MARKER\n"` | `"ERR-MARKER\n"` |

Both halves confirmed: the leak stops, and the captured output the test counts `ol/import-at-top` occurrences in is still there. `node --check` passes on the file.

Worth stating plainly since I could not run jest: if the suite behaves differently from that reproduction, this should be treated as unverified and I will re-check with a full install.

## Note on `'ignore'` for stdin

The child never reads stdin, and passing `'ignore'` rather than `'pipe'` avoids leaving a pipe open that nothing writes to.
