### PR TITLE
Add script for backfilling `store_index` IDs

### DIFF
--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -27,7 +27,7 @@ def find_upper_bound():
     query = """
         SELECT MIN(new_id) as min from store_index
     """
-    return list(oldb.query(query))[0]["min"]
+    return next(iter(oldb.query(query)))["min"]
 
 
 def backfill_rows(lower_bound, upper_bound):

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -1,0 +1,73 @@
+"""
+Backfills new ID column in the `store_index` table.
+"""
+import argparse
+import time
+
+import web
+
+from openlibrary.core import db
+from openlibrary.setup import setup_for_script
+from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_requested
+
+DEFAULT_CONFIG_PATH = "conf/openlibrary.yml"
+DEFAULT_BATCH_SIZE = 20_000
+
+def init(conf_path):
+    init_signal_handler()
+    setup_for_script(conf_path)
+    web.ctx.ip = web.ctx.ip or "127.0.0.1"
+
+def find_upper_bound():
+    oldb = db.get_db()
+
+    query = """
+        SELECT MIN(new_id) as min from store_index
+    """
+    return list(oldb.query(query))[0]["min"]
+
+def backfill_rows(lower_bound, upper_bound):
+    oldb = db.get_db()
+
+    query = """
+        UPDATE store_index SET new_id = id
+        WHERE id BETWEEN $lo AND $hi AND new_id IS NULL
+    """
+    oldb.query(query, vars={"lo": lower_bound, "hi": upper_bound})
+
+def main(args):
+    init(args.config)
+
+    # Find min new_id (for upper limit)
+    max_upper_bound = find_upper_bound()
+
+    # Backfill new IDs in batches
+    lower_bound = 0
+    while lower_bound < max_upper_bound and not was_shutdown_requested():
+        start = time.perf_counter()
+        backfill_rows(lower_bound, lower_bound + args.batch_size)
+        lower_bound += args.batch_size
+        elapsed = time.perf_counter() - start
+        print(f"Chunk updated in {elapsed:.6f} seconds")
+
+def _parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to openlibrary configuration yaml"
+    )
+    p.add_argument(
+        "-b",
+        "--batch-size",
+        default=DEFAULT_BATCH_SIZE,
+        type=int
+    )
+    p.set_defaults(func=main)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    args.func(args)

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -18,7 +18,7 @@ DEFAULT_BATCH_SIZE = 20_000
 def init(conf_path):
     init_signal_handler()
     setup_for_script(conf_path)
-    web.ctx.ip = web.ctx.ip or "127.0.0.1"
+    web.ctx.ip = getattr(web.ctx, "ip", None) or "127.0.0.1"
 
 
 def find_upper_bound():

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -1,6 +1,7 @@
 """
 Backfills new ID column in the `store_index` table.
 """
+
 import argparse
 import time
 
@@ -13,10 +14,12 @@ from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_re
 DEFAULT_CONFIG_PATH = "conf/openlibrary.yml"
 DEFAULT_BATCH_SIZE = 20_000
 
+
 def init(conf_path):
     init_signal_handler()
     setup_for_script(conf_path)
     web.ctx.ip = web.ctx.ip or "127.0.0.1"
+
 
 def find_upper_bound():
     oldb = db.get_db()
@@ -26,6 +29,7 @@ def find_upper_bound():
     """
     return list(oldb.query(query))[0]["min"]
 
+
 def backfill_rows(lower_bound, upper_bound):
     oldb = db.get_db()
 
@@ -34,6 +38,7 @@ def backfill_rows(lower_bound, upper_bound):
         WHERE id BETWEEN $lo AND $hi AND new_id IS NULL
     """
     oldb.query(query, vars={"lo": lower_bound, "hi": upper_bound})
+
 
 def main(args):
     init(args.config)
@@ -50,20 +55,11 @@ def main(args):
         elapsed = time.perf_counter() - start
         print(f"Chunk updated in {elapsed:.6f} seconds")
 
+
 def _parse_args():
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument(
-        "-c",
-        "--config",
-        default=DEFAULT_CONFIG_PATH,
-        help="Path to openlibrary configuration yaml"
-    )
-    p.add_argument(
-        "-b",
-        "--batch-size",
-        default=DEFAULT_BATCH_SIZE,
-        type=int
-    )
+    p.add_argument("-c", "--config", default=DEFAULT_CONFIG_PATH, help="Path to openlibrary configuration yaml")
+    p.add_argument("-b", "--batch-size", default=DEFAULT_BATCH_SIZE, type=int)
     p.set_defaults(func=main)
     return p.parse_args()
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In support of #10921

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds script that will backfill new `new_id` column of the `store_index` table.  Script users should ensure that the correct configuration path is passed using the `-c` option.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
