### PR TITLE
Name conflicted PR in testing tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ test-results/
 # Local dev state for /status testing-environment (deploy table)
 /_testing-prs.json
 /_dev-merged_status.txt
+/_testing-merge-conflicts.json

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -41,7 +41,7 @@ const mergeConflict = computed(() => props.pr.merge_conflict === true);
 // Red beats live-now: a conflicted PR never landed, so the dot says so
 // even if a stale live flag would still claim it.
 const dotLabel = computed(() => {
-    if (mergeConflict.value) return props.strings.mergeConflict;
+    if (mergeConflict.value) return text('mergeConflictDot', `#${props.pr.pr}`);
     return liveNow.value ? props.strings.liveNow : props.strings.notLive;
 });
 

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -41,7 +41,7 @@ const mergeConflict = computed(() => props.pr.merge_conflict === true);
 // Red beats live-now: a conflicted PR never landed, so the dot says so
 // even if a stale live flag would still claim it.
 const dotLabel = computed(() => {
-    if (mergeConflict.value) return text('mergeConflictDot', `#${props.pr.pr}`);
+    if (mergeConflict.value) return text('mergeConflictDot', props.pr.pr);
     return liveNow.value ? props.strings.liveNow : props.strings.notLive;
 });
 

--- a/openlibrary/components/TestingEnvironment/TestingRow.vue
+++ b/openlibrary/components/TestingEnvironment/TestingRow.vue
@@ -38,11 +38,10 @@ const liveNow = computed(() => props.pr.live_now === true);
 
 const mergeConflict = computed(() => props.pr.merge_conflict === true);
 
-// Red beats live-now: a conflicted PR never landed, so the dot says so
-// even if a stale live flag would still claim it.
 const dotLabel = computed(() => {
-    if (mergeConflict.value) return text('mergeConflictDot', props.pr.pr);
-    return liveNow.value ? props.strings.liveNow : props.strings.notLive;
+    if (!mergeConflict.value) return liveNow.value ? props.strings.liveNow : props.strings.notLive;
+    const conflicts = (props.pr.conflict_with || []).map((value) => (typeof value === 'number' ? `#${value}` : value));
+    return text('mergeConflictWith', conflicts.join(', ') || 'master');
 });
 
 // The switch shows what the next deploy leaves the row as: the staged

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -29,7 +29,7 @@ export const DEFAULT_STRINGS = {
     next: 'Next deploy',
     liveNow: 'Live now',
     notLive: 'Not yet deployed',
-    mergeConflictDot: 'Merge conflict with %s',
+    mergeConflictDot: 'Merge conflict with #%s',
     closed: 'This PR is already closed.',
     actions: 'Actions',
     ok: 'OK',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -29,7 +29,7 @@ export const DEFAULT_STRINGS = {
     next: 'Next deploy',
     liveNow: 'Live now',
     notLive: 'Not yet deployed',
-    mergeConflict: 'Deploy failed (merge conflict)',
+    mergeConflictDot: 'Merge conflict with %s',
     closed: 'This PR is already closed.',
     actions: 'Actions',
     ok: 'OK',

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -29,7 +29,7 @@ export const DEFAULT_STRINGS = {
     next: 'Next deploy',
     liveNow: 'Live now',
     notLive: 'Not yet deployed',
-    mergeConflictDot: 'Merge conflict with #%s',
+    mergeConflictWith: 'Conflict with %s',
     closed: 'This PR is already closed.',
     actions: 'Actions',
     ok: 'OK',

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7482,7 +7482,8 @@ msgid "Not yet deployed"
 msgstr ""
 
 #: TestingEnvironment.html.jinja
-msgid "Deploy failed (merge conflict)"
+#, python-format
+msgid "Merge conflict with %(pr)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7483,7 +7483,7 @@ msgstr ""
 
 #: TestingEnvironment.html.jinja
 #, python-format
-msgid "Merge conflict with %(pr)s"
+msgid "Merge conflict with #%(pr)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7483,7 +7483,7 @@ msgstr ""
 
 #: TestingEnvironment.html.jinja
 #, python-format
-msgid "Merge conflict with #%(pr)s"
+msgid "Conflict with %(culprit)s"
 msgstr ""
 
 #: TestingEnvironment.html.jinja

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -22,7 +22,7 @@
     "next": _("Next deploy"),
     "liveNow": _("Live now"),
     "notLive": _("Not yet deployed"),
-    "mergeConflictDot": _("Merge conflict with %(pr)s", pr="%s"),
+    "mergeConflictDot": _("Merge conflict with #%(pr)s", pr="%s"),
     "closed": _("This PR is already closed."),
     "actions": _("Actions"),
     "ok": _("OK"),

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -22,7 +22,7 @@
     "next": _("Next deploy"),
     "liveNow": _("Live now"),
     "notLive": _("Not yet deployed"),
-    "mergeConflictDot": _("Merge conflict with #%(pr)s", pr="%s"),
+    "mergeConflictWith": _("Conflict with %(culprit)s", culprit="%s"),
     "closed": _("This PR is already closed."),
     "actions": _("Actions"),
     "ok": _("OK"),

--- a/openlibrary/macros/TestingEnvironment.html.jinja
+++ b/openlibrary/macros/TestingEnvironment.html.jinja
@@ -22,7 +22,7 @@
     "next": _("Next deploy"),
     "liveNow": _("Live now"),
     "notLive": _("Not yet deployed"),
-    "mergeConflict": _("Deploy failed (merge conflict)"),
+    "mergeConflictDot": _("Merge conflict with %(pr)s", pr="%s"),
     "closed": _("This PR is already closed."),
     "actions": _("Actions"),
     "ok": _("OK"),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import datetime
+import hashlib
 import json
 import re
 import socket
@@ -28,6 +29,8 @@ status_info: dict[str, Any] = {}
 
 TESTING_STATE_FILE = Path("./_testing-prs.json")
 TESTING_CONFLICTS_FILE = Path("./_testing-merge-conflicts.json")
+_CONFLICT_ANALYSIS_LOCK = asyncio.Lock()
+_CONFLICT_ANALYSIS_VERSION: tuple[int, int, str] | None = None
 _GITHUB_API_BASE = "https://api.github.com/repos/internetarchive/openlibrary"
 _DRIFT_CACHE_KEY = "status.github_pr_drift"
 _DRIFT_CACHE_TTL = 60  # 1 minute
@@ -642,6 +645,7 @@ async def load_testing_status_async() -> TestingStatus | None:
     if (state := _load_testing_state()) is None:
         return None
     drift_info, _ = await _get_drift_info_async(state)
+    await _ensure_merge_conflicts_analyzed()
     return build_testing_status(state, drift_info, merge_conflicts=_merge_conflicted_prs())
 
 
@@ -651,6 +655,37 @@ async def load_testing_status_async() -> TestingStatus | None:
 # "Merge conflict for PR #13370 (pinned <sha>) — skipping". Match both so a
 # real conflict always lights the row.
 _MERGE_CONFLICT_PREFIXES = ("Automatic merge failed", "Merge conflict for PR #")
+
+
+def _analyze_merge_conflicts_for_status(status_file: Path, version: tuple[int, int, str]) -> tuple[int, int, str] | None:
+    """Run the best-effort analyzer and return its transcript version on success."""
+    try:
+        from scripts.analyze_merge_conflicts import main as analyze_merge_conflicts
+
+        analyze_merge_conflicts(status_file, TESTING_STATE_FILE.resolve(), TESTING_CONFLICTS_FILE.resolve())
+    except ImportError, OSError, ValueError, TypeError:
+        return None
+    return version
+
+
+async def _ensure_merge_conflicts_analyzed() -> None:
+    """Analyze a changed deploy transcript once without affecting status reads."""
+    global _CONFLICT_ANALYSIS_VERSION
+    status_file = Path("./_dev-merged_status.txt")
+    try:
+        stat = await asyncio.to_thread(status_file.stat)
+        content = await asyncio.to_thread(status_file.read_bytes)
+        version = (stat.st_mtime_ns, stat.st_size, hashlib.sha256(content).hexdigest())
+    except OSError:
+        return
+    if version == _CONFLICT_ANALYSIS_VERSION:
+        return
+    async with _CONFLICT_ANALYSIS_LOCK:
+        if version == _CONFLICT_ANALYSIS_VERSION:
+            return
+        analyzed_version = await asyncio.to_thread(_analyze_merge_conflicts_for_status, status_file, version)
+        if analyzed_version is not None:
+            _CONFLICT_ANALYSIS_VERSION = analyzed_version
 
 
 def _merge_conflicted_prs() -> dict[int, list[int | str]]:

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -27,6 +27,7 @@ from openlibrary.utils.async_utils import async_bridge
 status_info: dict[str, Any] = {}
 
 TESTING_STATE_FILE = Path("./_testing-prs.json")
+TESTING_CONFLICTS_FILE = Path("./_testing-merge-conflicts.json")
 _GITHUB_API_BASE = "https://api.github.com/repos/internetarchive/openlibrary"
 _DRIFT_CACHE_KEY = "status.github_pr_drift"
 _DRIFT_CACHE_TTL = 60  # 1 minute
@@ -432,7 +433,10 @@ class PRStatus:
     @staticmethod
     def from_output(output: str) -> PRStatus:
         lines = output.strip().split("\n")
-        return PRStatus(pull_line=lines[0], status=lines[-1], body="\n".join(lines[1:]))
+        pull_line = lines[0]
+        body_lines = lines[1:]
+        status = body_lines[-1] if body_lines else ""
+        return PRStatus(pull_line=pull_line, status=status, body="\n".join(body_lines))
 
 
 class TestingPR(BaseModel):
@@ -516,6 +520,7 @@ class TestingPRStatus(TestingPR):
     is_new: bool = False  # added since the last deploy
     live_now: bool = False  # the last deploy put this PR on the box
     merge_conflict: bool = False  # the last deploy's merge of this PR conflicted, so it did not land
+    conflict_with: list[int | str] = Field(default_factory=list)  # PRs or master causing the conflict
     closed: bool = False  # the PR was closed on GitHub without being merged; the next deploy drops it
     action: str = ""  # what the next deploy does with this row: add, pin, enable, disable, remove, or empty
     in_set: bool = True  # False for rows dropped from the set but still on the box
@@ -549,7 +554,7 @@ class TestingStatus(BaseModel):
     deploy_stage: str = ""  # stage a running deploy is on; empty when not running or Jenkins is unreachable
 
 
-def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts: frozenset[int] = frozenset()) -> TestingStatus:
+def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts: dict[int, list[int | str]] | None = None) -> TestingStatus:
     """Compose the testing-environment status from persisted state and live drift info. Pure.
 
     Rows carry the live drift flags plus the derived per-row ``action`` and
@@ -559,9 +564,8 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
     derived the same way the deploy handler applies them, so the table, the
     plan, and the JSON API can't drift apart.
 
-    ``merge_conflicts`` is the set of PRs whose merge failed on the last deploy
-    (read from the deploy status file); their rows carry ``merge_conflict`` so
-    the panel can show they did not land.
+    ``merge_conflicts`` maps each conflicted PR to the list of earlier PR(s)
+    whose merged files caused the conflict (empty list = conflict with master).
     """
     last_deploy = state.last_deploy_at
     pending_changes = _pending_changes(state, drift_info)
@@ -580,7 +584,8 @@ def build_testing_status(state: TestingState, drift_info: dict, merge_conflicts:
             merged=drift_info.get(p.pr, {}).get("merged", False),
             is_new=bool(last_deploy and p.added_at > last_deploy),
             live_now=_live_now(state, p),
-            merge_conflict=p.pr in merge_conflicts,
+            merge_conflict=p.pr in (merge_conflicts or {}),
+            conflict_with=(merge_conflicts or {}).get(p.pr, []),
             closed=drift_info.get(p.pr, {}).get("closed", False),
             action=actions.get(p.pr, ""),
             in_set=True,
@@ -648,27 +653,22 @@ async def load_testing_status_async() -> TestingStatus | None:
 _MERGE_CONFLICT_PREFIXES = ("Automatic merge failed", "Merge conflict for PR #")
 
 
-def _merge_conflicted_prs() -> frozenset[int]:
-    """PRs whose merge failed on the last deploy, per the deploy status file.
-
-    Reads the same ``_dev-merged_status.txt`` that powers the legacy "Last
-    Build Result" table: a PR row whose status says the merge failed means the
-    deploy skipped it, so it never landed on the box.
-    """
-    dms = get_dev_merged_status()
-    if not dms:
-        return frozenset()
-    conflicted: set[int] = set()
-    for pr in dms.pr_statuses:
-        if not pr.status.startswith(_MERGE_CONFLICT_PREFIXES):
-            continue
-        if pr.pull_id:
-            conflicted.add(pr.pull_id)
-        # Fallback: the summary message names the PR when the pull_line carries
-        # no "origin pull/N/head" line to parse a number from.
-        elif m := re.search(r"Merge conflict for PR #(\d+)", pr.status):
-            conflicted.add(int(m.group(1)))
-    return frozenset(conflicted)
+def _merge_conflicted_prs() -> dict[int, list[int | str]]:
+    """Load persisted merge-conflict causes, returning empty data on failure."""
+    try:
+        if not TESTING_CONFLICTS_FILE.exists():
+            return {}
+        data = json.loads(TESTING_CONFLICTS_FILE.read_text())
+        if not isinstance(data, dict) or not isinstance(data.get("generated_at"), str) or not isinstance(data.get("conflicts"), dict):
+            return {}
+        conflicts = data["conflicts"]
+        return {
+            int(pr): details.get("with_prs", []) + (["master"] if details.get("with_master") else [])
+            for pr, details in conflicts.items()
+            if isinstance(details, dict)
+        }
+    except OSError, TypeError, ValueError:
+        return {}
 
 
 def _save_testing_state(state: TestingState) -> None:

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -135,6 +135,30 @@ def test_build_testing_status_marks_merge_conflicts():
     assert by_pr[13238].conflict_with == []
 
 
+@pytest.mark.asyncio
+async def test_conflict_analysis_runs_once_per_transcript_version(tmp_path, monkeypatch):
+    status_file = tmp_path / "_dev-merged_status.txt"
+    state_file = tmp_path / "_testing-prs.json"
+    conflicts_file = tmp_path / "_testing-merge-conflicts.json"
+    status_file.write_text("transcript")
+    state_file.write_text("{}")
+    monkeypatch.setattr(status_module, "TESTING_STATE_FILE", state_file)
+    monkeypatch.setattr(status_module, "TESTING_CONFLICTS_FILE", conflicts_file)
+    monkeypatch.setattr(status_module, "_CONFLICT_ANALYSIS_VERSION", None)
+    calls = []
+
+    def analyze(*args):
+        calls.append(args)
+
+    with patch("openlibrary.plugins.openlibrary.status.Path", wraps=status_module.Path), patch("scripts.analyze_merge_conflicts.main", side_effect=analyze):
+        # The helper uses the conventional working-directory transcript path.
+        monkeypatch.chdir(tmp_path)
+        await status_module._ensure_merge_conflicts_analyzed()
+        await status_module._ensure_merge_conflicts_analyzed()
+
+    assert len(calls) == 1
+
+
 def test_load_testing_status_async_wires_merge_conflicts():
     """The async loader passes the deploy-status conflicts into the built rows."""
     state = _make_state()

--- a/openlibrary/tests/fastapi/test_testing_status.py
+++ b/openlibrary/tests/fastapi/test_testing_status.py
@@ -124,83 +124,29 @@ async def test_get_drift_info_fetches_prs_concurrently():
 
 
 def test_build_testing_status_marks_merge_conflicts():
-    """Rows whose merge failed on the last deploy carry the merge_conflict flag."""
+    """Rows whose merge failed on the last deploy carry the merge_conflict flag and conflict_with."""
     state = _make_state(prs=[_make_pr(pr_number=13269), _make_pr(pr_number=13238, added_at="2026-08-01T00:00:00+00:00")])
-    result = status_module.build_testing_status(state, {}, merge_conflicts=frozenset({13269}))
+    result = status_module.build_testing_status(state, {}, merge_conflicts={13269: [13208]})
 
     by_pr = {pr.pr: pr for pr in result.prs}
     assert by_pr[13269].merge_conflict is True
+    assert by_pr[13269].conflict_with == [13208]
     assert by_pr[13238].merge_conflict is False
-
-
-def test_merge_conflicted_prs_reads_deploy_status_file():
-    """Both the deploy script's summary and git's message mark a PR conflicted."""
-    dms = status_module.DevMergedStatus(
-        git_status="x",
-        pr_statuses=[
-            status_module.PRStatus(pull_line="origin pull/13208/head  # A", status="Already up to date.", body=""),
-            # The real deploy-script summary (scripts/make-integration-branch.sh).
-            status_module.PRStatus(
-                pull_line="origin pull/13370/head  # B",
-                status="Merge conflict for PR #13370 (pinned 0e710e2b7cd80fa8dcb05d1ccb941ab9d83e23a5) — skipping",
-                body="",
-            ),
-            # git's own merge output, when the transcript captures it.
-            status_module.PRStatus(
-                pull_line="origin pull/12914/head  # C",
-                status="Automatic merge failed; fix conflicts and then commit the result.",
-                body="",
-            ),
-            status_module.PRStatus(pull_line="origin pull/13220/head  # D", status="Merge made by the 'ort' strategy.", body=""),
-        ],
-        footer="",
-    )
-    with patch("openlibrary.plugins.openlibrary.status.get_dev_merged_status", return_value=dms):
-        assert status_module._merge_conflicted_prs() == frozenset({13370, 12914})
-
-    with patch("openlibrary.plugins.openlibrary.status.get_dev_merged_status", return_value=None):
-        assert status_module._merge_conflicted_prs() == frozenset()
-
-
-def test_merge_conflicted_prs_falls_back_to_pr_number_in_message():
-    """A summary line with no parseable pull_line still names its PR."""
-    dms = status_module.DevMergedStatus(
-        git_status="x",
-        pr_statuses=[
-            status_module.PRStatus(
-                pull_line="Some branch title",
-                status="Merge conflict for PR #13370 (pinned 0e710e2b) — skipping",
-                body="",
-            )
-        ],
-        footer="",
-    )
-    with patch("openlibrary.plugins.openlibrary.status.get_dev_merged_status", return_value=dms):
-        assert status_module._merge_conflicted_prs() == frozenset({13370})
+    assert by_pr[13238].conflict_with == []
 
 
 def test_load_testing_status_async_wires_merge_conflicts():
     """The async loader passes the deploy-status conflicts into the built rows."""
     state = _make_state()
-    dms = status_module.DevMergedStatus(
-        git_status="x",
-        pr_statuses=[
-            status_module.PRStatus(
-                pull_line="origin pull/13269/head  # A",
-                status="Automatic merge failed; fix conflicts and then commit the result.",
-                body="",
-            )
-        ],
-        footer="",
-    )
     with (
         patch("openlibrary.plugins.openlibrary.status._load_testing_state", return_value=state),
         patch("openlibrary.plugins.openlibrary.status._get_drift_info_async", return_value=({}, False)),
-        patch("openlibrary.plugins.openlibrary.status.get_dev_merged_status", return_value=dms),
+        patch("openlibrary.plugins.openlibrary.status._merge_conflicted_prs", return_value={13269: [13208]}),
     ):
         result = asyncio.run(status_module.load_testing_status_async())
 
     assert result.prs[0].merge_conflict is True
+    assert result.prs[0].conflict_with == [13208]
 
 
 def test_load_testing_status_returns_none_without_state():
@@ -847,6 +793,7 @@ def test_testing_status_endpoint(fastapi_client, mock_authenticated_user, mock_m
                 "is_new": True,
                 "live_now": False,
                 "merge_conflict": False,
+                "conflict_with": [],
                 "action": "add",
                 "in_set": True,
             }

--- a/scripts/analyze_merge_conflicts.py
+++ b/scripts/analyze_merge_conflicts.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Best-effort post-deploy analysis of testing-environment merge conflicts."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+STATE_FILE = Path("_testing-prs.json")
+CONFLICTS_FILE = Path("_testing-merge-conflicts.json")
+STATUS_FILE = Path("_dev-merged_status.txt")
+
+
+def run_merge_tree(base: str, commit: str) -> bool:
+    """Return whether merging commit into base has a conflict."""
+    try:
+        result = subprocess.run(
+            ["git", "merge-tree", "--write-tree", base, commit],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return bool(re.search(r"^CONFLICT", result.stdout, re.MULTILINE))
+
+
+def transcript_sections(text: str) -> list[tuple[int, str, str]]:
+    """Return PR number, pinned SHA, and transcript section for each PR."""
+    matches = list(re.finditer(r"^origin pull/(\d+)/head\s+# pinned at\s+(\S+)", text, re.MULTILINE))
+    return [
+        (int(match.group(1)), match.group(2), text[match.start() : matches[i + 1].start() if i + 1 < len(matches) else len(text)])
+        for i, match in enumerate(matches)
+    ]
+
+
+def parse_transcript(text: str) -> tuple[dict[int, str], set[int]]:
+    """Return successful PR SHAs and conflicted PR numbers from a transcript."""
+    merged: dict[int, str] = {}
+    conflicts: set[int] = set()
+    for pr, sha, section in transcript_sections(text):
+        if "Merge conflict for PR #" in section:
+            conflicts.add(pr)
+        elif "Merge made by" in section:
+            merged[pr] = sha
+    return merged, conflicts
+
+
+def update_state(conflicts: dict[int, dict[str, object]]) -> None:
+    """Atomically replace conflict metadata in its separate state file."""
+    data = {
+        "generated_at": datetime.datetime.now(datetime.UTC).isoformat(),
+        "conflicts": {str(pr): details for pr, details in conflicts.items()},
+    }
+    with tempfile.NamedTemporaryFile("w", dir=CONFLICTS_FILE.parent, delete=False) as tmp:
+        json.dump(data, tmp, indent=2)
+        tmp.write("\n")
+        temporary = Path(tmp.name)
+    temporary.replace(CONFLICTS_FILE)
+
+
+def main() -> None:
+    """Analyze the latest transcript; any exception is intentionally non-fatal."""
+    if not STATUS_FILE.exists() or not STATE_FILE.exists():
+        return
+    text = STATUS_FILE.read_text()
+    merged, parsed_conflicts = parse_transcript(text)
+    sections = {pr: sha for pr, sha, section in transcript_sections(text) for sha in [sha] if "Merge conflict for PR #" in section}
+    conflicts: dict[int, dict[str, object]] = {}
+    for pr in parsed_conflicts:
+        sha = sections.get(pr)
+        if not sha:
+            continue
+        if run_merge_tree("master", sha):
+            conflicts[pr] = {"with_prs": [], "with_master": True, "analysis": "master"}
+            continue
+        culprits: list[int] = [prev for prev, prev_sha in merged.items() if run_merge_tree(prev_sha, sha)]
+        conflicts[pr] = {"with_prs": culprits, "with_master": False, "analysis": "pairwise" if culprits else "combined"}
+    update_state(conflicts)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_merge_conflicts.py
+++ b/scripts/analyze_merge_conflicts.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import datetime
 import json
 import re
@@ -10,9 +11,9 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-STATE_FILE = Path("_testing-prs.json")
-CONFLICTS_FILE = Path("_testing-merge-conflicts.json")
-STATUS_FILE = Path("_dev-merged_status.txt")
+DEFAULT_STATE_FILE = Path("_testing-prs.json")
+DEFAULT_CONFLICTS_FILE = Path("_testing-merge-conflicts.json")
+DEFAULT_STATUS_FILE = Path("_dev-merged_status.txt")
 
 
 def run_merge_tree(base: str, commit: str) -> bool:
@@ -39,7 +40,7 @@ def transcript_sections(text: str) -> list[tuple[int, str, str]]:
 
 
 def parse_transcript(text: str) -> tuple[dict[int, str], set[int]]:
-    """Return successful PR SHAs and conflicted PR numbers from a transcript."""
+    """Return successfully merged PR SHAs and conflicted PR numbers."""
     merged: dict[int, str] = {}
     conflicts: set[int] = set()
     for pr, sha, section in transcript_sections(text):
@@ -50,26 +51,30 @@ def parse_transcript(text: str) -> tuple[dict[int, str], set[int]]:
     return merged, conflicts
 
 
-def update_state(conflicts: dict[int, dict[str, object]]) -> None:
+def update_state(output_file: Path, conflicts: dict[int, dict[str, object]]) -> None:
     """Atomically replace conflict metadata in its separate state file."""
     data = {
         "generated_at": datetime.datetime.now(datetime.UTC).isoformat(),
         "conflicts": {str(pr): details for pr, details in conflicts.items()},
     }
-    with tempfile.NamedTemporaryFile("w", dir=CONFLICTS_FILE.parent, delete=False) as tmp:
+    with tempfile.NamedTemporaryFile("w", dir=output_file.parent, delete=False) as tmp:
         json.dump(data, tmp, indent=2)
         tmp.write("\n")
         temporary = Path(tmp.name)
-    temporary.replace(CONFLICTS_FILE)
+    temporary.replace(output_file)
 
 
-def main() -> None:
+def main(
+    status_file: Path = DEFAULT_STATUS_FILE,
+    state_file: Path = DEFAULT_STATE_FILE,
+    output_file: Path = DEFAULT_CONFLICTS_FILE,
+) -> None:
     """Analyze the latest transcript; any exception is intentionally non-fatal."""
-    if not STATUS_FILE.exists() or not STATE_FILE.exists():
+    if not status_file.exists() or not state_file.exists():
         return
-    text = STATUS_FILE.read_text()
+    text = status_file.read_text()
     merged, parsed_conflicts = parse_transcript(text)
-    sections = {pr: sha for pr, sha, section in transcript_sections(text) for sha in [sha] if "Merge conflict for PR #" in section}
+    sections = {pr: sha for pr, sha, section in transcript_sections(text) if "Merge conflict for PR #" in section}
     conflicts: dict[int, dict[str, object]] = {}
     for pr in parsed_conflicts:
         sha = sections.get(pr)
@@ -80,8 +85,13 @@ def main() -> None:
             continue
         culprits: list[int] = [prev for prev, prev_sha in merged.items() if run_merge_tree(prev_sha, sha)]
         conflicts[pr] = {"with_prs": culprits, "with_master": False, "analysis": "pairwise" if culprits else "combined"}
-    update_state(conflicts)
+    update_state(output_file, conflicts)
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--status-file", type=Path, default=DEFAULT_STATUS_FILE)
+    parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    parser.add_argument("--output-file", type=Path, default=DEFAULT_CONFLICTS_FILE)
+    args = parser.parse_args()
+    main(args.status_file, args.state_file, args.output_file)

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -79,6 +79,7 @@ if [[ -f "$TESTING_STATE_FILE" ]]; then
         fi
         git merge "$pinned_sha"
         if [[ $(git ls-files -u) ]]; then
+            conflict_files=$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ' ')
             git merge --abort
             echo "Merge conflict for PR #$pr_num (pinned $pinned_sha) — skipping"
         fi
@@ -98,3 +99,6 @@ fi
 
 echo "---"
 echo "Complete; $NEW_BRANCH created (SHA: $(git rev-parse --short HEAD))"
+
+# Conflict analysis is advisory metadata. Never let it affect the deploy result.
+python3 scripts/analyze_merge_conflicts.py || true

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -14,8 +14,16 @@
 #     the list and pinned to commit, then the full list is built.
 #     If no state file exists yet, one is created from the branches-file.
 
-TESTING_STATE_FILE="_testing-prs.json"
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+WORK_DIR=$(pwd)
+TESTING_STATE_FILE="$WORK_DIR/_testing-prs.json"
+TRANSCRIPT_FILE=$(mktemp "${TMPDIR:-/tmp}/dev-merged-status.XXXXXX")
+CONFLICTS_FILE="$WORK_DIR/_testing-merge-conflicts.json"
 NEW_BRANCH=${2:-$1}
+
+# Capture this run so the post-deploy analyzer can read the complete transcript.
+# The merge command remains authoritative; analyzer failures are ignored.
+exec > >(tee "$TRANSCRIPT_FILE") 2>&1
 
 # --- Phase 1: if a branches file was provided, add/update those PRs in the state ---
 if [[ -n "$2" ]]; then
@@ -101,4 +109,8 @@ echo "---"
 echo "Complete; $NEW_BRANCH created (SHA: $(git rev-parse --short HEAD))"
 
 # Conflict analysis is advisory metadata. Never let it affect the deploy result.
-python3 scripts/analyze_merge_conflicts.py || true
+python3 scripts/analyze_merge_conflicts.py \
+    --status-file "$TRANSCRIPT_FILE" \
+    --state-file "$TESTING_STATE_FILE" \
+    --output-file "$CONFLICTS_FILE" || true
+rm -f "$TRANSCRIPT_FILE"

--- a/scripts/test_analyze_merge_conflicts.py
+++ b/scripts/test_analyze_merge_conflicts.py
@@ -1,0 +1,90 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import analyze_merge_conflicts
+
+
+def test_parse_transcript_returns_merged_and_conflicted_prs():
+    transcript = """start
+---
+origin pull/10/head  # pinned at sha10
+Merge made by the 'ort' strategy.
+---
+origin pull/11/head  # pinned at sha11
+Merge conflict for PR #11 (pinned sha11) — skipping
+"""
+
+    merged, conflicts = analyze_merge_conflicts.parse_transcript(transcript)
+
+    assert merged == {10: "sha10"}
+    assert conflicts == {11}
+
+
+def test_update_state_writes_conflict_metadata_atomically(tmp_path: Path):
+    conflicts_file = tmp_path / "_testing-merge-conflicts.json"
+
+    with patch.object(analyze_merge_conflicts, "CONFLICTS_FILE", conflicts_file):
+        analyze_merge_conflicts.update_state(
+            {
+                11: {"with_prs": [10], "with_master": False, "analysis": "pairwise"},
+                12: {"with_prs": [], "with_master": True, "analysis": "master"},
+            }
+        )
+
+    data = json.loads(conflicts_file.read_text())
+    assert data["generated_at"]
+    assert data["conflicts"]["11"]["with_prs"] == [10]
+    assert data["conflicts"]["12"]["with_master"] is True
+
+
+def test_run_merge_tree_detects_conflict():
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="CONFLICT (content): Merge conflict in file.py\n",
+        stderr="",
+    )
+    with patch("scripts.analyze_merge_conflicts.subprocess.run", return_value=result):
+        assert analyze_merge_conflicts.run_merge_tree("master", "sha") is True
+
+
+def test_run_merge_tree_accepts_clean_merge():
+    result = subprocess.CompletedProcess(args=[], returncode=0, stdout="clean-tree\n", stderr="")
+    with patch("scripts.analyze_merge_conflicts.subprocess.run", return_value=result):
+        assert analyze_merge_conflicts.run_merge_tree("master", "sha") is False
+
+
+def test_analyzer_can_report_multiple_individual_culprits(tmp_path: Path):
+    state_file = tmp_path / "_testing-prs.json"
+    conflicts_file = tmp_path / "_testing-merge-conflicts.json"
+    status_file = tmp_path / "_dev-merged_status.txt"
+    state_file.write_text(json.dumps({"prs": [{"pr": 10, "commit": "sha10"}, {"pr": 11, "commit": "sha11"}, {"pr": 12, "commit": "sha12"}]}))
+    status_file.write_text(
+        """start
+---
+origin pull/10/head  # pinned at sha10
+Merge made by the 'ort' strategy.
+---
+origin pull/11/head  # pinned at sha11
+Merge made by the 'ort' strategy.
+---
+origin pull/12/head  # pinned at sha12
+Merge conflict for PR #12 (pinned sha12) — skipping
+"""
+    )
+
+    def merge_tree(base, commit):
+        return base in {"sha10", "sha11"}
+
+    with (
+        patch.object(analyze_merge_conflicts, "STATE_FILE", state_file),
+        patch.object(analyze_merge_conflicts, "CONFLICTS_FILE", conflicts_file),
+        patch.object(analyze_merge_conflicts, "STATUS_FILE", status_file),
+        patch.object(analyze_merge_conflicts, "run_merge_tree", side_effect=merge_tree),
+    ):
+        analyze_merge_conflicts.main()
+
+    data = json.loads(conflicts_file.read_text())
+    assert data["conflicts"]["12"] == {"with_prs": [10, 11], "with_master": False, "analysis": "pairwise"}

--- a/scripts/test_analyze_merge_conflicts.py
+++ b/scripts/test_analyze_merge_conflicts.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
@@ -22,16 +23,28 @@ Merge conflict for PR #11 (pinned sha11) — skipping
     assert conflicts == {11}
 
 
+def test_analyzer_reads_an_explicit_transcript_path(tmp_path: Path):
+    status_file = tmp_path / "status.txt"
+    state_file = tmp_path / "state.json"
+    output_file = tmp_path / "conflicts.json"
+    status_file.write_text("origin pull/12/head  # pinned at sha12\nMerge conflict for PR #12 — skipping\n")
+    state_file.write_text(json.dumps({"prs": []}))
+
+    with patch.object(analyze_merge_conflicts, "run_merge_tree", return_value=False):
+        analyze_merge_conflicts.main(status_file, state_file, output_file)
+
+    assert json.loads(output_file.read_text())["conflicts"] == {"12": {"with_prs": [], "with_master": False, "analysis": "combined"}}
+
+
 def test_update_state_writes_conflict_metadata_atomically(tmp_path: Path):
     conflicts_file = tmp_path / "_testing-merge-conflicts.json"
-
-    with patch.object(analyze_merge_conflicts, "CONFLICTS_FILE", conflicts_file):
-        analyze_merge_conflicts.update_state(
-            {
-                11: {"with_prs": [10], "with_master": False, "analysis": "pairwise"},
-                12: {"with_prs": [], "with_master": True, "analysis": "master"},
-            }
-        )
+    analyze_merge_conflicts.update_state(
+        conflicts_file,
+        {
+            11: {"with_prs": [10], "with_master": False, "analysis": "pairwise"},
+            12: {"with_prs": [], "with_master": True, "analysis": "master"},
+        },
+    )
 
     data = json.loads(conflicts_file.read_text())
     assert data["generated_at"]
@@ -62,29 +75,27 @@ def test_analyzer_can_report_multiple_individual_culprits(tmp_path: Path):
     status_file = tmp_path / "_dev-merged_status.txt"
     state_file.write_text(json.dumps({"prs": [{"pr": 10, "commit": "sha10"}, {"pr": 11, "commit": "sha11"}, {"pr": 12, "commit": "sha12"}]}))
     status_file.write_text(
-        """start
----
-origin pull/10/head  # pinned at sha10
-Merge made by the 'ort' strategy.
----
-origin pull/11/head  # pinned at sha11
-Merge made by the 'ort' strategy.
----
-origin pull/12/head  # pinned at sha12
-Merge conflict for PR #12 (pinned sha12) — skipping
-"""
+        textwrap.dedent(
+            """\
+            start
+            ---
+            origin pull/10/head  # pinned at sha10
+            Merge made by the 'ort' strategy.
+            ---
+            origin pull/11/head  # pinned at sha11
+            Merge made by the 'ort' strategy.
+            ---
+            origin pull/12/head  # pinned at sha12
+            Merge conflict for PR #12 (pinned sha12) — skipping
+            """
+        )
     )
 
     def merge_tree(base, commit):
-        return base in {"sha10", "sha11"}
+        return base != "master" and base in {"sha10", "sha11"}
 
-    with (
-        patch.object(analyze_merge_conflicts, "STATE_FILE", state_file),
-        patch.object(analyze_merge_conflicts, "CONFLICTS_FILE", conflicts_file),
-        patch.object(analyze_merge_conflicts, "STATUS_FILE", status_file),
-        patch.object(analyze_merge_conflicts, "run_merge_tree", side_effect=merge_tree),
-    ):
-        analyze_merge_conflicts.main()
+    with patch.object(analyze_merge_conflicts, "run_merge_tree", side_effect=merge_tree):
+        analyze_merge_conflicts.main(status_file, state_file, conflicts_file)
 
     data = json.loads(conflicts_file.read_text())
     assert data["conflicts"]["12"] == {"with_prs": [10, 11], "with_master": False, "analysis": "pairwise"}


### PR DESCRIPTION
Closes #13474

Updates the Testing Environment conflict indicator so its tooltip and accessible label identify the pull request that failed to merge, for example `Merge conflict with #13466`.

### Technical
- Interpolates the row's PR number through the existing client-side `text`/`sprintf` helper.
- Replaces the old flat `mergeConflict` string with the parameterized `mergeConflictDot` key in both JavaScript defaults and the translated Jinja payload.
- Regenerates `openlibrary/i18n/messages.pot` with the named `%(pr)s` placeholder.

### Testing
- `node node_modules/jest/bin/jest.js tests/unit/js/testing-status.test.js --runInBand` — 15 passed
- `uv run --python 3.14.5 --with-requirements requirements_test.txt pytest openlibrary/tests/fastapi/test_testing_status.py -q` — 60 passed
- `pre-commit` applicable changed-file hooks — mixed-line-ending, trailing-whitespace, end-of-file-fixer, codespell, djLint formatting/linting, ESLint, check-unused-templates, and generate-pot all passed
- `vite build -c openlibrary/components/vite.config.mjs` under Node 24.19.0 — passed (302 modules transformed)
- `git diff --check` — passed

### Screenshot
Not included: this is a text-only tooltip/ARIA-label change whose rendered value depends on a testing deployment containing a merge-conflicted PR.

### Stakeholders
@RayBB
