### PR TITLE
Back up /opt/openlibrary to openlibrary_previous before deploy swap

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -443,22 +443,41 @@ deploy_openlibrary() {
     tar -czf openlibrary_new.tar.gz openlibrary_new
 
     if [[ "$SKIP_OL_TRANSFER_CODE" != "1" ]]; then
-        if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary" "openlibrary_new"; then
+        if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary_new" "openlibrary_new"; then
             cleanup "${DEPLOY_DIR}/openlibrary"
             exit 1
         fi
+
         echo ""
-        # Fix file ownership + Make into a git repo so can easily track local mods
+        echo "Final swap..."
         for SERVER in $FQDNS; do
-            ssh $SERVER "
+            echo -n "   $SERVER ... "
+
+            # Fix file ownership, back up the current copy to openlibrary_previous, swap in the
+            # new one, then make it into a git repo so local mods are easy to track.
+            if OUTPUT=$(ssh $SERVER "
                 set -e
-                sudo chown -R root:staff /opt/openlibrary
-                sudo chmod -R g+rwX /opt/openlibrary
+                sudo chown -R root:staff /opt/openlibrary_new
+                sudo chmod -R g+rwX /opt/openlibrary_new
+
+                sudo rm -rf /opt/openlibrary_previous || true
+                if [ -d /opt/openlibrary ]; then
+                    sudo mv /opt/openlibrary /opt/openlibrary_previous
+                fi
+                sudo mv /opt/openlibrary_new /opt/openlibrary
+
                 cd /opt/openlibrary
                 sudo git init 2>&1 > /dev/null
                 sudo git add . > /dev/null
                 sudo git commit -m 'Deployed openlibrary' > /dev/null
-            "
+            "); then
+                echo "✓"
+            else
+                echo "⚠"
+                echo "$OUTPUT"
+                cleanup "${DEPLOY_DIR}/openlibrary"
+                exit 1
+            fi
         done
 
         if ! prune_docker image; then


### PR DESCRIPTION
Mirrors the olsystem_previous backup already done by deploy_olsystem, so we have a backup of any changes that might've been made.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

✅ Used this for the last deploy.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
