### PR TITLE
make lint: use uvx ruff so it works without host-installed ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ reindex-solr:
 
 lint:
 	# See the pyproject.toml file for ruff's settings
-	python -m ruff check .
+	uvx ruff check .
 
 PYTEST_ARGS ?= . --doctest-modules
 


### PR DESCRIPTION
# [openlibrary] make lint: use uvx ruff so it works without host-installed ruff

Partially addresses #13456 (the Makefile half; see "AGENTS.md half" below for why I did *not* change AGENTS.md).

## What

`lint:` ran `python -m ruff check .`, which fails on hosts where the `python`/`python3` on PATH lacks ruff (`No module named ruff`; this exact failure is reproducible on a bare Linux box, and `make lint` even dies earlier at `make: python: No such file or directory`). Changed to:

```make
lint:
	# See the pyproject.toml file for ruff's settings
	uvx ruff check .
```

matching the existing `test-py-uv` pattern of using uv-managed tools.

## Verification

- Reproduced the broken state first: `make lint` → Error 127.
- After change: `make lint` invokes ruff successfully via uvx.

## Findings maintainers may care about

1. **Pre-existing lint drift on master.** With the repo's pinned version (`uvx ruff@0.15.16 check .`, per requirements_test.txt) master reports **124 × I001 (unsorted-imports) + 1 × RUF100**, all auto-fixable. This suggests CI never runs the whole-repo lint target, only pre-commit on changed files. A one-line follow-up PR running `ruff --fix` would clean it; happy to send it.

2. **AGENTS.md half of #13456 — I did not apply it, because my verification contradicts the issue's audit claim.** On this host (Linux, Python 3.14 installed via uv, pre-commit 4.6.2, fresh clone without submodules):
   - `pre-commit run mypy --files openlibrary/utils/request_context.py` **fails**: after installing Python 3.14, mypy aborts with `Cannot read file 'infogami': No such file or directory` when checking files that import infogami (the `vendor/infogami` submodule isn't checked out).
   - `pre-commit run generate-pot --files ...` **fails** with `ModuleNotFoundError: No module named 'infogami'`.

   So on at least one host setup both hooks genuinely fail — consistent with AGENTS.md's current warning, not with the issue's claim that an audit saw them pass. Rather than edit docs based on contradictory evidence, I left AGENTS.md untouched and am reporting these data points. Suggest re-running the audit on a full clone (submodules included); if it still passes there, the doc update can land with those specifics.
