### PR TITLE
Hoist list availability lookups into Python handler

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -527,7 +527,6 @@ def get_ocaid(item: dict) -> str | None:
     return next((ocaid for ocaid in ocaids if not is_non_ia_ocaid(ocaid)), None)
 
 
-@public
 def get_availabilities(items: list) -> dict:
     result = {}
     ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -14,6 +14,7 @@ from starlette.datastructures import URL
 import openlibrary.core.helpers as h
 from infogami.infobase import client, common
 from infogami.utils import delegate
+from infogami.utils.app import find_mode
 from infogami.utils.view import public, query_param, render_template, require_login, safeint
 from openlibrary.accounts import get_current_user
 from openlibrary.core import cache, formats
@@ -27,6 +28,7 @@ from openlibrary.core.lists.model import (
 )
 from openlibrary.core.lists.model import Seed as ListSeed
 from openlibrary.core.models import (
+    Thing,
     ThingKey,
     Work,
     WorkSeriesEdgeDB,
@@ -654,32 +656,43 @@ def get_list(key: str, raw: bool = False) -> dict | None:
 LIST_VIEW_PAGE_SIZE = 50
 
 
-def _resolve_list_view_items(seeds: list[ListSeed]) -> list[web.storage]:
+@dataclass
+class ResolvedListItem:
+    """A resolved list/series seed, ready for the template to render."""
+
+    seed: ListSeed
+    doc: dict | Thing | None
+    availability: dict | None
+
+
+def _resolve_list_view_items(seeds: list[ListSeed]) -> list[ResolvedListItem]:
     """Batch-resolve a page of list/series seeds into renderable items.
 
-    Moves the seed -> Solr doc -> availability resolution that used to run
-    inside type/list/view_body.html into Python, so the template only
-    renders data that has already been fetched.
+    Solr work docs carry an `editions` block, and get_availabilities keys
+    its result by whichever doc it is handed - so for a work seed we prefer
+    its first Solr edition (the edition's ocaid is authoritative) and fall
+    back to the work doc or the seed's own document.
     """
     if not seeds:
         return []
 
     solr_works = get_solr_works({s.key for s in seeds if s.type == "work"}, editions=True)
-    work_key_to_solr_edition = {
-        key: work_doc["editions"]["docs"][0] for key, work_doc in solr_works.items() if work_doc and work_doc.get("editions", {}).get("docs", [])
-    }
-    availabilities = get_availabilities(
-        [work_key_to_solr_edition.get(seed.key) or solr_works.get(seed.key) or seed.document for seed in seeds if seed.type in ["edition", "work"]]
-    )
+    first_edition = {key: work_doc["editions"]["docs"][0] for key, work_doc in solr_works.items() if work_doc and work_doc.get("editions", {}).get("docs")}
+
+    def doc_for(seed: ListSeed) -> dict | Thing | None:
+        return solr_works.get(seed.key) or seed.document
+
+    availabilities = get_availabilities([d for d in (first_edition.get(s.key) or doc_for(s) for s in seeds if s.type in ("edition", "work")) if d])
 
     items = []
     for seed in seeds:
-        if seed.type in ["edition", "work"]:
-            doc = solr_works.get(seed.key) or seed.document
-            availability = availabilities.get(work_key_to_solr_edition[seed.key]["key"]) if seed.key in work_key_to_solr_edition else availabilities.get(seed.key)
-            items.append(web.storage(seed=seed, doc=doc, availability=availability))
-        else:
-            items.append(web.storage(seed=seed, doc=None, availability=None))
+        if seed.type not in ("edition", "work"):
+            items.append(ResolvedListItem(seed=seed, doc=None, availability=None))
+            continue
+        doc = doc_for(seed)
+        av_doc = first_edition.get(seed.key) or doc
+        availability = availabilities.get(av_doc["key"]) if av_doc else None
+        items.append(ResolvedListItem(seed=seed, doc=doc, availability=availability))
     return items
 
 
@@ -689,23 +702,29 @@ class list_view(delegate.page):
     Shares list_view_yaml's `path` below so both encodings coexist on the
     same route (infogami keys page registrations by (path, encoding)); this
     is the plain-HTML sibling, registered with no `encoding` (defaults to
-    None). Before this handler existed, this path had no OL-owned HTML
-    handler and fell through to Infogami's generic type-view dispatch,
-    which is where the Solr/availability I/O below used to live, inside
-    view_body.html.
+    None).
     """
 
     path = r"((?:/people/[^/]+)?/(?:lists|series)/OL\d+L)"
 
     def GET(self, key):
         if web.ctx.encoding:
-            # Preserve the legacy web.py app's unsupported-encoding
-            # behavior (406) for anything that isn't plain HTML. Real JSON
-            # traffic for this path is served by FastAPI; this only guards
-            # the old web.py app in case a request reaches it directly.
+            # Only plain HTML is rendered here; JSON for this route is
+            # served by FastAPI. Keep web.py's 406 for other encodings.
             raise web.HTTPError("406 Not Acceptable", {})
 
-        i = web.input(v=None)
+        i = web.input(v=None, m=None)
+        m = i.get("m")
+        if m and m != "view":
+            # Registering this page shadows Infogami's mode dispatch
+            # (find_mode is only consulted when no page matches the path).
+            # Hand non-view modes back to the mode machinery so ?m=history,
+            # ?m=edit, ?m=diff, etc. keep their pre-existing behavior.
+            cls, args = find_mode()
+            if cls is not None:
+                return cls().GET(*args)
+            raise web.seeother(web.changequery(m=None))
+
         if i.v is not None and safeint(i.v, None) is None:
             raise web.seeother(web.changequery(v=None))
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -709,8 +709,6 @@ class list_view(delegate.page):
 
     def GET(self, key):
         if web.ctx.encoding:
-            # Only plain HTML is rendered here; JSON for this route is
-            # served by FastAPI. Keep web.py's 406 for other encodings.
             raise web.HTTPError("406 Not Acceptable", {})
 
         i = web.input(v=None, m=None)

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -14,9 +14,10 @@ from starlette.datastructures import URL
 import openlibrary.core.helpers as h
 from infogami.infobase import client, common
 from infogami.utils import delegate
-from infogami.utils.view import public, render_template, require_login
+from infogami.utils.view import public, query_param, render_template, require_login, safeint
 from openlibrary.accounts import get_current_user
 from openlibrary.core import cache, formats
+from openlibrary.core.lending import get_availabilities
 from openlibrary.core.lists.model import (
     AnnotatedSeedDict,
     List,
@@ -24,6 +25,7 @@ from openlibrary.core.lists.model import (
     Series,
     ThingReferenceDict,
 )
+from openlibrary.core.lists.model import Seed as ListSeed
 from openlibrary.core.models import (
     ThingKey,
     Work,
@@ -36,6 +38,7 @@ from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.account import MyBooksTemplate
 from openlibrary.plugins.upstream.addbook import safe_seeother
 from openlibrary.plugins.worksearch import subjects
+from openlibrary.plugins.worksearch.code import get_solr_works
 from openlibrary.utils import olid_to_key
 from openlibrary.utils.request_context import site
 
@@ -646,6 +649,84 @@ def get_list(key: str, raw: bool = False) -> dict | None:
             "last_modified": lst.last_modified.isoformat(),
         },
     }
+
+
+LIST_VIEW_PAGE_SIZE = 50
+
+
+def _resolve_list_view_items(seeds: list[ListSeed]) -> list[web.storage]:
+    """Batch-resolve a page of list/series seeds into renderable items.
+
+    Moves the seed -> Solr doc -> availability resolution that used to run
+    inside type/list/view_body.html into Python, so the template only
+    renders data that has already been fetched.
+    """
+    if not seeds:
+        return []
+
+    solr_works = get_solr_works({s.key for s in seeds if s.type == "work"}, editions=True)
+    work_key_to_solr_edition = {
+        key: work_doc["editions"]["docs"][0] for key, work_doc in solr_works.items() if work_doc and work_doc.get("editions", {}).get("docs", [])
+    }
+    availabilities = get_availabilities(
+        [work_key_to_solr_edition.get(seed.key) or solr_works.get(seed.key) or seed.document for seed in seeds if seed.type in ["edition", "work"]]
+    )
+
+    items = []
+    for seed in seeds:
+        if seed.type in ["edition", "work"]:
+            doc = solr_works.get(seed.key) or seed.document
+            availability = availabilities.get(work_key_to_solr_edition[seed.key]["key"]) if seed.key in work_key_to_solr_edition else availabilities.get(seed.key)
+            items.append(web.storage(seed=seed, doc=doc, availability=availability))
+        else:
+            items.append(web.storage(seed=seed, doc=None, availability=None))
+    return items
+
+
+class list_view(delegate.page):
+    """HTML view for a single list or series page.
+
+    Shares list_view_yaml's `path` below so both encodings coexist on the
+    same route (infogami keys page registrations by (path, encoding)); this
+    is the plain-HTML sibling, registered with no `encoding` (defaults to
+    None). Before this handler existed, this path had no OL-owned HTML
+    handler and fell through to Infogami's generic type-view dispatch,
+    which is where the Solr/availability I/O below used to live, inside
+    view_body.html.
+    """
+
+    path = r"((?:/people/[^/]+)?/(?:lists|series)/OL\d+L)"
+
+    def GET(self, key):
+        if web.ctx.encoding:
+            # Preserve the legacy web.py app's unsupported-encoding
+            # behavior (406) for anything that isn't plain HTML. Real JSON
+            # traffic for this path is served by FastAPI; this only guards
+            # the old web.py app in case a request reaches it directly.
+            raise web.HTTPError("406 Not Acceptable", {})
+
+        i = web.input(v=None)
+        if i.v is not None and safeint(i.v, None) is None:
+            raise web.seeother(web.changequery(v=None))
+
+        lst = site.get().get(key, i.v)
+        if lst is None:
+            raise web.notfound()
+        if lst.type.key == "/type/delete":
+            web.ctx.status = "404 Not Found"
+            return render_template("type/delete/view", lst)
+        if lst.type.key == "/type/redirect" and lst.location and not lst.location.startswith("http://") and not lst.location.startswith("://"):
+            web.redirect(lst.location)
+
+        page = safeint(query_param("page"), 1) - 1
+        sort = query_param("sort", None)
+        page_size = LIST_VIEW_PAGE_SIZE
+
+        seeds = lst.get_seeds(sort=(sort == "last_modified"), resolve_redirects=True)
+        page_seeds = seeds[page * page_size : page * page_size + page_size]
+        items = _resolve_list_view_items(page_seeds)
+
+        return render_template("type/list/view", lst, items, page, page_size, sort)
 
 
 class list_view_yaml(delegate.page):

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -274,8 +274,7 @@ def _make_seed(key, type_, document=None):
 
 
 class TestResolveListViewItems:
-    """Unit tests for the Solr/availability batching moved out of
-    type/list/view_body.html (issue #13419, subtask 4)."""
+    """Unit tests for the seed -> Solr doc -> availability batching."""
 
     def test_empty_seeds_skips_solr_and_availability(self, monkeypatch):
         solr_mock = Mock()
@@ -379,7 +378,7 @@ class TestResolveListViewItems:
 
 
 class TestListViewGet:
-    """Tests for the list_view HTML handler added for issue #13419, subtask 4."""
+    """Tests for the list_view HTML handler."""
 
     def test_non_html_encoding_returns_406(self, monkeypatch):
         monkeypatch.setattr(web.ctx, "encoding", "json", raising=False)
@@ -450,12 +449,10 @@ class TestListViewGet:
         render_mock.assert_called_once_with("type/list/view", lst, [], 1, 50, None)
 
     def test_page_zero_query_param_preserves_preexisting_slicing_quirk(self, monkeypatch):
-        """`?page=0` -> page=-1 -> a negative-start slice.
+        """`?page=0` -> page=-1 -> a negative-start slice that yields no items.
 
-        This is a pre-existing quirk of the template code being hoisted here
-        (safeint(query_param('page'), 1) - 1 has no lower bound), not
-        something introduced by this change. It is deliberately preserved
-        byte-for-byte rather than "fixed" as a silent side effect.
+        safeint(query_param('page'), 1) - 1 has no lower bound; the quirk is
+        preserved intentionally rather than fixed as a silent side effect.
         """
         monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
         monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, page="0", sort=None))
@@ -480,9 +477,41 @@ class TestListViewGet:
             legacy_lists.list_view().GET("/lists/OL1L")
 
         # page=0 -> page=-1 -> seeds[-50:0], which Python clamps to an empty
-        # slice here (same as the old template code would have produced).
+        # slice here.
         resolve_mock.assert_called_once_with(all_seeds[-50:0])
         assert all_seeds[-50:0] == []
+
+    def test_non_view_mode_is_delegated_to_mode_machinery(self, monkeypatch):
+        """?m=history (and any other non-view mode) is handed back to the
+        mode machinery, which the page registration would otherwise shadow."""
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, m="history"))
+
+        fake_mode = Mock()
+        fake_mode.return_value.GET.return_value = "history page"
+        monkeypatch.setattr(legacy_lists, "find_mode", lambda: (fake_mode, ["/lists/OL1L"]))
+
+        result = legacy_lists.list_view().GET("/lists/OL1L")
+
+        assert result == "history page"
+        fake_mode.return_value.GET.assert_called_once_with("/lists/OL1L")
+
+    def test_unknown_mode_redirects_to_default_view(self, monkeypatch):
+        """An unregistered mode falls back the way delegate() does:
+        seeother to m=None."""
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web.ctx, "path", "/lists/OL1L", raising=False)
+        monkeypatch.setattr(web.ctx, "home", "", raising=False)
+        monkeypatch.setattr(web.ctx, "headers", [], raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, m="bogus"))
+        monkeypatch.setattr(web, "changequery", lambda **kw: "/lists/OL1L")
+        monkeypatch.setattr(legacy_lists, "find_mode", lambda: (None, None))
+
+        with pytest.raises(web.HTTPError) as excinfo:
+            legacy_lists.list_view().GET("/lists/OL1L")
+
+        assert excinfo.value.args[0] == "303 See Other"
+        assert any(h[0] == "Location" and h[1] == "/lists/OL1L" for h in web.ctx.headers)
 
     def test_sort_last_modified_is_forwarded_to_get_seeds(self, monkeypatch):
         monkeypatch.setattr(web.ctx, "encoding", None, raising=False)

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -390,6 +390,7 @@ class TestListViewGet:
     def test_missing_list_raises_notfound(self, monkeypatch):
         monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
         monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None))
+        monkeypatch.setattr(web.ctx, "headers", [], raising=False)
 
         mock_site = Mock()
         mock_site.get.return_value = None

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -1,7 +1,9 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+import web
 from starlette.datastructures import URL
 
 from openlibrary.plugins.openlibrary import lists as legacy_lists
@@ -265,3 +267,239 @@ def test_get_lists_data_uses_lists_json_path_for_pagination_links():
 
     assert data["links"]["self"] == "/people/alice"
     assert data["links"]["next"] == "/people/alice/lists.json?limit=50&offset=50"
+
+
+def _make_seed(key, type_, document=None):
+    return SimpleNamespace(key=key, type=type_, document=document, notes=None, last_update=None)
+
+
+class TestResolveListViewItems:
+    """Unit tests for the Solr/availability batching moved out of
+    type/list/view_body.html (issue #13419, subtask 4)."""
+
+    def test_empty_seeds_skips_solr_and_availability(self, monkeypatch):
+        solr_mock = Mock()
+        availability_mock = Mock()
+        monkeypatch.setattr(legacy_lists, "get_solr_works", solr_mock)
+        monkeypatch.setattr(legacy_lists, "get_availabilities", availability_mock)
+
+        items = legacy_lists._resolve_list_view_items([])
+
+        assert items == []
+        solr_mock.assert_not_called()
+        availability_mock.assert_not_called()
+
+    def test_work_seed_resolved_via_solr(self, monkeypatch):
+        work_doc = {"key": "/works/OL1W", "editions": {"docs": [{"key": "/books/OL1M"}]}}
+        seed = _make_seed("/works/OL1W", "work")
+
+        monkeypatch.setattr(legacy_lists, "get_solr_works", Mock(return_value={"/works/OL1W": work_doc}))
+        monkeypatch.setattr(
+            legacy_lists,
+            "get_availabilities",
+            Mock(return_value={"/books/OL1M": {"status": "available"}}),
+        )
+
+        items = legacy_lists._resolve_list_view_items([seed])
+
+        assert len(items) == 1
+        assert items[0].seed is seed
+        assert items[0].doc == work_doc
+        assert items[0].availability == {"status": "available"}
+
+    def test_edition_seed_stays_edition_and_is_excluded_from_solr_query(self, monkeypatch):
+        edition_doc = {"key": "/books/OL2M"}
+        seed = _make_seed("/books/OL2M", "edition", document=edition_doc)
+
+        solr_mock = Mock(return_value={})
+        monkeypatch.setattr(legacy_lists, "get_solr_works", solr_mock)
+        monkeypatch.setattr(
+            legacy_lists,
+            "get_availabilities",
+            Mock(return_value={"/books/OL2M": {"status": "available"}}),
+        )
+
+        items = legacy_lists._resolve_list_view_items([seed])
+
+        # get_solr_works is only ever queried with `work`-type seed keys
+        solr_mock.assert_called_once_with(set(), editions=True)
+        assert items[0].doc == edition_doc
+        assert items[0].availability == {"status": "available"}
+
+    def test_orphan_seed_falls_back_to_document_without_crashing(self, monkeypatch):
+        seed = _make_seed("/works/OL3W", "work", document=None)
+
+        monkeypatch.setattr(legacy_lists, "get_solr_works", Mock(return_value={}))
+        monkeypatch.setattr(legacy_lists, "get_availabilities", Mock(return_value={}))
+
+        items = legacy_lists._resolve_list_view_items([seed])
+
+        assert items[0].doc is None
+        assert items[0].availability is None
+
+    def test_non_work_edition_seed_has_no_doc_or_availability(self, monkeypatch):
+        seed = _make_seed("subject:foo", "subject")
+
+        availability_mock = Mock(return_value={})
+        monkeypatch.setattr(legacy_lists, "get_solr_works", Mock(return_value={}))
+        monkeypatch.setattr(legacy_lists, "get_availabilities", availability_mock)
+
+        items = legacy_lists._resolve_list_view_items([seed])
+
+        assert items[0].doc is None
+        assert items[0].availability is None
+        # subject/person/place/time seeds never enter the availability batch
+        availability_mock.assert_called_once_with([])
+
+    def test_mixed_list_batches_availability_exactly_once(self, monkeypatch):
+        work_doc = {"key": "/works/OL1W"}  # no editions block -> falls back to the work doc itself
+        seeds = [
+            _make_seed("/works/OL1W", "work"),
+            _make_seed("/books/OL2M", "edition", document={"key": "/books/OL2M"}),
+            _make_seed("subject:foo", "subject"),
+        ]
+
+        availability_mock = Mock(
+            return_value={
+                "/works/OL1W": {"status": "available"},
+                "/books/OL2M": {"status": "borrowable"},
+            }
+        )
+        monkeypatch.setattr(legacy_lists, "get_solr_works", Mock(return_value={"/works/OL1W": work_doc}))
+        monkeypatch.setattr(legacy_lists, "get_availabilities", availability_mock)
+
+        items = legacy_lists._resolve_list_view_items(seeds)
+
+        assert availability_mock.call_count == 1
+        assert [item.availability for item in items] == [
+            {"status": "available"},
+            {"status": "borrowable"},
+            None,
+        ]
+
+
+class TestListViewGet:
+    """Tests for the list_view HTML handler added for issue #13419, subtask 4."""
+
+    def test_non_html_encoding_returns_406(self, monkeypatch):
+        monkeypatch.setattr(web.ctx, "encoding", "json", raising=False)
+
+        with pytest.raises(web.HTTPError):
+            legacy_lists.list_view().GET("/lists/OL1L")
+
+    def test_missing_list_raises_notfound(self, monkeypatch):
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None))
+
+        mock_site = Mock()
+        mock_site.get.return_value = None
+        with patch("openlibrary.plugins.openlibrary.lists.site") as mock_site_context:
+            mock_site_context.get.return_value = mock_site
+
+            with pytest.raises(web.HTTPError):
+                legacy_lists.list_view().GET("/lists/OL999L")
+
+    def test_deleted_list_renders_delete_template_with_404(self, monkeypatch):
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None))
+
+        deleted = SimpleNamespace(type=SimpleNamespace(key="/type/delete"))
+        mock_site = Mock()
+        mock_site.get.return_value = deleted
+
+        render_mock = Mock(return_value="rendered")
+        with (
+            patch("openlibrary.plugins.openlibrary.lists.site") as mock_site_context,
+            patch("openlibrary.plugins.openlibrary.lists.render_template", render_mock),
+        ):
+            mock_site_context.get.return_value = mock_site
+
+            result = legacy_lists.list_view().GET("/lists/OL1L")
+
+        assert result == "rendered"
+        render_mock.assert_called_once_with("type/delete/view", deleted)
+
+    def test_only_current_page_seeds_are_resolved(self, monkeypatch):
+        """Batch resolution must only ever see the seeds on the requested page."""
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, page="2", sort=None))
+
+        all_seeds = [_make_seed(f"/works/OL{i}W", "work") for i in range(120)]
+        lst = SimpleNamespace(
+            type=SimpleNamespace(key="/type/list"),
+            get_seeds=Mock(return_value=all_seeds),
+        )
+        mock_site = Mock()
+        mock_site.get.return_value = lst
+
+        resolve_mock = Mock(return_value=[])
+        render_mock = Mock(return_value="rendered")
+        with (
+            patch("openlibrary.plugins.openlibrary.lists.site") as mock_site_context,
+            patch("openlibrary.plugins.openlibrary.lists._resolve_list_view_items", resolve_mock),
+            patch("openlibrary.plugins.openlibrary.lists.render_template", render_mock),
+        ):
+            mock_site_context.get.return_value = mock_site
+
+            legacy_lists.list_view().GET("/lists/OL1L")
+
+        # page=2 (1-indexed in the query string) -> zero-indexed page 1 ->
+        # seeds[50:100], i.e. exactly LIST_VIEW_PAGE_SIZE items, never the full list.
+        resolve_mock.assert_called_once_with(all_seeds[50:100])
+        render_mock.assert_called_once_with("type/list/view", lst, [], 1, 50, None)
+
+    def test_page_zero_query_param_preserves_preexisting_slicing_quirk(self, monkeypatch):
+        """`?page=0` -> page=-1 -> a negative-start slice.
+
+        This is a pre-existing quirk of the template code being hoisted here
+        (safeint(query_param('page'), 1) - 1 has no lower bound), not
+        something introduced by this change. It is deliberately preserved
+        byte-for-byte rather than "fixed" as a silent side effect.
+        """
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, page="0", sort=None))
+
+        all_seeds = [_make_seed(f"/works/OL{i}W", "work") for i in range(10)]
+        lst = SimpleNamespace(
+            type=SimpleNamespace(key="/type/list"),
+            get_seeds=Mock(return_value=all_seeds),
+        )
+        mock_site = Mock()
+        mock_site.get.return_value = lst
+
+        resolve_mock = Mock(return_value=[])
+        render_mock = Mock(return_value="rendered")
+        with (
+            patch("openlibrary.plugins.openlibrary.lists.site") as mock_site_context,
+            patch("openlibrary.plugins.openlibrary.lists._resolve_list_view_items", resolve_mock),
+            patch("openlibrary.plugins.openlibrary.lists.render_template", render_mock),
+        ):
+            mock_site_context.get.return_value = mock_site
+
+            legacy_lists.list_view().GET("/lists/OL1L")
+
+        # page=0 -> page=-1 -> seeds[-50:0], which Python clamps to an empty
+        # slice here (same as the old template code would have produced).
+        resolve_mock.assert_called_once_with(all_seeds[-50:0])
+        assert all_seeds[-50:0] == []
+
+    def test_sort_last_modified_is_forwarded_to_get_seeds(self, monkeypatch):
+        monkeypatch.setattr(web.ctx, "encoding", None, raising=False)
+        monkeypatch.setattr(web, "input", lambda **kw: web.storage(v=None, page=None, sort="last_modified"))
+
+        lst = SimpleNamespace(
+            type=SimpleNamespace(key="/type/list"),
+            get_seeds=Mock(return_value=[]),
+        )
+        mock_site = Mock()
+        mock_site.get.return_value = lst
+
+        with (
+            patch("openlibrary.plugins.openlibrary.lists.site") as mock_site_context,
+            patch("openlibrary.plugins.openlibrary.lists.render_template", Mock(return_value="rendered")),
+        ):
+            mock_site_context.get.return_value = mock_site
+
+            legacy_lists.list_view().GET("/lists/OL1L")
+
+        lst.get_seeds.assert_called_once_with(sort=True, resolve_redirects=True)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -248,7 +248,6 @@ async def get_solr_works_async(work_keys: set[str], fields: Iterable[str] | None
 
 # Create a sync wrapper for backward compatibility
 get_solr_works = async_bridge.wrap(get_solr_works_async, "get_solr_works")
-public(get_solr_works)
 
 
 def read_author_facet(author_facet: str) -> tuple[str, str]:

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -1,4 +1,4 @@
-$def with (lst, check_owner=True, owns_page=False)
+$def with (lst, items, page, page_size, sort, check_owner=True, owns_page=False)
 
 $var title: $lst.name
 
@@ -11,10 +11,10 @@ $if lst['key'].startswith('/people/'):
 
     $ template = MyBooksTemplate(lst['key'].split('/')[2], 'list').render(
         $   header_title= "",
-        $   template=render_template("type/list/view_body", lst, is_owner),
+        $   template=render_template("type/list/view_body", lst, is_owner, items, page, page_size, sort),
         $   page=lst
         $ )
 $else:
-    $ template = render_template("type/list/view_body", lst, False)
+    $ template = render_template("type/list/view_body", lst, False, items, page, page_size, sort)
 
 $:template

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -1,4 +1,4 @@
-$def with (list, is_owner)
+$def with (list, is_owner, items, page, page_size, sort)
 
 $ title = list.name
 $ title_with_site = _("%(name)s | Lists | Open Library", name=title)
@@ -6,8 +6,6 @@ $ title_with_site = _("%(name)s | Lists | Open Library", name=title)
 $ component_times = {}
 $ component_times['TotalTime'] = time()
 
-$ page = safeint(query_param('page'), 1) - 1
-$ page_size = 50
 $ meta_description = title
 $if list.description:
     $ meta_description = _("%(title)s: %(description)s", title=title, description=list.description)
@@ -30,7 +28,6 @@ $add_metatag(property="og:description", content=meta_description)
 $add_metatag(property="og:image", content=request.canonical_url + "/preview.png")
 
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
-$ sort = query_param('sort', None)
 
 $jsdef render_seed_count(seed_count):
     $ungettext("%(count)d item", "%(count)d items", seed_count, count=seed_count)
@@ -104,25 +101,18 @@ $def seed_attrs(seed):
         <div class="clearfix"></div>
 
         <ul id="listResults" class="list-books clearfix $cond(layout == 'grid', 'list-books--grid')">
-            $ component_times['get_seeds'] = time()
-            $ seeds = list.get_seeds(sort=(sort == 'last_modified'), resolve_redirects=True)[page*page_size:page*page_size+page_size]
-            $ component_times['get_seeds'] = time() - component_times['get_seeds']
 
-        $if not seeds:
+        $if not items:
             <p>$_("There are no items on this list.")</p>
             <p>
                 $:_('<a href="/search" target="_blank" rel="noopener noreferrer">Search for book, subjects, or authors</a> to add to your list.')
                 <a href="/help/faq/reading-log#lists" target="_blank" rel="noopener noreferrer">$_('Learn more.')</a>
             </p>
 
-        $ solr_works = get_solr_works({s.key for s in seeds if s.type == 'work'}, editions=True)
-        $ work_key_to_solr_edition = {key: work_doc['editions']['docs'][0] for key, work_doc in solr_works.items() if work_doc and work_doc.get('editions', {}).get('docs', [])}
-        $ availabilities = get_availabilities([work_key_to_solr_edition.get(seed.key) or solr_works.get(seed.key) or seed.document for seed in seeds if seed.type in ['edition', 'work']])
-        $for seed in seeds:
+        $for item in items:
+            $ seed = item.seed
             $if seed.type in ['edition', 'work']:
-                $ doc = solr_works.get(seed.key) or seed.document
-                $ av = availabilities.get(work_key_to_solr_edition[seed.key]['key']) if seed.key in work_key_to_solr_edition else availabilities.get(seed.key)
-                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=av, decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=True, footer=seed.notes and sanitize(format(seed.notes)), seq_index=loop.index0)
+                $:macros.SearchResultsWork(item.doc, attrs=seed_attrs(seed), availability=item.availability, decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=True, footer=seed.notes and sanitize(format(seed.notes)), seq_index=loop.index0)
             $else:
                 $ default_image = "https://openlibrary.org/static/images/icons/avatar_book-sm.png"
                 $ cover = seed.get_cover()


### PR DESCRIPTION
### What

This PR handles subtask 4 of #13419 by moving list/series seed → Solr document → availability preparation out of `type/list/view_body.html` and into a Python `list_view` handler.

Templates now receive already-resolved items and only render them, no Solr or availability I/O remains in `view_body.html`.

Also:

- `get_solr_works` is no longer exposed to Templetor
- `get_availabilities` is no longer exposed to Templetor
- Both functions remain unchanged and importable by existing Python callers (`loanstats.py`, `bookshelves.py`, etc.)

### Why

This moves blocking Solr/availability I/O out of template rendering and into the request handler, as required by #13419 and in preparation for the FastAPI HTML migration.

### Implementation

- Adds an HTML `list_view` handler alongside the existing `list_view_yaml`, using the same route pattern (`(?:/people/[^/]+)?/(?:lists|series)/OL\d+L`)
- Moves seed → Solr document → availability resolution into Python
- Paginates seeds before resolving them, so only the current page is included in the batch
- Calls `get_solr_works()` at most once per request/page
- Calls `get_availabilities()` at most once per request/page
- Empty lists skip both lookups entirely
- Preserves existing work/edition resolution, series routing, people-scoped lists, pagination, sorting, and YAML handling
- Unsupported encodings reaching the legacy HTML handler (for example legacy web.py `.json` requests) return 406 instead of falling through to HTML rendering

### Testing

- `openlibrary/plugins/openlibrary/tests/test_lists.py` **42 passed**
- Related lending/worksearch/FastAPI list tests  **110 passed**
- Ruff check  passed
- Ruff format check  passed
- `git diff --check`  passed

**Manual QA:** tested locally using the project's seeded dev data with a mixed list, a 103-item paginated list, and an empty list. Before/after comparison showed no visual regressions.

**Routing QA** (`curl`):

- HTML → `200 text/html`
- YAML → `200 text/yaml`
- Legacy web.py `.json` → `406`, no HTML body
- FastAPI `.json` → `200 application/json`

### Screenshots

Manual QA was performed against the project's seeded dev data using the same viewport and application state for both `upstream/master` (Before) and this branch (After).

#### Mixed list

| Before | After |
| --- | --- |
| <img width="1366" height="633" alt="list-mixed-before" src="https://github.com/user-attachments/assets/5de598ef-d959-4d4d-b72e-2157514fc46b" /> | <img width="1366" height="633" alt="list-mixed-after" src="https://github.com/user-attachments/assets/8f6a258d-5b58-4cdd-b392-51c9b9c2ecf4" /> |

#### Pagination  page 1

| Before | After |
| --- | --- |
| <img width="1366" height="633" alt="list-page1-before" src="https://github.com/user-attachments/assets/3eefa89b-2ab8-4328-9d27-41294a0894aa" /> | <img width="1366" height="633" alt="list-page1-after" src="https://github.com/user-attachments/assets/19eaed7e-83ab-4ceb-840c-ae46d75ed29b" /> |

#### Pagination  page 2

| Before | After |
| --- | --- |
| <img width="1366" height="633" alt="list-page2-before" src="https://github.com/user-attachments/assets/96eda9c3-3df5-47a8-95a1-dddf0d8c7596" /> | <img width="1366" height="633" alt="list-page2-after" src="https://github.com/user-attachments/assets/193c9399-6164-4664-923e-246be4b360cb" /> |

No visual regressions were observed.


### Scope

This PR does **not**:

- modify FastAPI list JSON behavior
- change availability semantics
- intentionally change pagination or list UI behavior
- modify `vendor/infogami`

cc @RayBB