### PR TITLE
Report per-item success/failure when drag-and-drop moving works/editions

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -343,8 +343,12 @@ SelectionManager.DROP_HANDLERS = [
             console.log('move', data);
             window.ILE.setStatusText('Working...');
             try {
-                await move_to_author(data.items, data.from, location.pathname.match(/OL\d+A/)[0]);
-                window.ILE.setStatusText('Completed!');
+                const { total, failed } = await move_to_author(data.items, data.from, location.pathname.match(/OL\d+A/)[0]);
+                if (failed) {
+                    window.ILE.setStatusText(`Something went wrong: ${failed}/${total} failed to save.`);
+                } else {
+                    window.ILE.setStatusText(`Completed! ${total}/${total} saved.`);
+                }
             } catch (e) {
                 window.ILE.setStatusText('Errored!');
                 throw e;
@@ -365,8 +369,12 @@ SelectionManager.DROP_HANDLERS = [
                     const ed = await fetch(`/books/${location.pathname.match(/OL\d+M/)[0]}.json`).then(r => r.json());
                     workOlid = ed.works[0].key.match(/OL\d+W/)[0];
                 }
-                await move_to_work(data.items, data.from, workOlid);
-                window.ILE.setStatusText('Completed!');
+                const { total, failed } = await move_to_work(data.items, data.from, workOlid);
+                if (failed) {
+                    window.ILE.setStatusText(`Something went wrong: ${failed}/${total} failed to save.`);
+                } else {
+                    window.ILE.setStatusText(`Completed! ${total}/${total} saved.`);
+                }
             } catch (e) {
                 window.ILE.setStatusText('Errored!');
                 throw e;

--- a/openlibrary/plugins/openlibrary/js/ile/utils/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/ol.js
@@ -5,13 +5,17 @@ import uniqBy from 'lodash/uniqBy';
 /** @typedef {OLID} EditionOLID */
 /** @typedef {OLID} AuthorOLID */
 
+/** @typedef {{total: Number, failed: Number}} MoveResult */
+
 /**
  * Move the given editions from one work to another.
  * @param {EditionOLID[]} edition_ids
  * @param {WorkOLID} old_work
  * @param {WorkOLID} new_work
+ * @returns {Promise<MoveResult>}
  */
 export async function move_to_work(edition_ids, old_work, new_work) {
+    let failed = 0;
     for (const olid of edition_ids) {
         const url = `/books/${olid}.json`;
         const record = await fetch(url).then(r => r.json());
@@ -19,9 +23,16 @@ export async function move_to_work(edition_ids, old_work, new_work) {
         record.works = [{key: `/works/${new_work}`}];
         record._comment = 'move to correct work';
         const r = await fetch(url, { method: 'PUT', body: JSON.stringify(record) });
-        // eslint-disable-next-line no-console
-        console.log(`moved ${olid}; ${r.status}`);
+        if (r.ok) {
+            // eslint-disable-next-line no-console
+            console.log(`moved ${olid}; ${r.status}`);
+        } else {
+            failed += 1;
+            // eslint-disable-next-line no-console
+            console.warn(`failed to move ${olid}; ${r.status}`);
+        }
     }
+    return { total: edition_ids.length, failed };
 }
 
 /**
@@ -29,8 +40,10 @@ export async function move_to_work(edition_ids, old_work, new_work) {
  * @param {WorkOLID[]} edition_ids
  * @param {AuthorOLID} old_author
  * @param {AuthorOLID} new_author
+ * @returns {Promise<MoveResult>}
  */
 export async function move_to_author(work_ids, old_author, new_author) {
+    let failed = 0;
     for (const olid of work_ids) {
         const url = `/works/${olid}.json`;
         const record = await fetch(url).then(r => r.json());
@@ -44,11 +57,18 @@ export async function move_to_author(work_ids, old_author, new_author) {
             }), a => a.author.key);
             record._comment = 'move to correct author';
             const r = await fetch(url, { method: 'PUT', body: JSON.stringify(record) });
-            // eslint-disable-next-line no-console
-            console.log(`moved ${olid}; ${r.status}`);
+            if (r.ok) {
+                // eslint-disable-next-line no-console
+                console.log(`moved ${olid}; ${r.status}`);
+            } else {
+                failed += 1;
+                // eslint-disable-next-line no-console
+                console.warn(`failed to move ${olid}; ${r.status}`);
+            }
         } else {
             // eslint-disable-next-line no-console
             console.warn(`${old_author} not in ${url}!`);
         }
     }
+    return { total: work_ids.length, failed };
 }

--- a/tests/unit/js/ol.test.js
+++ b/tests/unit/js/ol.test.js
@@ -1,0 +1,71 @@
+import { move_to_work, move_to_author } from '../../../openlibrary/plugins/openlibrary/js/ile/utils/ol.js';
+
+describe('move_to_work', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('reports no failures when all PUTs succeed', async() => {
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ json: () => Promise.resolve({ works: [] }) })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await move_to_work(['OL1M'], 'OL1W', 'OL2W');
+
+        expect(result).toEqual({ total: 1, failed: 0 });
+    });
+
+    it('counts PUTs that return a non-successful status as failed and warns', async() => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ json: () => Promise.resolve({ works: [] }) })
+            .mockResolvedValueOnce({ ok: false, status: 500 })
+            .mockResolvedValueOnce({ json: () => Promise.resolve({ works: [] }) })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await move_to_work(['OL1M', 'OL2M'], 'OL1W', 'OL2W');
+
+        expect(result).toEqual({ total: 2, failed: 1 });
+        expect(warnSpy).toHaveBeenCalledWith('failed to move OL1M; 500');
+        warnSpy.mockRestore();
+    });
+});
+
+describe('move_to_author', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    function workRecord() {
+        return { authors: [{ author: { key: '/authors/OL1A' } }] };
+    }
+
+    it('reports no failures when all PUTs succeed', async() => {
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ json: () => Promise.resolve(workRecord()) })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await move_to_author(['OL1W'], 'OL1A', 'OL2A');
+
+        expect(result).toEqual({ total: 1, failed: 0 });
+    });
+
+    it('counts PUTs that return a non-successful status as failed and warns', async() => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({ json: () => Promise.resolve(workRecord()) })
+            .mockResolvedValueOnce({ ok: false, status: 400 })
+            .mockResolvedValueOnce({ json: () => Promise.resolve(workRecord()) })
+            .mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await move_to_author(['OL1W', 'OL2W'], 'OL1A', 'OL2A');
+
+        expect(result).toEqual({ total: 2, failed: 1 });
+        expect(warnSpy).toHaveBeenCalledWith('failed to move OL1W; 400');
+        warnSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
The ILE drag-and-drop move-to-author/move-to-work flows always reported "Completed!" because fetch() doesn't reject on non-2xx PUT responses, masking save failures from the user.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Don't think this needs QA since the code is rather simple, but to test you can, in the local environment:
1. log in
2. Open two author pages on separate tabs
4. Log out on a separate tab, so we can get a 403 error when saving
5. Select a work by clicking the grey rectangle and then click-and-drag it to the other tab, and drop it on the author page

It should say "Something went wrong: 1/1 failed to save".

6. Log in again
7. Now try dragging/dropping the work

It should say "Completed! 1/1 saved."

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
