### PR TITLE
fix: make /account/otp failures visible (real status codes + logging)

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -331,16 +331,64 @@ def _parse_low_auth_header():
     return access, secret
 
 
-def _require_s3_auth():
+#: HTTP status for each way an OTP request can be refused. These endpoints used
+#: to answer 200 for all of them, which made every failure invisible: a 200 is
+#: not an exception, so Sentry never saw one, and it is not an error status, so
+#: nothing in the request logs or the load balancer flagged it either. A caller
+#: that did not inspect the body could not tell success from failure at all.
+OTP_ERROR_STATUS: Final = {
+    "missing_or_invalid_authorization": "401 Unauthorized",
+    "unauthorized": "401 Unauthorized",
+    "auth_service_unavailable": "503 Service Unavailable",
+    "missing_keys": "400 Bad Request",
+    "challenge_failed": "403 Forbidden",
+    "ratelimit": "429 Too Many Requests",
+    "otp_mismatch": "401 Unauthorized",
+}
+
+
+def _mask_email(email: str) -> str:
+    """`alice@example.org` -> `al***@example.org`, so a log line is useful for
+    support without writing a patron's full address into the request logs."""
+    local, _, domain = (email or "").partition("@")
+    return f"{local[:2]}***@{domain}" if domain else "***"
+
+
+def _otp_error(operation: str, code: str, service_ip: str = "", email: str = "", **extra):
+    """Refuse an OTP request: set a real HTTP status, log it, return the body.
+
+    The JSON body keeps exactly the shape it had before, so existing callers that
+    only read `error` are unaffected; the status code and the log line are added
+    on top.
+
+    The log line is the point. Requests to these endpoints fan out across
+    ol-web0..3 behind haproxy, so without a greppable record naming the
+    `service_ip` the request actually presented, there is no way to tell which
+    head served a given call or why it was refused.
+    """
+    web.ctx.status = OTP_ERROR_STATUS.get(code, "400 Bad Request")
+    logger.warning(
+        "otp %s refused: error=%s service_ip=%r email=%s extra=%s",
+        operation,
+        code,
+        service_ip,
+        _mask_email(email),
+        extra or "-",
+    )
+    return delegate.RawText(json.dumps({"error": code, **extra}))
+
+
+def _require_s3_auth(operation: str):
     """Validate the request's IA S3 credentials. Returns None on success or a RawText error response."""
+    service_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR", "")
     try:
         s3_access, s3_secret = _parse_low_auth_header()
     except ValueError:
-        return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
+        return _otp_error(operation, "missing_or_invalid_authorization", service_ip)
     if "error" in (result := InternetArchiveAccount.s3auth(s3_access, s3_secret)):
         if result.get("code", 400) >= 500:
-            return delegate.RawText(json.dumps({"error": "auth_service_unavailable"}))
-        return delegate.RawText(json.dumps({"error": "unauthorized"}))
+            return _otp_error(operation, "auth_service_unavailable", service_ip)
+        return _otp_error(operation, "unauthorized", service_ip)
     return None
 
 
@@ -349,7 +397,7 @@ class otp_service_issue(delegate.page):
 
     def POST(self):
         web.header("Content-Type", "application/json")
-        if err := _require_s3_auth():
+        if err := _require_s3_auth("issue"):
             return err
 
         i = web.input(email="", ip="", challenge_url="", sendmail="true")
@@ -357,13 +405,13 @@ class otp_service_issue(delegate.page):
         i.email = i.email.replace(" ", "+").lower()
         i.service_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR")
         if missing_fields := [k for k in required_keys if not getattr(i, k)]:
-            return delegate.RawText(json.dumps({"error": "missing_keys", "missing_keys": missing_fields}))
+            return _otp_error("issue", "missing_keys", i.service_ip or "", i.email, missing_keys=missing_fields)
 
         # Challenge currently does not work due to Firewall/Proxy limitations
         if i.challenge_url and not OTP.verify_service(i.service_ip, i.challenge_url):
-            return delegate.RawText(json.dumps({"error": "challenge_failed"}))
+            return _otp_error("issue", "challenge_failed", i.service_ip, i.email)
         if error := OTP.is_ratelimited(service_ip=i.service_ip, email=i.email, ip=i.ip):
-            return delegate.RawText(json.dumps(error))
+            return _otp_error("issue", "ratelimit", i.service_ip, i.email, ratelimit=error["ratelimit"])
 
         otp = OTP.generate(i.service_ip, i.email, i.ip)
         if i.sendmail.lower() == "true":
@@ -373,6 +421,18 @@ class otp_service_issue(delegate.page):
                 subject="Your One Time Password",
                 message=web.safestr(f"Your one time password is: {otp.upper()}"),
             )
+        # Logged so an issue can be correlated with its later redeem. `service_ip`
+        # is an ingredient of the OTP's HMAC, so when a redeem fails with
+        # otp_mismatch, comparing this value against the redeem's is the first
+        # thing worth checking — and requests fan across ol-web0..3, so without a
+        # log line there is nothing to compare.
+        logger.info(
+            "otp issue ok: service_ip=%r email=%s ip=%r sendmail=%s",
+            i.service_ip,
+            _mask_email(i.email),
+            i.ip,
+            i.sendmail.lower() == "true",
+        )
         return delegate.RawText(json.dumps({"success": "issued"}))
 
 
@@ -381,7 +441,7 @@ class otp_service_redeem(delegate.page):
 
     def POST(self):
         web.header("Content-Type", "application/json")
-        if err := _require_s3_auth():
+        if err := _require_s3_auth("redeem"):
             return err
 
         required_keys = ("email", "ip", "service_ip", "otp")
@@ -389,10 +449,14 @@ class otp_service_redeem(delegate.page):
         i.email = i.email.replace(" ", "+").lower()
         i.service_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR")
         if missing_fields := [k for k in required_keys if not getattr(i, k)]:
-            return delegate.RawText(json.dumps({"error": "missing_keys", "missing_keys": missing_fields}))
+            return _otp_error("redeem", "missing_keys", i.service_ip or "", i.email, missing_keys=missing_fields)
         if OTP.is_valid(i.email, i.ip, i.service_ip, i.otp):
+            logger.info("otp redeem ok: service_ip=%r email=%s ip=%r", i.service_ip, _mask_email(i.email), i.ip)
             return delegate.RawText(json.dumps({"success": "redeemed"}))
-        return delegate.RawText(json.dumps({"error": "otp_mismatch"}))
+        # A mismatch is usually a typo, but it is also what a `service_ip` that
+        # differed between issue and redeem looks like — same payload, different
+        # HMAC. Log both so the two cases can be told apart.
+        return _otp_error("redeem", "otp_mismatch", i.service_ip, i.email)
 
 
 def _set_login_cookies(

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 from unittest import mock
@@ -448,6 +449,147 @@ class TestOtpServiceS3Auth:
         result = account.otp_service_redeem().POST()
         body = json.loads(result.rawtext)
         assert body == {"success": "redeemed"}
+
+
+class TestOtpFailuresAreVisible:
+    """Every refusal must carry a real HTTP status and a log line.
+
+    These endpoints used to answer `200 {"error": ...}` for every failure. A 200
+    is not an exception, so Sentry never saw one; it is not an error status, so
+    request logs and the load balancer did not flag it either. Requests also fan
+    across ol-web0..3 behind haproxy, so with nothing logged there was no way to
+    tell which head served a call or why it refused.
+    """
+
+    def _env(self, **extra):
+        return {
+            "HTTP_AUTHORIZATION": "LOW goodaccess:goodsecret",
+            "HTTP_X_FORWARDED_FOR": "1.2.3.4, 10.0.0.9",
+            **extra,
+        }
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_missing_auth_is_401(self, mock_web, mock_ia):
+        mock_web.ctx.env = {}
+        account.otp_service_issue().POST()
+        assert mock_web.ctx.status == "401 Unauthorized"
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_rejected_keys_are_401(self, mock_web, mock_ia):
+        mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
+        mock_web.ctx.env = self._env()
+        account.otp_service_issue().POST()
+        assert mock_web.ctx.status == "401 Unauthorized"
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_auth_service_outage_is_503(self, mock_web, mock_ia):
+        """A 5xx from xauthn is our problem, not the caller's — it must not be a
+        4xx that tells an integrator to go fix their credentials."""
+        mock_ia.s3auth.return_value = {"error": "service error", "code": 503}
+        mock_web.ctx.env = self._env()
+        account.otp_service_issue().POST()
+        assert mock_web.ctx.status == "503 Service Unavailable"
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_missing_service_ip_is_400(self, mock_web, mock_ia, mock_otp):
+        """No X-Forwarded-For means no service_ip. Callers hitting a web head
+        directly, bypassing nginx, see exactly this."""
+        mock_ia.s3auth.return_value = {"success": True}
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW goodaccess:goodsecret"}
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", challenge_url="", sendmail="false")
+        result = account.otp_service_issue().POST()
+        assert mock_web.ctx.status == "400 Bad Request"
+        assert json.loads(result.rawtext)["missing_keys"] == ["service_ip"]
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_ratelimit_is_429_and_keeps_its_body(self, mock_web, mock_ia, mock_otp):
+        mock_ia.s3auth.return_value = {"success": True}
+        mock_web.ctx.env = self._env()
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", challenge_url="", sendmail="false")
+        limit = {"ttl": 60, "key": "otp-client:1.2.3.4:email:test@example.com"}
+        mock_otp.is_ratelimited.return_value = {"error": "ratelimit", "ratelimit": limit}
+        result = account.otp_service_issue().POST()
+        assert mock_web.ctx.status == "429 Too Many Requests"
+        # The body shape is unchanged, so existing clients keep working.
+        assert json.loads(result.rawtext) == {"error": "ratelimit", "ratelimit": limit}
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_otp_mismatch_is_401(self, mock_web, mock_ia, mock_otp):
+        mock_ia.s3auth.return_value = {"success": True}
+        mock_web.ctx.env = self._env()
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", otp="wrong")
+        mock_otp.is_valid.return_value = False
+        result = account.otp_service_redeem().POST()
+        assert mock_web.ctx.status == "401 Unauthorized"
+        assert json.loads(result.rawtext) == {"error": "otp_mismatch"}
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_success_sets_no_error_status(self, mock_web, mock_ia, mock_otp):
+        mock_ia.s3auth.return_value = {"success": True}
+        mock_web.ctx.env = self._env()
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", challenge_url="", sendmail="false")
+        mock_otp.is_ratelimited.return_value = None
+        mock_otp.generate.return_value = "abc123"
+        result = account.otp_service_issue().POST()
+        assert json.loads(result.rawtext) == {"success": "issued"}
+        assert not isinstance(mock_web.ctx.status, str), "success must not set an error status"
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_refusal_logs_the_service_ip(self, mock_web, mock_ia, mock_otp, caplog):
+        """`service_ip` is an ingredient of the OTP's HMAC, so an issue/redeem
+        pair that disagrees about it fails forever with otp_mismatch. Logging it
+        is the only way to compare the two across web heads."""
+        mock_ia.s3auth.return_value = {"success": True}
+        mock_web.ctx.env = self._env()
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", otp="wrong")
+        mock_otp.is_valid.return_value = False
+        with caplog.at_level(logging.WARNING, logger="openlibrary.account"):
+            account.otp_service_redeem().POST()
+
+        assert "1.2.3.4, 10.0.0.9" in caplog.text
+        assert "otp_mismatch" in caplog.text
+        assert "redeem" in caplog.text
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_logs_do_not_contain_the_full_patron_email(self, mock_web, mock_ia, caplog):
+        mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
+        mock_web.ctx.env = self._env()
+        with caplog.at_level(logging.WARNING, logger="openlibrary.account"):
+            account.otp_service_issue().POST()
+        assert "test@example.com" not in caplog.text
+
+    def test_mask_email(self):
+        assert account._mask_email("alice@example.org") == "al***@example.org"
+        assert account._mask_email("a@b.c") == "a***@b.c"
+        assert account._mask_email("") == "***"
+        assert account._mask_email("notanemail") == "***"
+
+    def test_every_error_code_has_a_status(self):
+        """A code with no mapping silently degrades to 400. Keep them in step."""
+        emitted = {
+            "missing_or_invalid_authorization",
+            "unauthorized",
+            "auth_service_unavailable",
+            "missing_keys",
+            "challenge_failed",
+            "ratelimit",
+            "otp_mismatch",
+        }
+        assert emitted <= set(account.OTP_ERROR_STATUS)
 
 
 class TestParseLowAuthHeader:


### PR DESCRIPTION
`/account/otp/issue` and `/account/otp/redeem` answer **HTTP 200 with a JSON error body on every failure path**. `delegate.RawText` never raises, so a refusal is not an exception and Sentry never sees it; it is not an error status, so neither the request logs nor the load balancer flag it. Nothing is logged either.

The result is a failure mode that is invisible from every angle. Confirmed against production (`sendmail=false`, so no email was sent):

```
$ curl -s -w '\nHTTP=%{http_code}\n' -X POST \
    'https://openlibrary.org/account/otp/issue?email=…&ip=1.2.3.4&sendmail=false'
{"error": "missing_or_invalid_authorization"}
HTTP=200
```

A caller that doesn't inspect the body cannot tell success from failure at all — and at least one didn't. Lenny called `OTP.issue(...)` and discarded the return value, so patrons were told a one-time password had been emailed when Open Library had refused to send one. Nobody found out: not Sentry, not the OL logs, not Lenny's logs, not the patron. (Fixed on that side too: ArchiveLabs/lenny#201.)

This is made worse by fan-out. These requests spread across `ol-web0..3` behind `web_haproxy`, so with nothing logged there was no way to tell which head served a given call, or why it refused.

## What changed

**Real status codes.** One mapping, one helper:

| error | status |
|---|---|
| `missing_or_invalid_authorization`, `unauthorized`, `otp_mismatch` | `401` |
| `missing_keys` | `400` |
| `challenge_failed` | `403` |
| `ratelimit` | `429` |
| `auth_service_unavailable` | `503` |

**Logging, with `service_ip`.** Every refusal at `WARNING`, every success at `INFO`. `service_ip` is included deliberately: it's an ingredient of the OTP's HMAC —

```python
payload = f"{service_ip}:{client_email}:{client_ip}:{ts}"
```

— and it comes from the raw `X-Forwarded-For`, which nginx sets to `$remote_addr` and haproxy's `option forwardfor` then *appends* its own hop to. So an issue/redeem pair that disagrees about it by even one hop fails forever with `otp_mismatch`, and comparing the two sides was the first diagnostic step and previously impossible. Patron emails are masked (`al***@example.org`) in all log output.

## Compatibility

**JSON bodies are unchanged.** A client that only reads `error` keeps working exactly as before; the status code and log line are added on top. The `ratelimit` body still carries its `ratelimit` payload, and `missing_keys` still carries `missing_keys`.

Two things I checked rather than assumed:
- **nginx does not set `proxy_intercept_errors`** (grepped `docker/web_nginx.conf` and `olsystem/etc/nginx/`), so upstream 4xx/5xx bodies pass through untouched — the `error_page 429 = @429` block only catches nginx's own `limit_req` rejections, not the app's.
- **Lenny doesn't call `raise_for_status()`**, so the new codes don't break the existing integration; #201 makes it read the body properly regardless.

## Testing

- **11 new tests** (`TestOtpFailuresAreVisible`); `test_account.py` is **44 passed, 1 xfailed** in Docker.
- **Mutation-checked**: dropping the `web.ctx.status` assignment — i.e. the old behaviour — fails 6 of them, so these guards are known to bite.
- Full **pre-commit clean** (ruff check, ruff format, mypy, codespell, generate-pot).
- Wider sweep of `openlibrary/plugins/upstream/` + `openlibrary/core/`: 168 passed. The 3 failures in `test_addbook.py`/`test_models.py` **reproduce on unmodified `origin/master`** (verified by stashing) and are unrelated.
- One test pins that every emitted error code has a status mapping, so a new code can't silently degrade to 400.

No browser verification: these are machine-to-machine JSON endpoints with no frontend surface.
