### PR TITLE
Restore the Preview button for preview-only books outside the book page

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -151,13 +151,17 @@ $elif lending_state == 'checkedout':
   </div>
 
 $elif lending_state == 'preview_only':
+  $# PreviewSearchInside already provides a Preview button, so the secondary
+  $# case only needs a note explaining why there's no Read/Borrow button.
   $if secondary_action:
     $:macros.PreviewSearchInside(ocaid)
-  <div class="cta-button-group">
-    <p class="waitinglist-message">
-      <span>$_("Only a preview is available.")</span>
-    </p>
-  </div>
+    <div class="cta-button-group">
+      <p class="waitinglist-message">
+        <span>$_("Only a preview is available.")</span>
+      </p>
+    </div>
+  $else:
+    $:macros.BookPreview(ocaid, show_only=True)
 
 $else:
   $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.


### PR DESCRIPTION
Fixes a regression from #13314. No issue filed.

A preview-only book used to render a Preview call to action. #13314 replaced it with the sentence "Only a preview is available.", since on the book page the Preview and Search inside buttons sit right above it. But the sentence was added unconditionally while those buttons only render when `secondary_action` is true, so carousels, search results, and the editions table were left with a line saying a preview exists and no way to open it.

`LoanStatus` now splits the `preview_only` case on `secondary_action`. The book page keeps the behavior from #13314, and everywhere else falls back to `BookPreview` as before.

### Testing

View a preview-only book somewhere other than its own book page: a carousel, a search result, or the editions table on a work page. The Preview Only link is back.

### Screenshot

The `preview_only` state. Left is every surface that is not the book page, which is what this fixes; right is the book page, unchanged.

Before:

![preview_only before](https://raw.githubusercontent.com/lokesh/openlibrary/62ad230bde982e5b01461de6052b7747bf0f054a/preview-only-before.png)

After:

![preview_only after](https://raw.githubusercontent.com/lokesh/openlibrary/62ad230bde982e5b01461de6052b7747bf0f054a/preview-only-after.png)

<details>
<summary>All nine lending states, both values of <code>secondary_action</code></summary>

Only the `preview_only` cells differ. Rendered on a harness page with the real stylesheets, not a live book page, since dev has no preview-only book to point at.

Before:

![all lending states before](https://raw.githubusercontent.com/lokesh/openlibrary/62ad230bde982e5b01461de6052b7747bf0f054a/loanstatus-matrix-before.jpg)

After:

![all lending states after](https://raw.githubusercontent.com/lokesh/openlibrary/62ad230bde982e5b01461de6052b7747bf0f054a/loanstatus-matrix-after.jpg)

</details>

### Stakeholders

