### PR TITLE
Move featured subjects fetching from templates to Python handlers

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -45,11 +45,17 @@ def get_homepage(devmode):
         logger.error("Error in getting stats", exc_info=True)
         stats = None
     blog_posts = get_blog_feeds()
+    featured_subjects = get_cached_featured_subjects()
 
     # render template should be setting ctx.cssfile
     # but because get_homepage is cached, this doesn't happen
     # during subsequent called
-    page = render_template("home/index", stats=stats, blog_posts=blog_posts)
+    page = render_template(
+        "home/index",
+        stats=stats,
+        blog_posts=blog_posts,
+        featured_subjects=featured_subjects,
+    )
     # Convert to a dict so it can be cached
     return dict(page)
 
@@ -260,7 +266,6 @@ def get_featured_subjects():
     return [{**subject, **(subjects.get_subject(subject["key"], limit=0) or {})} for subject in FEATURED_SUBJECTS]
 
 
-@public
 def get_cached_featured_subjects():
     return cache.memcache_memoize(
         get_featured_subjects,

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -130,7 +130,7 @@ class TestHomeTemplates:
         macros = web.template.Template.globals.setdefault("macros", web.storage())
         macros.BookPreview = lambda *args, **kwargs: '<div id="bookPreview"></div>'
         macros.BookPreviewFloater = lambda *args, **kwargs: '<div id="bookPreview"></div>'
-        html = str(render_template("home/index", stats=stats, test=True))
+        html = str(render_template("home/index", stats=stats, test=True, featured_subjects=[]))
 
         assert "Recently Returned" in html
         assert "bookPreview" in html

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1200,6 +1200,7 @@ class account_loans(delegate.page):
     @require_login
     def GET(self):
         from openlibrary.core.lending import get_loans_of_user
+        from openlibrary.plugins.openlibrary.home import get_cached_featured_subjects
 
         i = web.input(page=1)
         try:
@@ -1212,6 +1213,7 @@ class account_loans(delegate.page):
         mb = MyBooksTemplate(username, "loans")
         docs = get_loans_of_user(user.key)
         loan_history_data = get_loan_history_data(username, page=page)
+        featured_subjects = get_cached_featured_subjects()
         template = render["account/loans"](
             user,
             docs,
@@ -1219,6 +1221,7 @@ class account_loans(delegate.page):
             current_page=page,
             show_next=loan_history_data["show_next"],
             ia_base_url=CONFIG_IA_DOMAIN,
+            featured_subjects=featured_subjects,
         )
         return mb.render(header_title=_("Loans & History"), template=template)
 

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -1,4 +1,4 @@
-$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False)
+$def with (user, loans, history_docs=None, current_page=1, show_next=False, ia_base_url="", test=False, featured_subjects=[])
 
 <style type="text/css">
 .date, .waitrank {
@@ -226,5 +226,5 @@ th.status {
 
 <div>$_("Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:")</div>
      $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, compact_mode=True)
-    $:render_template("home/categories", test=test)
+    $:render_template("home/categories", featured_subjects=featured_subjects)
     $:_('Or, check out our <a href="/collections">special collections</a>.')

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -1,7 +1,6 @@
-$def with (test=False)
+$def with (featured_subjects)
 
-$ subjects = get_cached_featured_subjects() if not test else []
-$if subjects:
+$if featured_subjects:
   <div class="carousel-section">
     <div class="carousel-section-header">
       <h2 class="home-h2"><a href="/subjects">$_('Browse by Subject')</a></h2>
@@ -9,7 +8,7 @@ $if subjects:
     <div class="carousel-container">
       <div class="carousel carousel--progressively-enhanced"
         data-config="$json_encode({'carouselKey': 'categories', 'booksPerBreakpoint': [6, 5, 4, 3, 2, 2]})">
-        $for subject in subjects:
+        $for subject in featured_subjects:
           $ presentable_subject_name = subject['presentable_name']
           $ icon = subject['key'].split('/')[-1]
           <div class="category-item carousel__item">

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -1,4 +1,4 @@
-$def with (stats=None, blog_posts=None, test=False)
+$def with (stats=None, blog_posts=None, test=False, featured_subjects=[])
 
 $ _x = ctx.setdefault('cssfile', 'home')
 $var title: $_("Welcome to Open Library")
@@ -38,7 +38,7 @@ $add_metatag(property="og:site_name", content="Open Library")
   $if not test and get_ol_env().LOCAL_DEV:
     $:macros.QueryCarousel(title=_('Books in Local Environment'), query='*', use_cache=False)
 
-  $:render_template("home/categories", test=test)
+  $:render_template("home/categories", featured_subjects=featured_subjects if not test else [])
 
   $:render_template("home/stats", stats)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes sub-task 2 of #13419

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor: move featured subjects fetching out of Templetor templates.

### Technical
<!-- What should be noted about the implementation? -->

- Moved `get_cached_featured_subjects()` from `home/categories.html` into the Python code paths that render the template.
- The homepage now fetches `featured_subjects` in `get_homepage()` and passes them through `home/index.html` to `home/categories.html`.
- The `/account/loans` handler now fetches and passes `featured_subjects` through `account/loans.html` to the shared categories template.
- Changed `home/categories.html` into a pure renderer that only consumes the provided `featured_subjects`.
- Removed `@public` from `get_cached_featured_subjects()` since it no longer needs to be exposed to Templetor.
- Preserved the existing `home.featured_subjects.{lang}` cache key, 1-hour TTL, `caching_prethread()` / `delegate.fakeload()` warm-up behavior, and existing rendering behavior.
- Preserved the existing `test=True` behavior by passing an empty subject list when the homepage template is rendered in test mode.
- The Python usage from `api.py` remains unchanged.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Pre-commit checks pass.
- Verified there are no remaining `.html` callers of `get_cached_featured_subjects()`.
- Run the homepage and verify the **Browse by Subject** section renders as before:
  - `http://localhost:8080/`
- Verify the **Browse by Subject** section also renders on:
  - `http://localhost:8080/account/loans`

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->