### PR TITLE
Update docs for FastAPI fallback proxy port swap (#13423)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,17 +91,17 @@ cat /tmp/cookies.txt
 2. **Use the session cookie in subsequent requests:**
 ```bash
 # Just use -b to send the cookie automatically (no manual extraction needed)
-curl -X POST "http://localhost:18080/people/openlibrary/lists/OL1L/delete.json" -b /tmp/cookies.txt
-curl "http://localhost:18080/people/openlibrary/lists/OL1L.json" -b /tmp/cookies.txt
+curl -X POST "http://localhost:8080/people/openlibrary/lists/OL1L/delete.json" -b /tmp/cookies.txt
+curl "http://localhost:8080/people/openlibrary/lists/OL1L.json" -b /tmp/cookies.txt
 ```
 
-**Note:** Sessions expire — always login fresh before testing. Both web.py (port 8080) and FastAPI (port 18080) share the same auth system.
+**Note:** Sessions expire — always login fresh before testing. In local dev, FastAPI serves on port 8080 and proxies unmatched requests to web.py; both share the same auth system.
 
 ### FastAPI and web.py Interaction
 
-Open Library runs two web servers in parallel:
-- **web.py** (port 8080) — **Legacy** (web.py / Infogami) — no new endpoints here, use FastAPI
-- **FastAPI** (port 18080) — New async endpoints via nginx proxy
+Open Library runs two web servers:
+- **FastAPI** — primary entry point in local dev (port 8080); unmatched requests proxy to web.py via `openlibrary/fastapi/proxy.py`. All new endpoints go here.
+- **web.py** — **Legacy** (web.py / Infogami) — no new endpoints here, use FastAPI. In local dev it is reached through the FastAPI fallback proxy; in production/staging it is still the front door on port 8080 (FastAPI on 18080).
 
 When testing:
 - Both servers share the same database

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -8,7 +8,7 @@ Open Library (openlibrary.org) is an open, editable library catalog by the Inter
 
 ## Development Setup
 
-Run `make git` to initialize the Infogami submodule, then `docker compose up` and visit http://localhost:8080. The FastAPI server runs on port 18080.
+Run `make git` to initialize the Infogami submodule, then `docker compose up` and visit http://localhost:8080. FastAPI is the primary entry point on port 8080; unmatched requests are proxied to the legacy web.py app by `openlibrary/fastapi/proxy.py` (the old web.py-on-8080 / FastAPI-on-18080 layout was swapped in #13423).
 
 On startup, the `home` container runs `docker/ol-home-start.sh`, which clones the [GitHub wiki](https://github.com/internetarchive/openlibrary.wiki) into `docs/wiki/` (gitignored). The wiki holds operational/how-to documentation that is **not** in this repo — search `docs/wiki/` locally before turning to a web search.
 
@@ -93,7 +93,7 @@ matches the app's configured `http_ext_header_uri`. The dev app sets this to
   `X-12-action: merge-authors`, `X-12-comment: ...`, `X-12-data: {...}`.
 - **Prefer FastAPI endpoints instead:** they share the session auth and need
   no custom headers — e.g. author merges via
-  `POST http://localhost:18080/authors/merge.json`.
+  `POST http://localhost:8080/authors/merge.json`.
 
 ### Scripts must log in via the JSON endpoint
 
@@ -164,7 +164,7 @@ The app is loaded through Infogami's plugin system. `openlibrary/code.py` is the
 
 **Routes (web.py/Infogami):** Defined as classes extending `delegate.page` in plugin `code.py` files. The class attribute `path` is a regex pattern, and `GET`/`POST` methods handle requests.
 
-**Routes (FastAPI):** New endpoints go in `openlibrary/fastapi/`. The ASGI app in `openlibrary/asgi_app.py` mounts FastAPI alongside the legacy WSGI app.
+**Routes (FastAPI):** New endpoints go in `openlibrary/fastapi/`. The ASGI app in `openlibrary/asgi_app.py` mounts FastAPI alongside the legacy WSGI app. In local dev, FastAPI is the primary entry point on port 8080; requests it has no route for are proxied to web.py via `openlibrary/fastapi/proxy.py`.
 
 **Key plugins:**
 - `plugins/openlibrary/` — Main plugin: site routes, JS source files (`js/`), processors

--- a/docs/ai/solr/index.md
+++ b/docs/ai/solr/index.md
@@ -224,7 +224,7 @@ Notable dynamic field patterns:
 
 ## Search Endpoints
 
-All `*.json` endpoints are defined in `openlibrary/fastapi/search.py`, served by FastAPI (port 18080, proxied from 8080).
+All `*.json` endpoints are defined in `openlibrary/fastapi/search.py`, served by FastAPI (the primary server on port 8080 in local dev; port 18080 behind the site proxy in production/staging).
 
 | Endpoint | Handler | Purpose |
 |----------|---------|---------|

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -105,11 +105,11 @@ async def check_authentication(
 
     Example:
         # With valid session cookie
-        curl http://localhost:18080/account/test.json \\
+        curl http://localhost:8080/account/test.json \\
             -b "session=/people/openlibrary%2C2026-01-18T17%3A25%3A46%2C7897f%24841a3bd2f8e9a5ca46f505fa557d57bd"
 
         # Without cookie
-        curl http://localhost:18080/account/test.json
+        curl http://localhost:8080/account/test.json
     """
 
     cookie_name = config.get("login_cookie_name", "session")

--- a/tests/integration/test_fastapi_auth.py
+++ b/tests/integration/test_fastapi_auth.py
@@ -9,7 +9,8 @@
 """Integration tests for FastAPI authentication endpoints.
 
 These tests are marked as "integration" and are skipped by default.
-They require a running FastAPI server on localhost:18080.
+They require a running FastAPI server on localhost:8080 (FastAPI is the
+primary local dev entry point; see openlibrary/fastapi/proxy.py).
 
 Run explicitly with:
     uv run pytest -m integration tests/integration/test_fastapi_auth.py -v
@@ -18,7 +19,7 @@ Run explicitly with:
 import pytest
 import requests
 
-BASE_URL = "http://localhost:18080"
+BASE_URL = "http://localhost:8080"
 USERNAME = "openlibrary@example.com"
 PASSWORD = "admin123"
 


### PR DESCRIPTION
Follow up to #13423 (Add FastAPI fallback proxy to web.py for local development and testing).

FastAPI is now the primary local-dev entry point on port 8080, proxying unmatched requests to web.py, and `deprecated_handler.py` was deleted. This updates the docs and one test that still referenced the old layout:

- `docs/ai/README.md`, `docs/ai/solr/index.md`, `AGENTS.md` — describe the new 8080-primary / proxy architecture
- `openlibrary/fastapi/account.py` — fix stale 18080 curl examples in docstring
- `tests/integration/test_fastapi_auth.py` — point BASE_URL at the new local FastAPI port

Note: the wiki pages (`docs/wiki/projects/fastapi-migration.md`, `docs/wiki/developers/backend/local-architecture.md`) were also updated but live in the separate `internetarchive/openlibrary.wiki` repo.