### PR TITLE
fix(vue): resolve remaining component lint warnings (#13477)

### DIFF
--- a/openlibrary/components/BulkSearch/components/MatchRow.vue
+++ b/openlibrary/components/BulkSearch/components/MatchRow.vue
@@ -14,10 +14,10 @@
           title="View results in Open Library"
         >🔎</a>
         <BookCard
-          v-for="(doc, index) in bookMatch.solrDocs.docs"
-          :key="index"
+          v-for="(doc, docIndex) in bookMatch.solrDocs.docs"
+          :key="docIndex"
           :doc="doc"
-          :is-primary="index === 0"
+          :is-primary="docIndex === 0"
         />
         <NoBookCard v-if="bookMatch.solrDocs.numFound===0" />
       </div>

--- a/openlibrary/components/LibraryExplorer/components/BookRoom.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookRoom.vue
@@ -176,6 +176,7 @@ export default {
             type: String
         },
         features: {
+            type: Object,
             default: () => ({
                 book3d: true,
                 cover: 'image',

--- a/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
+++ b/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
@@ -43,6 +43,7 @@ export default {
             validator: val => ['image', 'text'].includes(val)
         }
     },
+    emits: ['load'],
 
     computed: {
         byline() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -142,6 +142,7 @@ export default {
             default: null
         },
         sort: {
+            type: String,
             default: 'editions',
         },
         limit: {

--- a/openlibrary/components/MergeUI/MergeRowField.vue
+++ b/openlibrary/components/MergeUI/MergeRowField.vue
@@ -146,6 +146,7 @@ export default {
             required: true
         },
         value: {
+            type: [Object, Array, String, Number],
             required: true
         },
         merged: {

--- a/openlibrary/components/ObservationForm/components/CategorySelector.vue
+++ b/openlibrary/components/ObservationForm/components/CategorySelector.vue
@@ -18,8 +18,9 @@
         <template #before>
           <span
             class="symbol"
-            v-html="displaySymbol(o.label)"
-          />
+          >
+            {{ displaySymbol(o.label) }}
+          </span>
         </template>
       </OLChip>
     </div>
@@ -74,6 +75,7 @@ export default {
             default: 0
         }
     },
+    emits: ['update-selected'],
     data: function() {
         return {
             /**
@@ -116,19 +118,19 @@ export default {
             return this.selectedId === id;
         },
         /**
-         * Returns an HTML code denoting what symbol to display in a book tag type chip.
+         * Returns the Unicode symbol to display in a book tag type chip.
          *
          * Will return a bullet symbol if no book tags of a chip's type have been selected,
          * and a heavy checkmark otherwise.
          *
-         * @returns {String} An HTML code representing selections of a type.
+         * @returns {String} A Unicode symbol representing selections of a type.
          */
         displaySymbol: function(type) {
             if (this.allSelectedValues[type] && this.allSelectedValues[type].length) {
-                // &#10004; - Heavy checkmark
-                return '&#10004;';
+                // ✔ - Heavy checkmark
+                return '✔';
             }
-            return '&bull;';
+            return '•';
         }
     }
 };

--- a/openlibrary/components/ObservationForm/components/OLChip.vue
+++ b/openlibrary/components/ObservationForm/components/OLChip.vue
@@ -51,6 +51,7 @@ export default {
             default: ''
         }
     },
+    emits: ['update-selected'],
     data: function() {
         return {
             /**


### PR DESCRIPTION
## Summary

Resolves the 9 remaining Vue lint warnings tracked in #13477 (0 errors, 9 warnings) with single-line style fixes:

- **OLCarousel.vue** - add `type: String` to the `sort` prop (`vue/require-prop-types`)
- **BookRoom.vue** - add `type: Object` to the `features` prop (`vue/require-prop-types`)
- **MergeRowField.vue** - add union `type` to the `value` prop (`vue/require-prop-types`)
- **FlatBookCover.vue** - declare `emits: ['load']` (`vue/require-explicit-emits`)
- **CategorySelector.vue** - declare `emits: ['update-selected']`; replace `v-html` with text interpolation; `displaySymbol()` returns the Unicode chars ? / . instead of HTML entities (`vue/require-explicit-emits`, `vue/no-v-html`)
- **OLChip.vue** - declare `emits: ['update-selected']` (`vue/require-explicit-emits`)
- **MatchRow.vue** - rename loop variable `index` to `docIndex` (`vue/no-template-shadow`)

## Acceptance criteria

- [x] All 9 warnings addressed (no inline disables used)
- [x] No behavior change: chips still render ? / . (now via text interpolation of the Unicode chars)

## Notes

- JS/Vue only; no Python files touched.
- `npx eslint .` should now report 0 warnings on first-party Vue components.

Closes #13477.