### PR TITLE
fix(make): run lint through uv with the pinned ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,12 @@ reindex-solr:
 	parallel -j4 python ./scripts/solr_builder/solr_builder/index_subjects.py ::: subject person place time
 
 lint:
-	# See the pyproject.toml file for ruff's settings
-	python -m ruff check .
+	# See the pyproject.toml file for ruff's settings.
+	# Run through uv so a host without ruff installed still works, and so the
+	# pinned ruff from requirements_test.txt is used rather than whatever
+	# version happens to resolve -- lint results differ between ruff releases,
+	# so an unpinned run can disagree with CI. Same pattern as test-py-uv.
+	uv run --with-requirements requirements_test.txt ruff check .
 
 PYTEST_ARGS ?= . --doctest-modules
 


### PR DESCRIPTION
Closes part of #13456. Part of epic #13447.

## What this does

Changes the `lint:` target so it no longer depends on a host-installed ruff.

## Not quite the fix the issue proposed, and why

The issue suggests `uvx ruff check .`. I'd push back on that in two places:

**1. It would silently unpin ruff.** `requirements_test.txt` pins `ruff==0.15.16`. `uvx ruff` resolves the *latest* ruff instead — 0.16.4 on my machine. Lint results differ between ruff releases, so `make lint` would start disagreeing with CI in ways that look like your code changed when only the linter did. Running through `uv run --with-requirements requirements_test.txt` uses the pinned version.

**2. It matches the pattern already in this Makefile.** `test-py-uv` is `uv run --with-requirements requirements_test.txt pytest …`. Using the same form for `lint` keeps one convention rather than introducing a second.

So:

```make
lint:
	uv run --with-requirements requirements_test.txt ruff check .
```

This does make `uv` a requirement for `make lint`, where before it was ruff. That seems like the right trade given `uv` is already the documented path for `make test-py-uv` in both `AGENTS.md` and `docs/ai/README.md` — but say the word if you'd rather keep a host-ruff fallback and I'll add one.

## Worth knowing: the premise is host-specific

The issue says `python -m ruff check .` "fails with `No module named ruff`". On my host the opposite is true — `python -m ruff` works (0.16.4 installed) and `uv` is **not installed at all**, so `uvx ruff check .` would have broken `make lint` here. Both failure modes are real; they just depend on what the contributor happens to have. That is the argument for going through the pinned-requirements path rather than swapping one host assumption for another.

`make -n lint` parses and expands correctly.

## What I deliberately left out

The second half of #13456 — the stale `AGENTS.md` claim that the `mypy` and `generate-pot` hooks fail on the host — asks for verification on real macOS/Linux setups before changing it. **`pre-commit` is not installed on my host and I could not run it**, so I have not touched that line. Correcting a documentation claim about hook behaviour without having observed that behaviour would be the same kind of stale-claim problem the issue is trying to end, one revision later.

Happy for this to land as the Makefile half and leave #13456 open for the AGENTS.md part, or to close it if you verify the hooks yourself.
