### PR TITLE
fix(components): increase Vite chunk warning limit for Lit build

### DIFF
--- a/openlibrary/components/vite-lit.config.mjs
+++ b/openlibrary/components/vite-lit.config.mjs
@@ -36,6 +36,10 @@ export default defineConfig({
             }
         },
 
+        // Suppress the default 500 kB chunk-size warning — Lit components
+        // are intentionally bundled into a single file (~536 kB).
+        chunkSizeWarningLimit: 550,
+
         // Minify the output
         minify: true,
 


### PR DESCRIPTION
Description

Fixes sub-task 2 of #13454 .

Problem

make components lit-components emits a Vite chunk-size warning because the intentional editor-core-*.js bundle is ~536 kB after minification.

Fix
Increased build.chunkSizeWarningLimit to 550 kB in vite-lit.config.mjs.
No changes to the generated bundle structure or component behavior.

@RayBB 