### PR TITLE
Rating a book no longer moves it off Currently Reading or Stopped Reading

### DIFF
--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -170,9 +170,14 @@ class Ratings(db.CommonExtras):
         if rating not in cls.VALID_STAR_RATINGS:
             return None
 
-        # Vote implies user read book; Update reading log status as "Already Read"
+        # Vote implies user read book, so shelve unshelved (or Want to Read) books
+        # as "Already Read". Never overwrite Currently Reading or Stopped Reading,
+        # where the patron has explicitly said otherwise.
         users_read_status_for_work = Bookshelves.get_users_read_status_of_work(username, work_id)
-        if users_read_status_for_work != Bookshelves.PRESET_BOOKSHELVES["Already Read"]:
+        if users_read_status_for_work in (
+            None,
+            Bookshelves.PRESET_BOOKSHELVES["Want to Read"],
+        ):
             Bookshelves.add(
                 username,
                 Bookshelves.PRESET_BOOKSHELVES["Already Read"],

--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
@@ -180,6 +180,16 @@ export class MyBooksDropper extends Dropper {
     }
 
     /**
+     * Returns the ID of the shelf that this dropper's book is currently on,
+     * or `null` if the book is unshelved.
+     *
+     * @returns {ReadingLogShelf|null}
+     */
+    getActiveShelfId() {
+        return this.readingLogForms.getActiveShelfId();
+    }
+
+    /**
      * Updates this dropper's primary button's state and display to show that a book is active on the
      * given shelf.
      *

--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
@@ -262,6 +262,20 @@ export class ReadingLogForms {
     }
 
     /**
+     * Returns the ID of the shelf that the book is currently on, or `null`
+     * if the book is unshelved.
+     *
+     * @returns {ReadingLogShelf|null}
+     */
+    getActiveShelfId() {
+        if (!this.primaryForm) {
+            return null;
+        }
+        const isShelved = this.primaryForm.querySelector('input[name=action]').value === 'remove';
+        return isShelved ? this.primaryForm.querySelector('input[name=bookshelf_id]').value : null;
+    }
+
+    /**
      * Updates the visibility of dropdown buttons, hiding the given button.
      *
      * All other dropdown buttons will be visible after this method exits.

--- a/openlibrary/plugins/openlibrary/js/star-ratings/index.js
+++ b/openlibrary/plugins/openlibrary/js/star-ratings/index.js
@@ -71,7 +71,12 @@ function handleRatingSubmission(event, form) {
                     // Find dropper that is associated with this star rating affordance:
                     const dropper = findDropperForWork(form.dataset.workKey);
                     if (dropper) {
-                        dropper.updateShelfDisplay(ReadingLogShelves.ALREADY_READ);
+                        // Mirrors the server, which only auto-shelves rated books as
+                        // "Already Read" when unshelved or on "Want to Read":
+                        const activeShelfId = dropper.getActiveShelfId();
+                        if (activeShelfId === null || activeShelfId === ReadingLogShelves.WANT_TO_READ) {
+                            dropper.updateShelfDisplay(ReadingLogShelves.ALREADY_READ);
+                        }
                     }
                 } else {  // A rating was deleted
                     clearButton.classList.add('hidden');

--- a/openlibrary/tests/core/test_ratings.py
+++ b/openlibrary/tests/core/test_ratings.py
@@ -5,7 +5,45 @@ Focuses on testing the pure mathematical functions that compute rating statistic
 These functions don't require database access and test the core rating logic.
 """
 
+from unittest.mock import patch
+
+import pytest
+
 from openlibrary.core.ratings import Ratings
+
+
+class TestAddAutoShelve:
+    """Test that rating a book only auto-shelves it as "Already Read" when
+    doing so doesn't overwrite an explicit shelf choice."""
+
+    WANT_TO_READ = 1
+    CURRENTLY_READING = 2
+    ALREADY_READ = 3
+    STOPPED_READING = 4
+
+    @pytest.mark.parametrize(
+        ("read_status", "should_auto_shelve"),
+        [
+            (None, True),  # Unshelved books are moved to Already Read
+            (WANT_TO_READ, True),  # ... as are Want to Read books
+            (CURRENTLY_READING, False),  # Explicit shelf choices are preserved
+            (STOPPED_READING, False),
+            (ALREADY_READ, False),  # Already there; nothing to do
+        ],
+    )
+    def test_add_only_auto_shelves_unshelved_and_want_to_read(self, read_status, should_auto_shelve):
+        with (
+            patch("openlibrary.core.ratings.db.get_db"),
+            patch("openlibrary.core.bookshelves.Bookshelves.get_users_read_status_of_work", return_value=read_status),
+            patch("openlibrary.core.bookshelves.Bookshelves.add") as bookshelves_add,
+            patch.object(Ratings, "get_users_rating_for_work", return_value=None),
+        ):
+            Ratings.add("testuser", 123, rating=4)
+
+        if should_auto_shelve:
+            bookshelves_add.assert_called_once_with("testuser", self.ALREADY_READ, 123, edition_id=None)
+        else:
+            bookshelves_add.assert_not_called()
 
 
 class TestComputeSortableRating:


### PR DESCRIPTION
Closes #13398

Fix: rating a book always shelved it as Already Read, even when the patron had it on Currently Reading or Stopped Reading. What happens now when a patron rates a book, by current shelf:

| Shelf when rating | Before | After |
|---|---|---|
| Not on a shelf | Moved to Already Read | Moved to Already Read (unchanged) |
| Want to Read | Moved to Already Read | Moved to Already Read (unchanged) |
| Currently Reading | Moved to Already Read | Stays on Currently Reading |
| Stopped Reading | Moved to Already Read | Stays on Stopped Reading |
| Already Read | No change | No change |

### Technical

The real fix is server side, in the rating write path in `Ratings.add()`, so it covers the book page, the API, and any future clients.

### Testing

- New parametrized test in `openlibrary/tests/core/test_ratings.py` covering all five states above, including rate-while-Currently-Reading.

### Screenshot

No visual changes; the fix changes which shelf a rating writes to, not how anything renders.

### Stakeholders
@mekarpeles @cdrini 
