### PR TITLE
Move generic_carousel() from templates to Python handlers

### DIFF
--- a/openlibrary/core/carousels.py
+++ b/openlibrary/core/carousels.py
@@ -1,0 +1,166 @@
+"""Canonical data fetching for the homepage "carousel" sections.
+
+These carousels (staff picks, recently returned) used to fetch from the IA
+advanced-search API while rendering inside `home/custom_ia_carousel.html`.
+Fetching lives here so templates only ever render pre-fetched data, and so
+both consumers — the homepage (`openlibrary.plugins.openlibrary.home`) and the
+loans page (`openlibrary.plugins.upstream.account`) — build their carousels
+from one shared module in `openlibrary.core` instead of importing from each
+other's page controllers.
+"""
+
+from collections.abc import Iterable
+from typing import Any, Literal
+
+import web
+
+from infogami.infobase.client import storify
+from infogami.utils import delegate
+from openlibrary.core import cache, ia, lending
+from openlibrary.core.lending import compose_ia_url
+from openlibrary.plugins.upstream.utils import convert_iso_to_marc, get_populated_languages
+from openlibrary.utils.request_context import caching_prethread, get_request_lang
+
+CAROUSELS_PRESETS = {
+    "preset:comics": (
+        '(subject:"comics" OR creator:("Gary Larson") OR creator:("Larson, Gary") '
+        'OR creator:("Charles M Schulz") OR creator:("Schulz, Charles M") OR '
+        'creator:("Jim Davis") OR creator:("Davis, Jim") OR creator:("Bill Watterson")'
+        'OR creator:("Watterson, Bill") OR creator:("Lee, Stan"))'
+    ),
+    "preset:authorsalliance_mitpress": (
+        "(openlibrary_subject:(authorsalliance) OR collection:(mitpress) OR publisher:(MIT Press) OR openlibrary_subject:(mitpress))"
+    ),
+}
+
+CarouselName = Literal["staff_picks", "recently_returned"]
+
+CAROUSEL_SUBJECTS: dict[CarouselName, str] = {
+    "staff_picks": "openlibrary_staff_picks",
+    "recently_returned": "",
+}
+
+
+def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[str, dict[str, Any]]:
+    """Fetch books, IA search URLs, and load-more configs for the given carousels."""
+    names: Iterable[CarouselName]
+    if carousels is None:
+        names = ("staff_picks", "recently_returned")
+    else:
+        names = carousels
+
+    lang = get_request_lang()
+    marc_lang = convert_iso_to_marc(lang)
+    lang_filter = f" language:{marc_lang}" if marc_lang and marc_lang in get_populated_languages() else ""
+    sorts = ["lending___last_browse desc"]
+    limit = 18
+
+    result: dict[str, dict[str, Any]] = {}
+    for name in names:
+        subject = CAROUSEL_SUBJECTS[name]
+        result[name] = {
+            "books": generic_carousel(query=lang_filter, subject=subject, sorts=sorts, limit=limit, safe_mode=True),
+            "url": compose_ia_url(
+                query=lang_filter,
+                subject=subject,
+                sorts=sorts,
+                limit=limit,
+                advanced=False,
+                safe_mode=True,
+            ),
+            "load_more": {
+                "queryType": "BROWSE",
+                "q": lang_filter,
+                "subject": subject,
+                "sorts": ",".join(sorts),
+                "mode": "page",
+                "limit": limit,
+            },
+        }
+    return result
+
+
+def get_ia_carousel_books(query=None, subject=None, sorts=None, limit=None, safe_mode=True):
+    """Query the IA advanced-search API and return formatted book data for a carousel."""
+    if "env" not in web.ctx:
+        delegate.fakeload()
+
+    elif query in CAROUSELS_PRESETS:
+        query = CAROUSELS_PRESETS[query]
+
+    limit = limit or lending.DEFAULT_IA_RESULTS
+    books = lending.get_available(
+        limit=limit,
+        subject=subject,
+        sorts=sorts,
+        query=query,
+        safe_mode=safe_mode,
+    )
+    formatted_books = [format_book_data(book, False) for book in books if book != "error"]
+    return formatted_books
+
+
+def generic_carousel(
+    query=None,
+    subject=None,
+    sorts=None,
+    limit=None,
+    timeout=None,
+    safe_mode=True,
+):
+    """Memoized carousel book fetch; falls back to a synchronous update on cache miss."""
+    memcache_key = "home.ia_carousel_books"
+    cached_ia_carousel_books = cache.memcache_memoize(
+        get_ia_carousel_books,
+        memcache_key,
+        timeout=timeout or cache.DEFAULT_CACHE_LIFETIME,
+        prethread=caching_prethread(),
+    )
+    books = cached_ia_carousel_books(
+        query=query,
+        subject=subject,
+        sorts=sorts,
+        limit=limit,
+        safe_mode=safe_mode,
+    )
+    if not books:
+        books = cached_ia_carousel_books.update(
+            query=query,
+            subject=subject,
+            sorts=sorts,
+            limit=limit,
+            safe_mode=safe_mode,
+        )[0]
+    return storify(books) if books else books
+
+
+def format_book_data(book, fetch_availability=True):
+    """Format an IA search result / edition doc into the shape carousel cards consume."""
+    d = web.storage()
+    d.key = book.get("key")
+    d.url = book.url()
+    d.title = book.title or None
+    d.ocaid = book.get("ocaid")
+    d.eligibility = book.get("eligibility", {})
+    d.availability = book.get("availability", {})
+
+    def get_authors(doc):
+        return [web.storage(key=a.key, name=a.name or None) for a in doc.get_authors()]
+
+    work = book.works and book.works[0]
+    d.authors = get_authors(work or book)
+    d.work_key = work.key if work else book.key
+
+    if cover := book.get_cover():
+        d.cover_url = cover.url("M")
+    elif d.ocaid:
+        d.cover_url = "https://archive.org/services/img/%s" % d.ocaid
+
+    if fetch_availability and d.ocaid:
+        collections = ia.get_metadata(d.ocaid).get("collection", [])
+
+        if "inlibrary" in collections:
+            d.borrow_url = book.url("/borrow")
+        else:
+            d.read_url = book.url("/borrow")
+    return d

--- a/openlibrary/core/carousels.py
+++ b/openlibrary/core/carousels.py
@@ -10,7 +10,7 @@ other's page controllers.
 """
 
 from collections.abc import Iterable
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 import web
 
@@ -41,7 +41,26 @@ CAROUSEL_SUBJECTS: dict[CarouselName, str] = {
 }
 
 
-def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[str, dict[str, Any]]:
+class LoadMoreConfig(TypedDict):
+    """Config passed to the carousel JS data-loader for lazy pagination."""
+
+    queryType: str
+    q: str
+    subject: str
+    sorts: str
+    mode: str
+    limit: int
+
+
+class CarouselData(TypedDict):
+    """Typed shape of a single carousel returned by get_carousel_data()."""
+
+    books: list[Any]
+    url: str | None
+    load_more: LoadMoreConfig
+
+
+def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[CarouselName, CarouselData]:
     """Fetch books, IA search URLs, and load-more configs for the given carousels."""
     names: Iterable[CarouselName]
     if carousels is None:
@@ -55,7 +74,7 @@ def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[s
     sorts = ["lending___last_browse desc"]
     limit = 18
 
-    result: dict[str, dict[str, Any]] = {}
+    result: dict[CarouselName, CarouselData] = {}
     for name in names:
         subject = CAROUSEL_SUBJECTS[name]
         result[name] = {

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -5,8 +5,8 @@ from urllib.parse import urlencode
 import httpx
 
 from infogami import config
+from openlibrary.core.carousels import format_book_data
 from openlibrary.core.lending import get_availability_async
-from openlibrary.plugins.openlibrary.home import format_book_data
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.request_context import req_context, site
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -118,7 +118,7 @@ def compose_ia_url(
 
     Returns None if we get an empty query
     """
-    from openlibrary.plugins.openlibrary.home import CAROUSELS_PRESETS
+    from openlibrary.core.carousels import CAROUSELS_PRESETS
 
     query = CAROUSELS_PRESETS.get(query, query)
     q = "openlibrary_work:(*)"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1287,6 +1287,10 @@ msgstr ""
 msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
 msgstr ""
 
+#: account/loans.html home/index.html
+msgid "Books We Love"
+msgstr ""
+
 #: account/loans.html
 msgid "Or, check out our <a href=\"/collections\">special collections</a>."
 msgstr ""
@@ -4159,10 +4163,6 @@ msgstr ""
 
 #: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
-msgstr ""
-
-#: home/index.html openlibrary/plugins/upstream/account.py
-msgid "Books We Love"
 msgstr ""
 
 #: home/index.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1287,10 +1287,6 @@ msgstr ""
 msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
 msgstr ""
 
-#: account/loans.html home/index.html
-msgid "Books We Love"
-msgstr ""
-
 #: account/loans.html
 msgid "Or, check out our <a href=\"/collections\">special collections</a>."
 msgstr ""
@@ -4163,6 +4159,10 @@ msgstr ""
 
 #: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
+msgstr ""
+
+#: home/index.html openlibrary/plugins/upstream/account.py
+msgid "Books We Love"
 msgstr ""
 
 #: home/index.html

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -619,8 +619,8 @@ class opds_home(delegate.page):
 
         def get_cached_homepage():
             from openlibrary.plugins.openlibrary.code import is_bot
-            from openlibrary.plugins.openlibrary.home import caching_prethread
             from openlibrary.utils import dateutil
+            from openlibrary.utils.request_context import caching_prethread
 
             five_minutes = 5 * dateutil.MINUTE_SECS
             lang = web.ctx.lang

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -8,8 +8,9 @@ import web
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.infobase.client import storify
 from infogami.utils import delegate
-from infogami.utils.view import public, render_template
+from infogami.utils.view import render_template
 from openlibrary.core import admin, cache, env, ia, lending
+from openlibrary.core.lending import compose_ia_url
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import (
     convert_iso_to_marc,
@@ -19,6 +20,7 @@ from openlibrary.plugins.upstream.utils import (
 from openlibrary.plugins.worksearch import search, subjects
 from openlibrary.utils import dateutil
 from openlibrary.utils.request_context import (
+    get_request_lang,
     req_context,
     set_context_from_legacy_web_py,
 )
@@ -50,14 +52,88 @@ def get_homepage(devmode):
     # render template should be setting ctx.cssfile
     # but because get_homepage is cached, this doesn't happen
     # during subsequent called
+    carousel_data = get_carousel_data()
     page = render_template(
         "home/index",
         stats=stats,
         blog_posts=blog_posts,
         featured_subjects=featured_subjects,
+        carousel_data=carousel_data,
     )
     # Convert to a dict so it can be cached
     return dict(page)
+
+
+def get_carousel_data():
+    lang = get_request_lang()
+    marc_lang = convert_iso_to_marc(lang)
+    lang_filter = f" language:{marc_lang}" if marc_lang and marc_lang in get_populated_languages() else ""
+
+    staff_picks_query = 'languageSorter:("English")' + lang_filter
+    staff_picks_subject = "openlibrary_staff_picks"
+    staff_picks_sorts = ["lending___last_browse desc"]
+    staff_picks_limit = 18
+
+    staff_picks_books = generic_carousel(
+        query=staff_picks_query,
+        subject=staff_picks_subject,
+        sorts=staff_picks_sorts,
+        limit=staff_picks_limit,
+        safe_mode=True,
+    )
+    staff_picks_url = compose_ia_url(
+        query=staff_picks_query,
+        subject=staff_picks_subject,
+        sorts=staff_picks_sorts,
+        limit=staff_picks_limit,
+        advanced=False,
+        safe_mode=True,
+    )
+
+    recently_returned_query = "" + lang_filter
+    recently_returned_sorts = ["lending___last_browse desc"]
+    recently_returned_limit = 18
+
+    recently_returned_books = generic_carousel(
+        query=recently_returned_query,
+        sorts=recently_returned_sorts,
+        limit=recently_returned_limit,
+        safe_mode=True,
+    )
+    recently_returned_url = compose_ia_url(
+        query=recently_returned_query,
+        sorts=recently_returned_sorts,
+        limit=recently_returned_limit,
+        advanced=False,
+        safe_mode=True,
+    )
+
+    return {
+        "staff_picks": {
+            "books": staff_picks_books,
+            "url": staff_picks_url,
+            "load_more": {
+                "queryType": "BROWSE",
+                "q": staff_picks_query,
+                "subject": staff_picks_subject,
+                "sorts": ",".join(staff_picks_sorts),
+                "mode": "page",
+                "limit": staff_picks_limit,
+            },
+        },
+        "recently_returned": {
+            "books": recently_returned_books,
+            "url": recently_returned_url,
+            "load_more": {
+                "queryType": "BROWSE",
+                "q": recently_returned_query,
+                "subject": "",
+                "sorts": ",".join(recently_returned_sorts),
+                "mode": "page",
+                "limit": recently_returned_limit,
+            },
+        },
+    }
 
 
 def get_cached_homepage():
@@ -275,7 +351,6 @@ def get_cached_featured_subjects():
     )()
 
 
-@public
 def generic_carousel(
     query=None,
     subject=None,

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -2,6 +2,8 @@
 
 import logging
 import random
+from collections.abc import Iterable
+from typing import Any, Literal
 
 import web
 
@@ -40,6 +42,14 @@ CAROUSELS_PRESETS = {
 }
 
 
+CarouselName = Literal["staff_picks", "recently_returned"]
+
+CAROUSEL_CONFIGS: dict[CarouselName, dict[str, str]] = {
+    "staff_picks": {"subject": "openlibrary_staff_picks"},
+    "recently_returned": {"subject": ""},
+}
+
+
 def get_homepage(devmode):
     try:
         stats = admin.get_stats(use_mock_data=devmode)
@@ -64,83 +74,37 @@ def get_homepage(devmode):
     return dict(page)
 
 
-def get_carousel_data(carousels=None):
-    if carousels is None:
-        carousels = ("staff_picks", "recently_returned")
+def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[str, dict[str, Any]]:
+    carousels = carousels or ("staff_picks", "recently_returned")
 
     lang = get_request_lang()
     marc_lang = convert_iso_to_marc(lang)
     lang_filter = f" language:{marc_lang}" if marc_lang and marc_lang in get_populated_languages() else ""
 
-    result = {}
-
-    if "staff_picks" in carousels:
-        staff_picks_query = lang_filter
-        staff_picks_subject = "openlibrary_staff_picks"
-        staff_picks_sorts = ["lending___last_browse desc"]
-        staff_picks_limit = 18
-
-        staff_picks_books = generic_carousel(
-            query=staff_picks_query,
-            subject=staff_picks_subject,
-            sorts=staff_picks_sorts,
-            limit=staff_picks_limit,
-            safe_mode=True,
-        )
-        staff_picks_url = compose_ia_url(
-            query=staff_picks_query,
-            subject=staff_picks_subject,
-            sorts=staff_picks_sorts,
-            limit=staff_picks_limit,
-            advanced=False,
-            safe_mode=True,
-        )
-
-        result["staff_picks"] = {
-            "books": staff_picks_books,
-            "url": staff_picks_url,
+    result: dict[str, dict[str, Any]] = {}
+    for name in carousels:
+        subject = CAROUSEL_CONFIGS[name]["subject"]
+        sorts = ["lending___last_browse desc"]
+        limit = 18
+        result[name] = {
+            "books": generic_carousel(query=lang_filter, subject=subject, sorts=sorts, limit=limit, safe_mode=True),
+            "url": compose_ia_url(
+                query=lang_filter,
+                subject=subject,
+                sorts=sorts,
+                limit=limit,
+                advanced=False,
+                safe_mode=True,
+            ),
             "load_more": {
                 "queryType": "BROWSE",
-                "q": staff_picks_query,
-                "subject": staff_picks_subject,
-                "sorts": ",".join(staff_picks_sorts),
+                "q": lang_filter,
+                "subject": subject,
+                "sorts": ",".join(sorts),
                 "mode": "page",
-                "limit": staff_picks_limit,
+                "limit": limit,
             },
         }
-
-    if "recently_returned" in carousels:
-        recently_returned_query = lang_filter
-        recently_returned_sorts = ["lending___last_browse desc"]
-        recently_returned_limit = 18
-
-        recently_returned_books = generic_carousel(
-            query=recently_returned_query,
-            sorts=recently_returned_sorts,
-            limit=recently_returned_limit,
-            safe_mode=True,
-        )
-        recently_returned_url = compose_ia_url(
-            query=recently_returned_query,
-            sorts=recently_returned_sorts,
-            limit=recently_returned_limit,
-            advanced=False,
-            safe_mode=True,
-        )
-
-        result["recently_returned"] = {
-            "books": recently_returned_books,
-            "url": recently_returned_url,
-            "load_more": {
-                "queryType": "BROWSE",
-                "q": recently_returned_query,
-                "subject": "",
-                "sorts": ",".join(recently_returned_sorts),
-                "mode": "page",
-                "limit": recently_returned_limit,
-            },
-        }
-
     return result
 
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -64,52 +64,39 @@ def get_homepage(devmode):
     return dict(page)
 
 
-def get_carousel_data():
+def get_carousel_data(carousels=None):
+    if carousels is None:
+        carousels = ("staff_picks", "recently_returned")
+
     lang = get_request_lang()
     marc_lang = convert_iso_to_marc(lang)
     lang_filter = f" language:{marc_lang}" if marc_lang and marc_lang in get_populated_languages() else ""
 
-    staff_picks_query = 'languageSorter:("English")' + lang_filter
-    staff_picks_subject = "openlibrary_staff_picks"
-    staff_picks_sorts = ["lending___last_browse desc"]
-    staff_picks_limit = 18
+    result = {}
 
-    staff_picks_books = generic_carousel(
-        query=staff_picks_query,
-        subject=staff_picks_subject,
-        sorts=staff_picks_sorts,
-        limit=staff_picks_limit,
-        safe_mode=True,
-    )
-    staff_picks_url = compose_ia_url(
-        query=staff_picks_query,
-        subject=staff_picks_subject,
-        sorts=staff_picks_sorts,
-        limit=staff_picks_limit,
-        advanced=False,
-        safe_mode=True,
-    )
+    if "staff_picks" in carousels:
+        staff_picks_query = lang_filter
+        staff_picks_subject = "openlibrary_staff_picks"
+        staff_picks_sorts = ["lending___last_browse desc"]
+        staff_picks_limit = 18
 
-    recently_returned_query = "" + lang_filter
-    recently_returned_sorts = ["lending___last_browse desc"]
-    recently_returned_limit = 18
+        staff_picks_books = generic_carousel(
+            query=staff_picks_query,
+            subject=staff_picks_subject,
+            sorts=staff_picks_sorts,
+            limit=staff_picks_limit,
+            safe_mode=True,
+        )
+        staff_picks_url = compose_ia_url(
+            query=staff_picks_query,
+            subject=staff_picks_subject,
+            sorts=staff_picks_sorts,
+            limit=staff_picks_limit,
+            advanced=False,
+            safe_mode=True,
+        )
 
-    recently_returned_books = generic_carousel(
-        query=recently_returned_query,
-        sorts=recently_returned_sorts,
-        limit=recently_returned_limit,
-        safe_mode=True,
-    )
-    recently_returned_url = compose_ia_url(
-        query=recently_returned_query,
-        sorts=recently_returned_sorts,
-        limit=recently_returned_limit,
-        advanced=False,
-        safe_mode=True,
-    )
-
-    return {
-        "staff_picks": {
+        result["staff_picks"] = {
             "books": staff_picks_books,
             "url": staff_picks_url,
             "load_more": {
@@ -120,8 +107,28 @@ def get_carousel_data():
                 "mode": "page",
                 "limit": staff_picks_limit,
             },
-        },
-        "recently_returned": {
+        }
+
+    if "recently_returned" in carousels:
+        recently_returned_query = lang_filter
+        recently_returned_sorts = ["lending___last_browse desc"]
+        recently_returned_limit = 18
+
+        recently_returned_books = generic_carousel(
+            query=recently_returned_query,
+            sorts=recently_returned_sorts,
+            limit=recently_returned_limit,
+            safe_mode=True,
+        )
+        recently_returned_url = compose_ia_url(
+            query=recently_returned_query,
+            sorts=recently_returned_sorts,
+            limit=recently_returned_limit,
+            advanced=False,
+            safe_mode=True,
+        )
+
+        result["recently_returned"] = {
             "books": recently_returned_books,
             "url": recently_returned_url,
             "load_more": {
@@ -132,8 +139,9 @@ def get_carousel_data():
                 "mode": "page",
                 "limit": recently_returned_limit,
             },
-        },
-    }
+        }
+
+    return result
 
 
 def get_cached_homepage():

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -2,17 +2,14 @@
 
 import logging
 import random
-from collections.abc import Iterable
-from typing import Any, Literal
 
 import web
 
 from infogami import config  # noqa: F401 side effects may be needed
-from infogami.infobase.client import storify
 from infogami.utils import delegate
 from infogami.utils.view import render_template
-from openlibrary.core import admin, cache, env, ia, lending
-from openlibrary.core.lending import compose_ia_url
+from openlibrary.core import admin, cache, env
+from openlibrary.core.carousels import get_carousel_data
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import (
     convert_iso_to_marc,
@@ -21,33 +18,9 @@ from openlibrary.plugins.upstream.utils import (
 )
 from openlibrary.plugins.worksearch import search, subjects
 from openlibrary.utils import dateutil
-from openlibrary.utils.request_context import (
-    get_request_lang,
-    req_context,
-    set_context_from_legacy_web_py,
-)
+from openlibrary.utils.request_context import caching_prethread, req_context
 
 logger = logging.getLogger("openlibrary.home")
-
-CAROUSELS_PRESETS = {
-    "preset:comics": (
-        '(subject:"comics" OR creator:("Gary Larson") OR creator:("Larson, Gary") '
-        'OR creator:("Charles M Schulz") OR creator:("Schulz, Charles M") OR '
-        'creator:("Jim Davis") OR creator:("Davis, Jim") OR creator:("Bill Watterson")'
-        'OR creator:("Watterson, Bill") OR creator:("Lee, Stan"))'
-    ),
-    "preset:authorsalliance_mitpress": (
-        "(openlibrary_subject:(authorsalliance) OR collection:(mitpress) OR publisher:(MIT Press) OR openlibrary_subject:(mitpress))"
-    ),
-}
-
-
-CarouselName = Literal["staff_picks", "recently_returned"]
-
-CAROUSEL_CONFIGS: dict[CarouselName, dict[str, str]] = {
-    "staff_picks": {"subject": "openlibrary_staff_picks"},
-    "recently_returned": {"subject": ""},
-}
 
 
 def get_homepage(devmode):
@@ -74,40 +47,6 @@ def get_homepage(devmode):
     return dict(page)
 
 
-def get_carousel_data(carousels: Iterable[CarouselName] | None = None) -> dict[str, dict[str, Any]]:
-    carousels = carousels or ("staff_picks", "recently_returned")
-
-    lang = get_request_lang()
-    marc_lang = convert_iso_to_marc(lang)
-    lang_filter = f" language:{marc_lang}" if marc_lang and marc_lang in get_populated_languages() else ""
-
-    result: dict[str, dict[str, Any]] = {}
-    for name in carousels:
-        subject = CAROUSEL_CONFIGS[name]["subject"]
-        sorts = ["lending___last_browse desc"]
-        limit = 18
-        result[name] = {
-            "books": generic_carousel(query=lang_filter, subject=subject, sorts=sorts, limit=limit, safe_mode=True),
-            "url": compose_ia_url(
-                query=lang_filter,
-                subject=subject,
-                sorts=sorts,
-                limit=limit,
-                advanced=False,
-                safe_mode=True,
-            ),
-            "load_more": {
-                "queryType": "BROWSE",
-                "q": lang_filter,
-                "subject": subject,
-                "sorts": ",".join(sorts),
-                "mode": "page",
-                "limit": limit,
-            },
-        }
-    return result
-
-
 def get_cached_homepage():
     from openlibrary.plugins.openlibrary.code import is_bot
 
@@ -131,32 +70,6 @@ def get_cached_homepage():
         mc(devmode)
 
     return page
-
-
-# Because of caching, memcache will call `get_homepage` on another thread! So we
-# need a way to carry some information to that computation on the other thread.
-# We do that by using a python closure. The outer function is executed on the main
-# thread, so all the web.* stuff is correct. The inner function is executed on the
-# other thread, so all the web.* stuff will be dummy.
-def caching_prethread():
-    from openlibrary.plugins.openlibrary.code import is_bot
-
-    # web.ctx.lang is undefined on the new thread, so need to transfer it over
-    lang = req_context.get().lang
-    host = web.ctx.host
-    _is_bot = is_bot()
-
-    def main():
-        # Leaving this in since this is a bit strange, but you can see it clearly
-        # in action with this debug line:
-        # web.debug(f'XXXXXXXXXXX web.ctx.lang={web.ctx.get("lang")}; {lang=}')
-        delegate.fakeload()
-        web.ctx.lang = lang
-        web.ctx.is_bot = _is_bot
-        web.ctx.host = host
-        set_context_from_legacy_web_py()
-
-    return main
 
 
 class home(delegate.page):
@@ -208,25 +121,6 @@ class random_book(delegate.page):
 
         keys = get_random_borrowable_ebook_keys(1000, language=user_lang)
         raise web.seeother(random.choice(keys))
-
-
-def get_ia_carousel_books(query=None, subject=None, sorts=None, limit=None, safe_mode=True):
-    if "env" not in web.ctx:
-        delegate.fakeload()
-
-    elif query in CAROUSELS_PRESETS:
-        query = CAROUSELS_PRESETS[query]
-
-    limit = limit or lending.DEFAULT_IA_RESULTS
-    books = lending.get_available(
-        limit=limit,
-        subject=subject,
-        sorts=sorts,
-        query=query,
-        safe_mode=safe_mode,
-    )
-    formatted_books = [format_book_data(book, False) for book in books if book != "error"]
-    return formatted_books
 
 
 def get_featured_subjects():
@@ -321,70 +215,6 @@ def get_cached_featured_subjects():
         timeout=dateutil.HOUR_SECS,
         prethread=caching_prethread(),
     )()
-
-
-def generic_carousel(
-    query=None,
-    subject=None,
-    sorts=None,
-    limit=None,
-    timeout=None,
-    safe_mode=True,
-):
-    memcache_key = "home.ia_carousel_books"
-    cached_ia_carousel_books = cache.memcache_memoize(
-        get_ia_carousel_books,
-        memcache_key,
-        timeout=timeout or cache.DEFAULT_CACHE_LIFETIME,
-        prethread=caching_prethread(),
-    )
-    books = cached_ia_carousel_books(
-        query=query,
-        subject=subject,
-        sorts=sorts,
-        limit=limit,
-        safe_mode=safe_mode,
-    )
-    if not books:
-        books = cached_ia_carousel_books.update(
-            query=query,
-            subject=subject,
-            sorts=sorts,
-            limit=limit,
-            safe_mode=safe_mode,
-        )[0]
-    return storify(books) if books else books
-
-
-def format_book_data(book, fetch_availability=True):
-    d = web.storage()
-    d.key = book.get("key")
-    d.url = book.url()
-    d.title = book.title or None
-    d.ocaid = book.get("ocaid")
-    d.eligibility = book.get("eligibility", {})
-    d.availability = book.get("availability", {})
-
-    def get_authors(doc):
-        return [web.storage(key=a.key, name=a.name or None) for a in doc.get_authors()]
-
-    work = book.works and book.works[0]
-    d.authors = get_authors(work or book)
-    d.work_key = work.key if work else book.key
-
-    if cover := book.get_cover():
-        d.cover_url = cover.url("M")
-    elif d.ocaid:
-        d.cover_url = "https://archive.org/services/img/%s" % d.ocaid
-
-    if fetch_availability and d.ocaid:
-        collections = ia.get_metadata(d.ocaid).get("collection", [])
-
-        if "inlibrary" in collections:
-            d.borrow_url = book.url("/borrow")
-        else:
-            d.read_url = book.url("/borrow")
-    return d
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -76,7 +76,7 @@ class TestHomeTemplates:
         html = str(render_template("home/stats"))
         assert html == ""
 
-    def test_home_template(self, render_template, mock_site, monkeypatch):
+    def test_home_template(self, render_template, monkeypatch, mock_site):
         self.setup_monkeypatch(monkeypatch)
         docs = [
             MockDoc(
@@ -112,25 +112,37 @@ class TestHomeTemplates:
 
         mock_site.quicksave("/people/foo/lists/OL1L", "/type/list")
 
-        def spoofed_generic_carousel(*args, **kwargs):
-            return [
-                {
-                    "work": None,
-                    "key": "/books/OL1M",
-                    "url": "/books/OL1M",
-                    "title": "The Great Book",
-                    "authors": [web.storage({"key": "/authors/OL1A", "name": "Some Author"})],
-                    "read_url": "http://archive.org/stream/foo",
-                    "borrow_url": "/books/OL1M/foo/borrow",
-                    "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
-                    "cover_url": "",
-                }
-            ]
+        carousel_data = {
+            "staff_picks": {
+                "books": [],
+                "url": "/search?q=staff_picks",
+                "load_more": {
+                    "queryType": "BROWSE",
+                    "q": "test_query",
+                    "subject": "test_subject",
+                    "sorts": "test_sort",
+                    "mode": "page",
+                    "limit": 18,
+                },
+            },
+            "recently_returned": {
+                "books": [],
+                "url": "/search?q=recently_returned",
+                "load_more": {
+                    "queryType": "BROWSE",
+                    "q": "test_query",
+                    "subject": "",
+                    "sorts": "test_sort",
+                    "mode": "page",
+                    "limit": 18,
+                },
+            },
+        }
 
         macros = web.template.Template.globals.setdefault("macros", web.storage())
         macros.BookPreview = lambda *args, **kwargs: '<div id="bookPreview"></div>'
         macros.BookPreviewFloater = lambda *args, **kwargs: '<div id="bookPreview"></div>'
-        html = str(render_template("home/index", stats=stats, test=True, featured_subjects=[]))
+        html = str(render_template("home/index", stats=stats, test=True, featured_subjects=[], carousel_data=carousel_data))
 
         assert "Recently Returned" in html
         assert "bookPreview" in html

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -5,8 +5,8 @@ import web
 from bs4 import BeautifulSoup
 
 from openlibrary.core.admin import Stats
+from openlibrary.core.carousels import format_book_data
 from openlibrary.mocks.mock_infobase import MockSite
-from openlibrary.plugins.openlibrary import home
 
 
 class MockDoc(dict):
@@ -166,7 +166,7 @@ class Test_format_book_data:
         )
 
         book = mock_site.quicksave("/books/OL1M", "/type/edition", title="Foo")
-        assert home.format_book_data(book)["authors"] == []
+        assert format_book_data(book)["authors"] == []
 
         # when there is no work and authors, the authors field must be picked from the book
         book = mock_site.quicksave(
@@ -175,7 +175,7 @@ class Test_format_book_data:
             title="Foo",
             authors=[{"key": "/authors/OL1A"}],
         )
-        assert home.format_book_data(book)["authors"] == [{"key": "/authors/OL1A", "name": "A1"}]
+        assert format_book_data(book)["authors"] == [{"key": "/authors/OL1A", "name": "A1"}]
 
         # when there is work, the authors field must be picked from the work
         book = mock_site.quicksave(
@@ -185,4 +185,4 @@ class Test_format_book_data:
             authors=[{"key": "/authors/OL1A"}],
             works=[{"key": "/works/OL1W"}],
         )
-        assert home.format_book_data(book)["authors"] == [{"key": "/authors/OL2A", "name": "A2"}]
+        assert format_book_data(book)["authors"] == [{"key": "/authors/OL2A", "name": "A2"}]

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1281,7 +1281,7 @@ class account_loans(delegate.page):
 
         from openlibrary.plugins.openlibrary.home import get_carousel_data
 
-        staff_picks = get_carousel_data()["staff_picks"]
+        staff_picks = get_carousel_data(carousels=("staff_picks",))["staff_picks"]
 
         template = render["account/loans"](
             user,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -40,6 +40,7 @@ from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.core.auth import TimedOneTimePassword as OTP
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.carousels import get_carousel_data
 from openlibrary.core.db import get_db
 from openlibrary.core.follows import PubSub
 from openlibrary.core.lending import get_loan_history_data
@@ -1278,8 +1279,6 @@ class account_loans(delegate.page):
         docs = get_loans_of_user(user.key)
         loan_history_data = get_loan_history_data(username, page=page)
         featured_subjects = get_cached_featured_subjects()
-
-        from openlibrary.plugins.openlibrary.home import get_carousel_data
 
         staff_picks = get_carousel_data(carousels=("staff_picks",))["staff_picks"]
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1291,10 +1291,7 @@ class account_loans(delegate.page):
             show_next=loan_history_data["show_next"],
             ia_base_url=CONFIG_IA_DOMAIN,
             featured_subjects=featured_subjects,
-            carousel_books=staff_picks["books"],
-            carousel_title=_("Books We Love"),
-            carousel_url=staff_picks["url"],
-            carousel_load_more=staff_picks["load_more"],
+            carousel=staff_picks,
         )
         return mb.render(header_title=_("Loans & History"), template=template)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1278,6 +1278,11 @@ class account_loans(delegate.page):
         docs = get_loans_of_user(user.key)
         loan_history_data = get_loan_history_data(username, page=page)
         featured_subjects = get_cached_featured_subjects()
+
+        from openlibrary.plugins.openlibrary.home import get_carousel_data
+
+        staff_picks = get_carousel_data()["staff_picks"]
+
         template = render["account/loans"](
             user,
             docs,
@@ -1286,6 +1291,10 @@ class account_loans(delegate.page):
             show_next=loan_history_data["show_next"],
             ia_base_url=CONFIG_IA_DOMAIN,
             featured_subjects=featured_subjects,
+            carousel_books=staff_picks["books"],
+            carousel_title=_("Books We Love"),
+            carousel_url=staff_picks["url"],
+            carousel_load_more=staff_picks["load_more"],
         )
         return mb.render(header_title=_("Loans & History"), template=template)
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -25,14 +25,13 @@ from openlibrary.core.lending import add_availability, get_loan_history_data, ge
 from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.i18n import gettext as _
-from openlibrary.plugins.openlibrary.home import caching_prethread
 from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
 from openlibrary.plugins.worksearch.schemes.works import get_fulltext_min
 from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.dateutil import current_year
-from openlibrary.utils.request_context import site
+from openlibrary.utils.request_context import caching_prethread, site
 
 if TYPE_CHECKING:
     from web.template import TemplateResult

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -369,7 +369,7 @@ def test_render_cached_macro_evicts_cache_on_error(monkeypatch):
             return_value=False,
         ),
         patch(
-            "openlibrary.plugins.openlibrary.home.caching_prethread",
+            "openlibrary.utils.request_context.caching_prethread",
             return_value=None,
         ),
     ):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -247,7 +247,7 @@ def render_macro(name, args, **kwargs):
 
 @public
 def render_cached_macro(name: str, args: tuple, **kwargs):
-    from openlibrary.plugins.openlibrary.home import caching_prethread
+    from openlibrary.utils.request_context import caching_prethread
 
     def get_key_prefix():
         req_context = request_context.req_context.get()

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -1,4 +1,4 @@
-$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False, featured_subjects=[])
+$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False, featured_subjects=[], carousel_books=None, carousel_title=None, carousel_url=None, carousel_load_more=None)
 
 <style type="text/css">
 .date, .waitrank {
@@ -225,6 +225,6 @@ th.status {
 <br/>
 
 <div>$_("Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:")</div>
-     $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, compact_mode=True)
+     $:render_template("home/custom_ia_carousel", carousel_books, title=carousel_title, url=carousel_url, key="staff_picks", load_more=carousel_load_more, min_books=7, test=test, compact_mode=True)
     $:render_template("home/categories", featured_subjects=featured_subjects)
     $:_('Or, check out our <a href="/collections">special collections</a>.')

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -1,4 +1,4 @@
-$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False, featured_subjects=[], carousel_books=None, carousel_title=None, carousel_url=None, carousel_load_more=None)
+$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False, featured_subjects=[], carousel=None)
 
 <style type="text/css">
 .date, .waitrank {
@@ -225,6 +225,6 @@ th.status {
 <br/>
 
 <div>$_("Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:")</div>
-     $:render_template("home/custom_ia_carousel", carousel_books, title=carousel_title, url=carousel_url, key="staff_picks", load_more=carousel_load_more, min_books=7, test=test, compact_mode=True)
+     $:render_template("books/custom_carousel", carousel["books"], title=_('Books We Love'), url=carousel["url"], key="staff_picks", load_more=carousel["load_more"], min_books=7, test=test, compact_mode=True)
     $:render_template("home/categories", featured_subjects=featured_subjects)
     $:_('Or, check out our <a href="/collections">special collections</a>.')

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -225,6 +225,7 @@ th.status {
 <br/>
 
 <div>$_("Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:")</div>
-     $:render_template("books/custom_carousel", carousel["books"], title=_('Books We Love'), url=carousel["url"], key="staff_picks", load_more=carousel["load_more"], min_books=7, test=test, compact_mode=True)
+    $if carousel:
+        $:render_template("books/custom_carousel", carousel["books"], title=_('Books We Love'), url=carousel["url"], key="staff_picks", load_more=carousel["load_more"], min_books=7, test=test, compact_mode=True)
     $:render_template("home/categories", featured_subjects=featured_subjects)
     $:_('Or, check out our <a href="/collections">special collections</a>.')

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,22 +1,2 @@
-$def with(title, key, query='', subject='', sorts='', limit=None, min_books=7, test=False, compact_mode=False, user_lang_only=False, safe_mode=True)
-
-$code:
-  if user_lang_only:
-    web_lang= get_lang() or 'en'
-    user_lang= convert_iso_to_marc(web_lang)
-    if user_lang and user_lang in get_populated_languages():
-      query = query + ' language:' + user_lang
-  title_url = compose_ia_url(query=query, subject=subject, sorts=sorts, limit=limit, advanced=False, safe_mode=safe_mode)
-  books = generic_carousel(query=query, subject=subject, sorts=sorts, limit=limit, safe_mode=safe_mode) if not test else []
-  sorts = ','.join(sorts) if sorts else ''
-  load_more_config = {
-    "queryType": "BROWSE",
-    "q": query,
-    "subject": subject,
-    "sorts": sorts,
-    "mode": "page",
-    "limit": limit
-  }
-
-
-$:render_template("books/custom_carousel", books, title=title, url=title_url, key=key, min_books=min_books, load_more=load_more_config, test=test, compact_mode=compact_mode)
+$def with(books, title, url, key, load_more=None, min_books=7, test=False, compact_mode=False)
+$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more=load_more, test=test, compact_mode=compact_mode)

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,2 +1,0 @@
-$def with(books, title, url, key, load_more=None, min_books=7, test=False, compact_mode=False)
-$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more=load_more, test=test, compact_mode=compact_mode)

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -23,9 +23,9 @@ $add_metatag(property="og:site_name", content="Open Library")
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", sort='trending', user_lang_only=True)
 
   $if carousel_data:
-    $:render_template("home/custom_ia_carousel", carousel_data["staff_picks"]["books"], title=_('Books We Love'), url=carousel_data["staff_picks"]["url"], key="staff_picks", load_more=carousel_data["staff_picks"]["load_more"], min_books=7, test=test, compact_mode=False)
+    $:render_template("books/custom_carousel", carousel_data["staff_picks"]["books"], title=_('Books We Love'), url=carousel_data["staff_picks"]["url"], key="staff_picks", load_more=carousel_data["staff_picks"]["load_more"], min_books=7, test=test, compact_mode=False)
 
-    $:render_template("home/custom_ia_carousel", carousel_data["recently_returned"]["books"], title=_('Recently Returned'), url=carousel_data["recently_returned"]["url"], key="recently_returned", load_more=carousel_data["recently_returned"]["load_more"], min_books=7, test=test, compact_mode=False)
+    $:render_template("books/custom_carousel", carousel_data["recently_returned"]["books"], title=_('Recently Returned'), url=carousel_data["recently_returned"]["url"], key="recently_returned", load_more=carousel_data["recently_returned"]["load_more"], min_books=7, test=test, compact_mode=False)
 
   $if not test:
     $# TODO: See if we can remove the first_publish_year restriction. But the label "romance" seems to be applied unexpectedly to books before 1930.

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -1,4 +1,4 @@
-$def with (stats=None, blog_posts=None, test=False, featured_subjects=[])
+$def with (stats=None, blog_posts=None, test=False, featured_subjects=[], carousel_data=None)
 
 $ _x = ctx.setdefault('cssfile', 'home')
 $var title: $_("Welcome to Open Library")
@@ -22,9 +22,10 @@ $add_metatag(property="og:site_name", content="Open Library")
     $:macros.QueryCarousel(query='trending_score_hourly_sum:[1 TO *] readinglog_count:[4 TO *]', title=_('Trending Books'), key="trending", sort='trending', has_fulltext_only=False, user_lang_only=True)
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", sort='trending', user_lang_only=True)
 
-  $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
+  $if carousel_data:
+    $:render_template("home/custom_ia_carousel", carousel_data["staff_picks"]["books"], title=_('Books We Love'), url=carousel_data["staff_picks"]["url"], key="staff_picks", load_more=carousel_data["staff_picks"]["load_more"], min_books=7, test=test, compact_mode=False)
 
-  $:render_template("home/custom_ia_carousel", title=_('Recently Returned'), key="recently_returned", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
+    $:render_template("home/custom_ia_carousel", carousel_data["recently_returned"]["books"], title=_('Recently Returned'), url=carousel_data["recently_returned"]["url"], key="recently_returned", load_more=carousel_data["recently_returned"]["load_more"], min_books=7, test=test, compact_mode=False)
 
   $if not test:
     $# TODO: See if we can remove the first_publish_year restriction. But the label "romance" seems to be applied unexpectedly to books before 1930.

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -16,6 +16,7 @@ from urllib.parse import unquote
 import web
 
 from infogami import config
+from infogami.utils import delegate
 from infogami.utils.delegate import create_site
 
 if TYPE_CHECKING:
@@ -201,6 +202,35 @@ def set_context_from_legacy_web_py() -> None:
             is_bot=is_bot,
         )
     )
+
+
+def caching_prethread():
+    """Return a callback that re-establishes request context on a worker thread.
+
+    Memcache-memoized fetches (homepage, carousels, featured subjects, cached
+    macros) can be computed on a background thread where the `web.ctx.*` globals
+    are stale or unset. The returned callback copies the language, host, and bot
+    flag captured on the main thread onto the worker thread before the fetch runs.
+    """
+    # Module-level would cycle: `code.py` imports this module.
+    from openlibrary.plugins.openlibrary.code import is_bot  # noqa: PLC0415
+
+    # web.ctx.lang is undefined on the new thread, so need to transfer it over
+    lang = req_context.get().lang
+    host = web.ctx.host
+    _is_bot = is_bot()
+
+    def main():
+        # Leaving this in since this is a bit strange, but you can see it clearly
+        # in action with this debug line:
+        # web.debug(f'XXXXXXXXXXX web.ctx.lang={web.ctx.get("lang")}; {lang=}')
+        delegate.fakeload()
+        web.ctx.lang = lang
+        web.ctx.is_bot = _is_bot
+        web.ctx.host = host
+        set_context_from_legacy_web_py()
+
+    return main
 
 
 def set_context_from_fastapi(request: Request) -> None:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #13419 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moves `generic_carousel()` and `compose_ia_url()` network calls out of the Templetor template (`custom_ia_carousel.html`) into Python handlers (`home.py`, `account.py`). Templates now receive pre-fetched data instead of making network calls directly.

### Technical
<!-- What should be noted about the implementation? -->
- `home.py` - `get_carousel_data()` fetches books, URLs, and load_more configs; restores `user_lang_only` language filtering via `get_request_lang()`; removes `@public` from `generic_carousel()`
- `custom_ia_carousel.html` -  accepts pre-fetched `books`, `title`, `url`, `load_more`
- `home/index.html` - passes translated titles and pre-built load_more configs from `carousel_data`
- `account.py` and`loans.html` - reuses `get_carousel_data()` instead of duplicating carousel logic
- `test_home.py` - updated for new data flow, removed dead mock code


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
