### PR TITLE
Show who started the last testing deploy on the /status page

### DIFF
--- a/openlibrary/components/TestingEnvironment/DeploySection.vue
+++ b/openlibrary/components/TestingEnvironment/DeploySection.vue
@@ -62,8 +62,6 @@ const deployFinishedAt = computed(() => (props.payload && props.payload.deploy_f
 
 const deployStage = computed(() => (props.payload && props.payload.deploy_stage) || '');
 
-// OL username of whoever clicked the last deploy; empty for state files that
-// predate the field, in which case the plain strings carry the line.
 const deployer = computed(() => (props.payload && props.payload.deployed_by) || '');
 
 function text(key, ...args) {

--- a/openlibrary/components/TestingEnvironment/DeploySection.vue
+++ b/openlibrary/components/TestingEnvironment/DeploySection.vue
@@ -62,6 +62,10 @@ const deployFinishedAt = computed(() => (props.payload && props.payload.deploy_f
 
 const deployStage = computed(() => (props.payload && props.payload.deploy_stage) || '');
 
+// OL username of whoever clicked the last deploy; empty for state files that
+// predate the field, in which case the plain strings carry the line.
+const deployer = computed(() => (props.payload && props.payload.deployed_by) || '');
+
 function text(key, ...args) {
     return sprintf(props.strings[key] || key, ...args);
 }
@@ -203,7 +207,9 @@ function prUrl(pr) {
         <span
           class="testing-env__dot"
           aria-hidden="true"
-        />{{ text('deploySucceeded', timeAgo(deployFinishedAt, now)) }}
+        />{{ deployer
+          ? text('deploySucceededBy', timeAgo(deployFinishedAt, now), deployer)
+          : text('deploySucceeded', timeAgo(deployFinishedAt, now)) }}
       </span>
       <span
         v-else-if="deployResult === 'FAILURE' || deployResult === 'ABORTED'"
@@ -213,7 +219,9 @@ function prUrl(pr) {
         <span
           class="testing-env__dot"
           aria-hidden="true"
-        />{{ text('deployFailed', timeAgo(deployFinishedAt, now)) }}
+        />{{ deployer
+          ? text('deployFailedBy', timeAgo(deployFinishedAt, now), deployer)
+          : text('deployFailed', timeAgo(deployFinishedAt, now)) }}
       </span>
       <span
         v-else-if="payload.deploying"
@@ -224,8 +232,12 @@ function prUrl(pr) {
           class="testing-env__dot"
           aria-hidden="true"
         />{{ deployStage
-          ? text('deployingStage', timeAgo(payload.deploy_started_at, now), deployStage)
-          : text('deployingStarted', timeAgo(payload.deploy_started_at, now)) }}
+          ? (deployer
+            ? text('deployingStageBy', timeAgo(payload.deploy_started_at, now), deployStage, deployer)
+            : text('deployingStage', timeAgo(payload.deploy_started_at, now), deployStage))
+          : (deployer
+            ? text('deployingStartedBy', timeAgo(payload.deploy_started_at, now), deployer)
+            : text('deployingStarted', timeAgo(payload.deploy_started_at, now))) }}
       </span>
       <span
         v-else-if="payload.last_deploy_at"
@@ -235,7 +247,9 @@ function prUrl(pr) {
         <span
           class="testing-env__dot"
           aria-hidden="true"
-        />{{ text('lastDeploy', timeAgo(payload.last_deploy_at, now)) }}
+        />{{ deployer
+          ? text('lastDeployBy', timeAgo(payload.last_deploy_at, now), deployer)
+          : text('lastDeploy', timeAgo(payload.last_deploy_at, now)) }}
       </span>
       <span
         v-else

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -54,12 +54,17 @@ export const DEFAULT_STRINGS = {
     behindMany: '%s commits behind %s',
     neverDeployed: 'Never deployed',
     deployingStarted: 'Deploying, started %s',
+    deployingStartedBy: 'Deploying, started %s by %s',
     deployingStage: 'Deploying, started %s — %s',
+    deployingStageBy: 'Deploying, started %s — %s by %s',
     deploySucceeded: 'Deploy succeeded %s',
+    deploySucceededBy: 'Deploy succeeded %s by %s',
     deployFailed: 'Deploy failed %s',
+    deployFailedBy: 'Deploy failed %s by %s',
     deployFailedTrigger: 'Could not start the deploy — Jenkins did not accept the build.',
     deployUnconfigured: 'Deploy is not configured on this instance — nothing was deployed.',
     lastDeploy: 'Last deploy %s',
+    lastDeployBy: 'Last deploy %s by %s',
     viewJenkins: 'View Jenkins',
     noPrs: 'No PRs in testing set.'
 };

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7576,7 +7576,17 @@ msgstr ""
 
 #: TestingEnvironment.html.jinja
 #, python-format
+msgid "Deploying, started %(time)s by %(user)s"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
+#, python-format
 msgid "Deploying, started %(time)s — %(stage)s"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
+#, python-format
+msgid "Deploying, started %(time)s — %(stage)s by %(user)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
@@ -7586,7 +7596,17 @@ msgstr ""
 
 #: TestingEnvironment.html.jinja
 #, python-format
+msgid "Deploy succeeded %(time)s by %(user)s"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
+#, python-format
 msgid "Deploy failed %(time)s"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
+#, python-format
+msgid "Deploy failed %(time)s by %(user)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
@@ -7600,6 +7620,11 @@ msgstr ""
 #: TestingEnvironment.html.jinja
 #, python-format
 msgid "Last deploy %(time)s"
+msgstr ""
+
+#: TestingEnvironment.html.jinja
+#, python-format
+msgid "Last deploy %(time)s by %(user)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -47,12 +47,17 @@
     "behindMany": ngettext("%(num)s commit behind %(sha)s", "%(num)s commits behind %(sha)s", 2, num="%s", sha="%s"),
     "neverDeployed": _("Never deployed"),
     "deployingStarted": _("Deploying, started %(time)s", time="%s"),
+    "deployingStartedBy": _("Deploying, started %(time)s by %(user)s", time="%s", user="%s"),
     "deployingStage": _("Deploying, started %(time)s — %(stage)s", time="%s", stage="%s"),
+    "deployingStageBy": _("Deploying, started %(time)s — %(stage)s by %(user)s", time="%s", stage="%s", user="%s"),
     "deploySucceeded": _("Deploy succeeded %(time)s", time="%s"),
+    "deploySucceededBy": _("Deploy succeeded %(time)s by %(user)s", time="%s", user="%s"),
     "deployFailed": _("Deploy failed %(time)s", time="%s"),
+    "deployFailedBy": _("Deploy failed %(time)s by %(user)s", time="%s", user="%s"),
     "deployFailedTrigger": _("Could not start the deploy — Jenkins did not accept the build."),
     "deployUnconfigured": _("Deploy is not configured on this instance — nothing was deployed."),
     "lastDeploy": _("Last deploy %(time)s", time="%s"),
+    "lastDeployBy": _("Last deploy %(time)s by %(user)s", time="%s", user="%s"),
     "viewJenkins": _("View Jenkins"),
     "noPrs": _("No PRs in testing set.")
 } %}

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -253,7 +253,9 @@ class status_deploy(delegate.page):
         outcome = trigger_rebuild(state.prs)
         if outcome == "failed":
             return _json_error("deploy_failed")
+        user = get_current_user()
         state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
+        state.deployed_by = user.key.split("/")[-1] if user else ""
         # What this build puts on the box: active PRs only, the same filter
         # trigger_rebuild sends. Recorded so a later removal has a set to be
         # missing from — nothing else survives one.
@@ -485,6 +487,9 @@ class TestingPR(BaseModel):
 class TestingState(BaseModel):
     last_deploy_at: str  # ISO timestamp, empty if never deployed
     prs: list[TestingPR] = Field(default_factory=list)
+    # OL username of whoever clicked the last deploy; empty for state files
+    # written before the field existed.
+    deployed_by: str = ""
     # Set only when Jenkins accepted a build; self-expires after _DEPLOY_WINDOW.
     deploy_started_at: str = ""
     # {pr number: title} of what the last deploy actually built — what
@@ -539,6 +544,7 @@ class TestingStatus(BaseModel):
     """
 
     last_deploy_at: str  # ISO timestamp, empty if never deployed
+    deployed_by: str = ""  # OL username of whoever clicked the last deploy; empty if never
     deploy_started_at: str  # ISO timestamp of the last deploy Jenkins accepted; empty if never
     deploying: bool  # whether a build is presumed still running (a time window, not a result)
     has_pending: bool  # whether there are pending changes ready to deploy
@@ -619,6 +625,7 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
     prs.sort(key=lambda row: row.pr)
     return TestingStatus(
         last_deploy_at=last_deploy,
+        deployed_by=state.deployed_by,
         deploy_started_at=state.deploy_started_at,
         deploying=_is_deploying(state),
         pending_changes=pending_changes,

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -487,9 +487,7 @@ class TestingPR(BaseModel):
 class TestingState(BaseModel):
     last_deploy_at: str  # ISO timestamp, empty if never deployed
     prs: list[TestingPR] = Field(default_factory=list)
-    # OL username of whoever clicked the last deploy; empty for state files
-    # written before the field existed.
-    deployed_by: str = ""
+    deployed_by: str = ""  # OL username of whoever clicked the last deploy; empty if never
     # Set only when Jenkins accepted a build; self-expires after _DEPLOY_WINDOW.
     deploy_started_at: str = ""
     # {pr number: title} of what the last deploy actually built — what

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -340,6 +340,7 @@ def test_deploy_drops_closed_prs():
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
     ):
         status_module.status_deploy().POST()
 
@@ -360,6 +361,7 @@ def test_deploy_drops_staged_removals():
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
     ):
         status_module.status_deploy().POST()
 
@@ -709,6 +711,7 @@ def test_deploy_unconfigured_answers_error_but_advances_state():
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="unconfigured"),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
     ):
         response = status_module.status_deploy().POST()
 
@@ -788,6 +791,7 @@ def test_deploy_success_applies_staged_changes_then_saves_once():
         patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="triggered"),
         patch("openlibrary.plugins.openlibrary.status._save_testing_state") as mock_save,
         patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=None),
     ):
         response = status_module.status_deploy().POST()
 
@@ -805,6 +809,36 @@ def test_deploy_success_applies_staged_changes_then_saves_once():
     mock_save.assert_called_once_with(state)
 
 
+def test_deploy_records_who_clicked_it():
+    """A deploy records the OL username of the maintainer who clicked it."""
+    state = _make_state(prs=[_make_pr(added_at="2026-08-01T10:00:00+00:00")])
+    user = MagicMock()
+    user.key = "/people/mecha-kraken"
+
+    with (
+        patch("openlibrary.plugins.openlibrary.status._is_maintainer", return_value=True),
+        patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
+        patch("openlibrary.plugins.openlibrary.status._get_drift_info", return_value=({}, False)),
+        patch("openlibrary.plugins.openlibrary.status.trigger_rebuild", return_value="triggered"),
+        patch("openlibrary.plugins.openlibrary.status._save_testing_state"),
+        patch("openlibrary.plugins.openlibrary.status._evict_drift_cache"),
+        patch("openlibrary.plugins.openlibrary.status.get_current_user", return_value=user),
+    ):
+        status_module.status_deploy().POST()
+
+    assert state.deployed_by == "mecha-kraken"
+
+
+def test_build_testing_status_passes_deployed_by():
+    """The API response carries the recorded deployer username through."""
+    state = _make_state(prs=[_make_pr(added_at="2026-08-01T10:00:00+00:00")])
+    state.deployed_by = "mecha-kraken"
+
+    result = status_module.build_testing_status(state, {})
+
+    assert result.deployed_by == "mecha-kraken"
+
+
 def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_maintainer_user):
     mock_maintainer_user(is_maintainer=True)
     state = _make_state()
@@ -818,6 +852,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
     assert response.status_code == 200
     assert response.json() == {
         "last_deploy_at": "2026-08-05T18:00:00+00:00",
+        "deployed_by": "",
         "deploy_started_at": "",
         "deploying": False,
         "deploy_result": "",

--- a/tests/unit/js/testing-status.test.js
+++ b/tests/unit/js/testing-status.test.js
@@ -92,6 +92,15 @@ describe('Testing Environment utils', () => {
         expect(sprintf('%s selected', 2)).toBe('2 selected');
     });
 
+    test('deploy-status strings carry the deployer username variant', () => {
+        expect(sprintf(DEFAULT_STRINGS.deployingStartedBy, '2 minutes ago', 'openlibrary'))
+            .toBe('Deploying, started 2 minutes ago by openlibrary');
+        expect(sprintf(DEFAULT_STRINGS.deploySucceededBy, '5 minutes ago', 'openlibrary'))
+            .toBe('Deploy succeeded 5 minutes ago by openlibrary');
+        expect(sprintf(DEFAULT_STRINGS.lastDeployBy, '5 minutes ago', 'openlibrary'))
+            .toBe('Last deploy 5 minutes ago by openlibrary');
+    });
+
     test('detects the favicon environment', () => {
         expect(faviconEnv('/static/images/openlibrary-testing-192x192.png')).toBe('testing');
         expect(faviconEnv('/static/images/openlibrary-development-128x128.png')).toBe('development');


### PR DESCRIPTION
The status page's deploy-status line now shows the Open Library username of the maintainer who last clicked **Deploy** (e.g. "Deploying, started 2m ago by raybb"), recorded at click time and served through `/status/testing.json`. Falls back to the existing wording when no username is recorded.

@lokesh had the idea that this would be helpful for when you wanna communicate with the team to not clobber someone elses work on testing and I agree.