### PR TITLE
Remove stray pytest debug output

### DIFF
--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -29,7 +29,7 @@ def create_stats_client(cfg=config):
             host, port = stats_server.rsplit(":", 1)
             return StatsClient(host, port)
         else:
-            logger.critical("Couldn't find statsd_server section in config")
+            logger.debug("Couldn't find statsd_server section in config")
             return False
     except Exception as e:
         logger.critical("Couldn't create stats client - %s", e, exc_info=True)

--- a/openlibrary/plugins/openlibrary/tests/conftest.py
+++ b/openlibrary/plugins/openlibrary/tests/conftest.py
@@ -8,7 +8,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    print("pytest_configure", config.getvalue("server"))
 
     if config.getvalue("server"):
         collect_ignore[:] = []


### PR DESCRIPTION
Closes #13450

fix: remove stray pytest debug output

### Technical

* Removed the leftover `pytest_configure` debug `print()`.
* Downgraded the missing `statsd_server` configuration log from `CRITICAL` to `DEBUG`.
* Existing StatsD initialization behavior remains unchanged when `statsd_server` is configured.

### Testing

Ran:

```bash
make test-py-uv
```

Result:

```text
5793 passed, 39 skipped, 5 deselected, 1 xfailed
```

Confirmed that the pytest output no longer contains:

```text
pytest_configure None
Couldn't find statsd_server section in config
```

### Stakeholders

@RayBB
