### PR TITLE
fix(components): replace deprecated >>> combinators with :deep()

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -225,13 +225,13 @@ export default {
   contain: strict;
 }
 
-.shelf >>> .book {
+.shelf :deep(.book) {
   justify-content: flex-end;
   margin-bottom: 10px;
 }
 
-.shelf >>> .book:first-child .book-3d,
-.shelf >>> .book-end-start + .book .book-3d {
+.shelf :deep(.book:first-child .book-3d),
+.shelf :deep(.book-end-start + .book .book-3d) {
   margin-left: 20px;
 }
 


### PR DESCRIPTION
Closes part of #13454. Part of epic #13447.

## What this does

Replaces the three deprecated `>>>` combinators in `Shelf.vue` — the source of 3 of the 4 warning lines — with `:deep()`:

```css
.shelf >>> .book                              →  .shelf :deep(.book)
.shelf >>> .book:first-child .book-3d,        →  .shelf :deep(.book:first-child .book-3d),
.shelf >>> .book-end-start + .book .book-3d   →  .shelf :deep(.book-end-start + .book .book-3d)
```

The whole selector after the combinator goes inside `:deep(...)`, which is the documented equivalent: `>>>` made everything to its right unscoped, and `:deep()` does the same for what it wraps. The style block is `<style scoped>` (line 218), so the deep escape is doing real work here and dropping it would break the 3D shelf styles rather than just quieting a warning.

`grep -rn ">>>\|/deep/" --include="*.vue" openlibrary/components/` now returns nothing, so these were the only three in the tree.

## What I have not done, and why

The fourth warning — the Vite chunk-size one from the lit build — is **not** addressed here.

The issue suggests setting `build.chunkSizeWarningLimit` in `vite-lit.config.mjs`. I did not, because I could not measure the chunk: `package.json` requires `node ^24.0.0` and this host has v22.13.1, so `npm ci` refuses and the build will not run. Picking a threshold without knowing the actual chunk size would either be so high it silences a real future regression, or so low it fires again on the next dependency bump — and either way it would be a number nobody could defend later.

Splitting the chunk also looks wrong for this config: `vite-lit.config.mjs`'s own header says it "creates a bundled build of all Lit components in a single file", so the size is intentional. Raising the limit is probably right; it just wants a measured number.

Happy for this to land as the `:deep()` half with #13454 staying open for the chunk warning, or to add the limit if someone tells me the current chunk size.

## Verification

I could not run `make components lit-components` for the same Node-version reason, so I have not observed the warnings disappear. What I can state: the three `>>>` occurrences are gone, the replacement is the documented equivalent, and no other Vue file in `openlibrary/components/` uses a deprecated combinator. Treat the "3 of 4 warnings go away" claim as reasoned rather than measured.
