### PR TITLE
Fix Vue prop lint warnings

### DIFF
--- a/openlibrary/components/BarcodeScanner/components/LazyBookCard.vue
+++ b/openlibrary/components/BarcodeScanner/components/LazyBookCard.vue
@@ -21,6 +21,7 @@ export default {
     props: {
         isbn: {
             type: String,
+            required: true,
         },
         tentativeCover: {
             type: String,

--- a/openlibrary/components/BulkSearch/components/BookCard.vue
+++ b/openlibrary/components/BulkSearch/components/BookCard.vue
@@ -32,7 +32,10 @@
 <script>
 export default {
     props: {
-        doc: Object,
+        doc: {
+            type: Object,
+            required: true
+        },
         isPrimary: {
             type: Boolean,
             default: false

--- a/openlibrary/components/BulkSearch/components/MatchRow.vue
+++ b/openlibrary/components/BulkSearch/components/MatchRow.vue
@@ -37,8 +37,14 @@ export default {
     props: {
         bulkSearchState: BulkSearchState,
         bookMatch: BookMatch,
-        columns: Array,
-        index: Number
+        columns: {
+            type: Array,
+            default: () => []
+        },
+        index: {
+            type: Number,
+            default: 0
+        }
     },
     computed: {
         searchUrl() {

--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -21,7 +21,7 @@
         </option>
         <template v-if="hasPopularIds">
           <option
-            v-for="entry in popularIds.filter(e => isAdmin || e.name !== 'ocaid')"
+            v-for="entry in popularIdConfigs.filter(e => isAdmin || e.name !== 'ocaid')"
             :key="entry.name"
             :value="entry.name"
           >
@@ -124,22 +124,22 @@ export default {
     // the view automatically re-renders
     props: {
         /** The list of ids currently associated with the entity in the database in string form */
-        assigned_ids_string: {
+        assignedIdsString: {
             type: String,
-            //default: () =>  "{'wikidata': 'Q10000'}"
+            required: true
         },
         /** everything from https://openlibrary.org/config/author
          * Most importantly:
          * {"identifiers": [{"label": "ISNI", "name": "isni", "notes": "", "url": "http://www.isni.org/@@@", "website": "http://www.isni.org/"}, ... ]}
          */
-        id_config_string: {
+        idConfigString: {
             type: String,
             required: true
         },
         /** see createHiddenInputs function for usage
          * #hiddenEditionIdentifiers, #hiddenWorkIdentifiers
          */
-        output_selector: {
+        outputSelector: {
             type: String,
             required: true
         },
@@ -147,8 +147,9 @@ export default {
         Where to save; eg author--remote_ids-- for authors or
         edition--identifiers-- for editions
         */
-        input_prefix: {
-            type: String
+        inputPrefix: {
+            type: String,
+            required: true
         },
         /** Editions and works can have multiple identifiers in the form of a list
          * Not applicable to author identifiers
@@ -165,7 +166,7 @@ export default {
          * Expects a list containing the name field from the
          * respective identifiers.yaml file
         */
-        popular_ids: {
+        popularIds: {
             type: String,
             default: '',
         },
@@ -183,11 +184,11 @@ export default {
 
     computed: {
         idConfigs: function() {
-            return JSON.parse(decodeURIComponent(this.id_config_string));
+            return JSON.parse(decodeURIComponent(this.idConfigString));
         },
-        popularIds: function() {
-            if (this.popular_ids) {
-                const popularIdNames = JSON.parse(decodeURIComponent(this.popular_ids));
+        popularIdConfigs: function() {
+            if (this.popularIds) {
+                const popularIdNames = JSON.parse(decodeURIComponent(this.popularIds));
                 return this.idConfigs.filter((config) => popularIdNames.includes(config.name));
             }
             return [];
@@ -202,7 +203,7 @@ export default {
             return this.selectedIdentifier !== '' && this.inputValue !== '' && (this.isAdmin || this.selectedIdentifier !== 'ocaid');
         },
         hasPopularIds: function() {
-            return Object.keys(this.popularIds).length !== 0;
+            return Object.keys(this.popularIdConfigs).length !== 0;
         },
         isAdmin: function() {
             return this.admin.toLowerCase() === 'true';
@@ -220,7 +221,7 @@ export default {
             },
     },
     created: function(){
-        this.assignedIdentifiers = JSON.parse(decodeURIComponent(this.assigned_ids_string));
+        this.assignedIdentifiers = JSON.parse(decodeURIComponent(this.assignedIdsString));
         if (this.assignedIdentifiers.length === 0) {
             this.assignedIdentifiers = {};
             return;
@@ -251,10 +252,10 @@ export default {
                 const existingIds = this.assignedIdentifiers[this.selectedIdentifier] ?? [];
                 // Only one Internet Archive ID (ocaid) is allowed per edition
                 if (this.selectedIdentifier === 'ocaid' && existingIds.length > 0) {
-                    errorDisplay('Only one Internet Archive ID is allowed per edition.', this.output_selector);
+                    errorDisplay('Only one Internet Archive ID is allowed per edition.', this.outputSelector);
                     return;
                 }
-                const validEditionId = validateIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.output_selector);
+                const validEditionId = validateIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.outputSelector);
                 if (validEditionId) {
                     if (!this.assignedIdentifiers[this.selectedIdentifier]) {
                         this.inputValue = [this.inputValue];
@@ -267,9 +268,9 @@ export default {
                     return;
                 }
             } else if (this.assignedIdentifiers[this.selectedIdentifier]) {
-                errorDisplay(`An identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`, this.output_selector);
+                errorDisplay(`An identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`, this.outputSelector);
                 return;
-            } else { errorDisplay('', this.output_selector); }
+            } else { errorDisplay('', this.outputSelector); }
 
             this.assignedIdentifiers[this.selectedIdentifier] = this.inputValue;
             this.inputValue = '';
@@ -295,17 +296,17 @@ export default {
                 let num = 0;
                 for (const [key, value] of Object.entries(this.assignedIdentifiers)) {
                     for (const idx in value) {
-                        html += `<input type="hidden" name="${this.input_prefix}--${num}--name" value="${key}"/>`;
-                        html += `<input type="hidden" name="${this.input_prefix}--${num}--value" value="${value[idx]}"/>`;
+                        html += `<input type="hidden" name="${this.inputPrefix}--${num}--name" value="${key}"/>`;
+                        html += `<input type="hidden" name="${this.inputPrefix}--${num}--value" value="${value[idx]}"/>`;
                         num += 1;
                     }
                 }
             }
             else {
                 html = Object.entries(this.assignedIdentifiers)
-                    .map(([name, value]) => `<input type="hidden" name="${this.input_prefix}--${name}" value="${value}"/>`).join('');
+                    .map(([name, value]) => `<input type="hidden" name="${this.inputPrefix}--${name}" value="${value}"/>`).join('');
             }
-            document.querySelector(this.output_selector).innerHTML = html;
+            document.querySelector(this.outputSelector).innerHTML = html;
         },
         selectIdentifierByInputValue: function() {
             // Ignore for edition identifiers

--- a/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
@@ -61,7 +61,8 @@ export default {
         },
         cover: {
             type: String,
-            default: 'image'
+            default: 'image',
+            validator: val => ['image', 'text'].includes(val)
         },
     },
 

--- a/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
@@ -55,9 +55,14 @@ export default {
             type: Number,
             default: 50
         },
-        book: Object,
-        /** @type {'image' | 'text'} */
-        cover: String,
+        book: {
+            type: Object,
+            required: true
+        },
+        cover: {
+            type: String,
+            default: 'image'
+        },
     },
 
     data() {

--- a/openlibrary/components/LibraryExplorer/components/BookRoom.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookRoom.vue
@@ -153,12 +153,24 @@ export default {
     },
     props: {
         /** @type {import('../utils.js').ClassificationTree} */
-        classification: Object,
-        appSettings: Object,
+        classification: {
+            type: Object,
+            required: true
+        },
+        appSettings: {
+            type: Object,
+            required: true
+        },
 
         /** The classification to jump to @example 658.91500202854 */
-        jumpTo: String,
-        sort: String,
+        jumpTo: {
+            type: String,
+            default: ''
+        },
+        sort: {
+            type: String,
+            default: ''
+        },
         filter: {
             default: '',
             type: String

--- a/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
@@ -51,7 +51,10 @@ import CONFIGS from '../../configs';
 export default {
     components: { FlatBookCover },
     props: {
-        books: Array
+        books: {
+            type: Array,
+            default: () => []
+        }
     },
     data() {
         return {

--- a/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
@@ -25,13 +25,38 @@ export default {
     },
 
     props: {
-        classification: Object,
-        node: Object,
-        expandBookshelf: Function,
-        labels: Array,
-        features: Object,
-        filter: String,
-        sort: String,
+        classification: {
+            type: Object,
+            required: true
+        },
+        node: {
+            type: Object,
+            required: true
+        },
+        expandBookshelf: {
+            type: Function,
+            required: true
+        },
+        labels: {
+            type: Array,
+            default: () => []
+        },
+        features: {
+            type: Object,
+            default: () => ({
+                book3d: true,
+                cover: 'image',
+                shelfLabel: 'slider',
+            })
+        },
+        filter: {
+            type: String,
+            default: ''
+        },
+        sort: {
+            type: String,
+            default: ''
+        },
     },
 
 };

--- a/openlibrary/components/LibraryExplorer/components/CSSBox.vue
+++ b/openlibrary/components/LibraryExplorer/components/CSSBox.vue
@@ -45,9 +45,18 @@
 <script>
 export default {
     props: {
-        width: Number,
-        height: Number,
-        thickness: Number
+        width: {
+            type: Number,
+            required: true
+        },
+        height: {
+            type: Number,
+            required: true
+        },
+        thickness: {
+            type: Number,
+            required: true
+        }
     },
     computed: {
         cubeStyle() {

--- a/openlibrary/components/LibraryExplorer/components/ClassSlider.vue
+++ b/openlibrary/components/LibraryExplorer/components/ClassSlider.vue
@@ -49,7 +49,10 @@ import ShelfProgressBar from './ShelfProgressBar.vue';
 export default {
     components: { RightArrowIcon, ShelfProgressBar },
     props: {
-        node: Object
+        node: {
+            type: Object,
+            required: true
+        }
     },
     data() {
         return {

--- a/openlibrary/components/LibraryExplorer/components/DemoA.vue
+++ b/openlibrary/components/LibraryExplorer/components/DemoA.vue
@@ -33,7 +33,10 @@ export default {
             default: '',
             type: String
         },
-        classification: Object
+        classification: {
+            type: Object,
+            required: true
+        }
     },
     data() {
         return {};

--- a/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
+++ b/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
@@ -37,9 +37,10 @@ export default {
             type: Object,
             required: true
         },
-        /** @type {'image' | 'text'} */
         cover: {
-            default: 'image'
+            type: String,
+            default: 'image',
+            validator: val => ['image', 'text'].includes(val)
         }
     },
 

--- a/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
+++ b/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
@@ -33,7 +33,10 @@ import { hashCode } from '../utils.js';
 
 export default {
     props: {
-        book: Object,
+        book: {
+            type: Object,
+            required: true
+        },
         /** @type {'image' | 'text'} */
         cover: {
             default: 'image'

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -406,9 +406,18 @@ export default {
     },
 
     props: {
-        filterState: Object,
-        settingsState: Object,
-        sortState: Object,
+        filterState: {
+            type: Object,
+            required: true
+        },
+        settingsState: {
+            type: Object,
+            required: true
+        },
+        sortState: {
+            type: Object,
+            required: true
+        },
     },
 
     data() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -127,9 +127,20 @@ async function waitUntil(predicate, sleep = 100, maxSleep = 2000) {
 export default {
     components: { BooksCarousel },
     props: {
-        query: String,
-        node: Object,
-        fetchCoordinator: Object,
+        query: {
+            type: String,
+            required: true
+        },
+        node: {
+            type: Object,
+            default: () => ({
+                requests: {}
+            })
+        },
+        fetchCoordinator: {
+            type: Object,
+            default: null
+        },
         sort: {
             default: 'editions',
         },

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -194,16 +194,44 @@ export default {
     },
     props: {
         /** @type {import('../utils').ClassificationNode} */
-        node: Object,
-        parent: Object,
+        node: {
+            type: Object,
+            required: true
+        },
+        parent: {
+            type: Object,
+            required: true
+        },
 
-        labels: Array,
+        labels: {
+            type: Array,
+            default: () => []
+        },
         /** @type {import('../utils').ClassificationTree} */
-        classification: Object,
-        expandBookshelf: Function,
-        features: Object,
-        filter: String,
-        sort: String,
+        classification: {
+            type: Object,
+            required: true
+        },
+        expandBookshelf: {
+            type: Function,
+            required: true
+        },
+        features: {
+            type: Object,
+            default: () => ({
+                book3d: true,
+                cover: 'image',
+                shelfLabel: 'slider',
+            })
+        },
+        filter: {
+            type: String,
+            default: ''
+        },
+        sort: {
+            type: String,
+            default: ''
+        },
     },
 
     data() {

--- a/openlibrary/components/LibraryExplorer/components/ShelfIndex.vue
+++ b/openlibrary/components/LibraryExplorer/components/ShelfIndex.vue
@@ -29,7 +29,10 @@
 <script>
 export default {
     props: {
-        node: Object,
+        node: {
+            type: Object,
+            required: true
+        },
     },
 
     computed: {

--- a/openlibrary/components/LibraryExplorer/components/ShelfLabel.vue
+++ b/openlibrary/components/LibraryExplorer/components/ShelfLabel.vue
@@ -28,7 +28,10 @@ import ShelfIndex from './ShelfIndex.vue';
 export default {
     components: { RightArrowIcon, ShelfIndex },
     props: {
-        node: Object
+        node: {
+            type: Object,
+            required: true
+        }
     },
 
     computed: {

--- a/openlibrary/components/LibraryExplorer/components/ShelfProgressBar.vue
+++ b/openlibrary/components/LibraryExplorer/components/ShelfProgressBar.vue
@@ -19,8 +19,14 @@
 <script>
 export default {
     props: {
-        sections: Array,
-        index: Number,
+        sections: {
+            type: Array,
+            required: true
+        },
+        index: {
+            type: Number,
+            required: true
+        },
     },
 };
 </script>

--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -7,7 +7,7 @@
       <MergeTable
         ref="mergeTable"
         :olids="olids"
-        :show_diffs="show_diffs"
+        :show-diffs="showDiffs"
         :primary="primary"
       />
       <div class="action-bar">
@@ -38,7 +38,7 @@
         <div id="diffs-toggle">
           <label>
             <input
-              v-model="show_diffs"
+              v-model="showDiffs"
               type="checkbox"
               title="Show textual differences"
             >
@@ -73,7 +73,8 @@ export default {
         },
         primary: {
             type: String,
-            required: false
+            required: false,
+            default: ''
         },
         canmerge: {
             type: String,
@@ -86,7 +87,7 @@ export default {
             url: new URL(location.toString()),
             mergeStatus: LOADING,
             mergeOutput: null,
-            show_diffs: false,
+            showDiffs: false,
             comment: ''
         };
     },

--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -51,7 +51,10 @@ import _ from 'lodash';
 
 export default {
     props: {
-        roles: Array
+        roles: {
+            type: Array,
+            default: () => []
+        }
     },
     computed: {
         fields() {

--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -58,7 +58,10 @@ import ISBN from 'isbn3';
 
 export default {
     props: {
-        edition: Object
+        edition: {
+            type: Object,
+            default: () => ({})
+        }
     },
     computed: {
         publish_year() {

--- a/openlibrary/components/MergeUI/ExcerptsTable.vue
+++ b/openlibrary/components/MergeUI/ExcerptsTable.vue
@@ -34,7 +34,10 @@ import _ from 'lodash';
 
 export default {
     props: {
-        excerpts: Array
+        excerpts: {
+            type: Array,
+            default: () => []
+        }
     },
     computed: {
         fields() {

--- a/openlibrary/components/MergeUI/MergeRow.vue
+++ b/openlibrary/components/MergeUI/MergeRow.vue
@@ -13,7 +13,7 @@
         :merged="merged"
         :cell-selected="cellSelected"
         :class="{ [`wrap-${field.replace(/\|/g, '--')}`]: true }"
-        :show_diffs="show_diffs"
+        :show-diffs="showDiffs"
       />
       <MergeRowField
         v-else-if="field in record"
@@ -21,7 +21,7 @@
         :value="record[field]"
         :merged="merged"
         :class="{ selected: cellSelected && cellSelected(record, field) }"
-        :show_diffs="show_diffs"
+        :show-diffs="showDiffs"
       />
       <MergeRowEditionField
         v-else-if="field == 'editions'"
@@ -67,24 +67,29 @@ export default {
         },
         editions: {
             type: Array,
+            required: true
         },
         lists: {
             type: Object,
+            default: null
         },
         bookshelves: {
             type: Object,
+            default: null
         },
         ratings: {
             type: Object,
+            default: null
         },
         cellSelected: {
-            type: Function
+            type: Function,
+            default: null
         },
         merged: {
             type: Object,
-            required: false
+            default: null
         },
-        show_diffs: {
+        showDiffs: {
             type: Boolean
         }
     },

--- a/openlibrary/components/MergeUI/MergeRowEditionField.vue
+++ b/openlibrary/components/MergeUI/MergeRowEditionField.vue
@@ -43,7 +43,7 @@ export default {
         },
         merged: {
             type: Object,
-            required: false
+            default: null
         }
     },
 };

--- a/openlibrary/components/MergeUI/MergeRowField.vue
+++ b/openlibrary/components/MergeUI/MergeRowField.vue
@@ -110,7 +110,7 @@
       :title="JSON.stringify(value)"
       :left="value.value || value"
       :right="merged ? ((field in merged && merged[field].value) || merged[field] || '') : (value.value || value)"
-      :show_diffs="show_diffs"
+      :show-diffs="showDiffs"
     />
 
     <!-- Defaults -->
@@ -118,7 +118,7 @@
       v-else-if="typeof(value) == 'string'"
       :left="value"
       :right="merged ? (merged[field] || '') : value"
-      :show_diffs="show_diffs"
+      :show-diffs="showDiffs"
     />
     <div v-else-if="typeof(value) == 'number'">
       {{ value }}
@@ -150,9 +150,9 @@ export default {
         },
         merged: {
             type: Object,
-            required: false
+            default: null
         },
-        show_diffs: {
+        showDiffs: {
             type: Boolean
         }
     },

--- a/openlibrary/components/MergeUI/MergeRowJointField.vue
+++ b/openlibrary/components/MergeUI/MergeRowJointField.vue
@@ -7,7 +7,7 @@
       :value="record[field]"
       :merged="merged"
       :class="{ selected: cellSelected && cellSelected(record, field) }"
-      :show_diffs="show_diffs"
+      :show-diffs="showDiffs"
     />
   </div>
 </template>
@@ -29,13 +29,14 @@ export default {
             required: true
         },
         cellSelected: {
-            type: Function
+            type: Function,
+            default: null
         },
         merged: {
             type: Object,
-            required: false
+            default: null
         },
-        show_diffs: {
+        showDiffs: {
             type: Boolean
         }
     },

--- a/openlibrary/components/MergeUI/MergeRowReferencesField.vue
+++ b/openlibrary/components/MergeUI/MergeRowReferencesField.vue
@@ -53,16 +53,19 @@ export default {
         },
         lists: {
             type: Object,
+            default: null
         },
         bookshelves: {
             type: Object,
+            default: null
         },
         ratings: {
             type: Object,
+            default: null
         },
         merged: {
             type: Object,
-            required: false
+            default: null
         }
     },
 };

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -24,7 +24,7 @@
         :class="{ selected: selected[record.key]}"
         :cell-selected="isCellUsed"
         :merged="merge ? merge.record : null"
-        :show_diffs="show_diffs"
+        :show-diffs="showDiffs"
       >
         <template #pre>
           <td
@@ -107,9 +107,15 @@ export default {
         MergeRow
     },
     props: {
-        olids: Array,
-        show_diffs: Boolean,
-        primary: String
+        olids: {
+            type: Array,
+            required: true
+        },
+        showDiffs: Boolean,
+        primary: {
+            type: String,
+            default: ''
+        }
     },
     data() {
         return {

--- a/openlibrary/components/MergeUI/TextDiff.vue
+++ b/openlibrary/components/MergeUI/TextDiff.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show_diffs">
+  <div v-if="showDiffs">
     <span
       v-for="(part, i) in diff"
       :key="i"
@@ -16,9 +16,15 @@ import {diffChars, diffWordsWithSpace} from 'diff';
 
 export default {
     props: {
-        left: String,
-        right: String,
-        show_diffs: Boolean,
+        left: {
+            type: String,
+            default: ''
+        },
+        right: {
+            type: String,
+            default: ''
+        },
+        showDiffs: Boolean,
         resolution: {
             default: 'char',
             validator: val => ['char', 'word'].includes(val),

--- a/openlibrary/components/ObservationForm.vue
+++ b/openlibrary/components/ObservationForm.vue
@@ -5,7 +5,7 @@
   >
     <SavedTags
       :all-selected-values="allSelectedValues"
-      :work-key="work_key"
+      :work-key="workKey"
       :username="username"
     />
     <CategorySelector
@@ -23,7 +23,7 @@
       :multi-select="selectedObservation.multi_choice"
       :values="selectedObservation.values"
       :all-selected-values="allSelectedValues"
-      :work-key="work_key"
+      :work-key="workKey"
       :username="username"
     />
   </div>
@@ -72,7 +72,7 @@ export default {
          * @example
          * /works/OL123W
          */
-        work_key: {
+        workKey: {
             type: String,
             required: true
         },

--- a/openlibrary/macros/ObservationsModal.html
+++ b/openlibrary/macros/ObservationsModal.html
@@ -27,7 +27,7 @@ $if reload_id:
           <h2>$_("My Book Review")</h2>
           <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        $:render_component('ObservationForm', asyncDefer=True, attrs=dict(schema=dict(get_observations()), observations=dict(work.get_users_observations(username)), work_key=work.key, username=username))
+        $:render_component('ObservationForm', asyncDefer=True, attrs={'schema': dict(get_observations()), 'observations': dict(work.get_users_observations(username)), 'work-key': work.key, 'username': username})
       </div>
     </div>
 </div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -159,7 +159,7 @@ $:macros.HiddenSaveButton("addWork")
                     <div id="hiddenWorkIdentifiers"></div>
                     <div id="identifiers-display-works">
                         $ admin = str(bool(ctx.user) and ctx.user.is_super_librarian_or_higher())
-                        $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenWorkIdentifiers', id_config_string=work_config.identifiers, input_prefix='work--identifiers', multiple='true', admin=admin))
+                        $:render_component('IdentifiersInput', attrs={'assigned-ids-string': work.get_identifiers().values(), 'output-selector': '#hiddenWorkIdentifiers', 'id-config-string': work_config.identifiers, 'input-prefix': 'work--identifiers', 'multiple': 'true', 'admin': admin})
                     </div>
                 </fieldset>
             </div>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -455,7 +455,7 @@ $ })
                 $ id_dict = dict((id.name, id) for id in edition_config.identifiers)
                 $ popular = ["ocaid", "isbn_10", "isbn_13", "lccn", "librivox", "oclc_numbers", "project_gutenberg"]
 
-                $:render_component('IdentifiersInput', attrs=dict(id_config_string=edition_config.identifiers, assigned_ids_string=book.get_identifiers().values(), input_prefix='edition--identifiers', output_selector='#hiddenEditionIdentifiers', multiple='true', popular_ids=popular,admin=str(is_privileged_user)))
+                $:render_component('IdentifiersInput', attrs={'id-config-string': edition_config.identifiers, 'assigned-ids-string': book.get_identifiers().values(), 'input-prefix': 'edition--identifiers', 'output-selector': '#hiddenEditionIdentifiers', 'multiple': 'true', 'popular-ids': popular, 'admin': str(is_privileged_user)})
             </div>
         </div>
     </div>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -107,7 +107,7 @@ $:macros.HiddenSaveButton("addAuthor")
                         <div id="hiddenAuthorIdentifiers"></div>
                         <div id="identifiers-display">
                             $ admin = ctx.user.is_super_librarian_or_higher()
-                            $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=dict(page.remote_ids),output_selector='#hiddenAuthorIdentifiers', admin=str(admin), input_prefix='author--remote_ids', id_config_string=author_config.identifiers))
+                            $:render_component('IdentifiersInput', attrs={'assigned-ids-string': dict(page.remote_ids), 'output-selector': '#hiddenAuthorIdentifiers', 'admin': str(admin), 'input-prefix': 'author--remote_ids', 'id-config-string': author_config.identifiers})
                         </div>
                         <br>
                         <fieldset class="major">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13455

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

This PR fixes the Vue lint warnings related to `vue/require-default-prop` and `vue/prop-name-casing`.

### Technical
- Added appropriate `default` values or `required: true` to Vue props based on how each prop is used.
- Renamed snake_case Vue props to camelCase.
- Updated the corresponding template and component call sites to use kebab-case attributes.
- Preserved optional prop behavior where absence is meaningful.

### Testing
- Ran `git diff --check` successfully.
- Manually verified the updated prop names and their corresponding call sites.
- Verified that obsolete snake_case prop names are no longer used in the affected components.

### Stakeholders
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->