### PR TITLE
Only open the search modal on drop, not dragover, when dragging in text

### DIFF
--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -86,6 +86,13 @@ const COVER_PLACEHOLDER = '/static/images/icons/avatar_book-sm.png';
 // to /search is still allowed for it (handled by the length-only gates).
 const AUTOCOMPLETE_STOPWORDS = new Set(['the']);
 
+// A drag the trigger should accept: it carries plain text (a text selection
+// or a URL) and is not an ILE book selection, which stores JSON as text/plain.
+function isTextDrag(dataTransfer) {
+    const types = Array.from(dataTransfer?.types || []);
+    return types.includes('text/plain') && !types.includes('application/x.ile+json');
+}
+
 export class SearchModal extends LitElement {
     static properties = {
         open: { type: Boolean, reflect: true },
@@ -818,8 +825,10 @@ export class SearchModal extends LitElement {
         });
         // preventDefault (required for 'drop' to fire on this element at all)
         // and show the "copy" cursor so the drag doesn't look rejected while
-        // hovering over the trigger.
+        // hovering over the trigger. Non-text drags (files, images, ILE book
+        // selections) are left alone so they can't open an empty modal.
         trigger.addEventListener('dragover', (e) => {
+            if (!isTextDrag(e.dataTransfer)) return;
             e.preventDefault();
             e.dataTransfer.dropEffect = 'copy';
         });
@@ -827,10 +836,12 @@ export class SearchModal extends LitElement {
         // would pop the modal open before the patron has committed to the
         // drop) and forward the dropped text into the search input.
         trigger.addEventListener('drop', (e) => {
+            if (!isTextDrag(e.dataTransfer)) return;
             e.preventDefault();
-            if (!this.open) this._openModal('drag');
             const text = e.dataTransfer.getData('text/plain');
-            if (text) this._applyDroppedText(text);
+            if (!text) return;
+            if (!this.open) this._openModal('drag');
+            this._applyDroppedText(text);
         });
     }
 

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -816,12 +816,21 @@ export class SearchModal extends LitElement {
             e.preventDefault();
             this._openModal();
         });
-        // Open the modal when text is dragged over the trigger so the patron
-        // can complete the drop into the search input. Without this the modal
-        // never opens during a drag (clicking ends the drag) and the drop is lost.
+        // preventDefault (required for 'drop' to fire on this element at all)
+        // and show the "copy" cursor so the drag doesn't look rejected while
+        // hovering over the trigger.
         trigger.addEventListener('dragover', (e) => {
             e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
+        });
+        // Open the modal on drop (not dragover, which fires continuously and
+        // would pop the modal open before the patron has committed to the
+        // drop) and forward the dropped text into the search input.
+        trigger.addEventListener('drop', (e) => {
+            e.preventDefault();
             if (!this.open) this._openModal('drag');
+            const text = e.dataTransfer.getData('text/plain');
+            if (text) this._applyDroppedText(text);
         });
     }
 
@@ -1462,6 +1471,12 @@ export class SearchModal extends LitElement {
         e.preventDefault();
         const text = e.dataTransfer.getData('text/plain');
         if (!text) return;
+        this._applyDroppedText(text);
+    }
+
+    // Shared by the search-input's own @drop and the trigger button's drop
+    // handler (which opens the modal first, then forwards the text here).
+    _applyDroppedText(text) {
         this._query = text;
         const input = this.renderRoot.querySelector('.search-input');
         if (input) input.value = text;

--- a/tests/unit/js/searchModalTriggerDrag.test.js
+++ b/tests/unit/js/searchModalTriggerDrag.test.js
@@ -17,10 +17,14 @@ function setup() {
     return { modal, trigger };
 }
 
+function textTransfer(text) {
+    return { types: ['text/plain'], dropEffect: '', getData: jest.fn().mockReturnValue(text) };
+}
+
 describe('SearchModal trigger drag-and-drop', () => {
     test('dragover shows the copy cursor without opening the modal', () => {
         const { modal, trigger } = setup();
-        const dataTransfer = { dropEffect: '' };
+        const dataTransfer = textTransfer('dune');
 
         const preventDefault = dispatch(trigger, 'dragover', dataTransfer);
 
@@ -32,7 +36,7 @@ describe('SearchModal trigger drag-and-drop', () => {
 
     test('drop opens the modal and forwards the dropped text', () => {
         const { modal, trigger } = setup();
-        const dataTransfer = { getData: jest.fn().mockReturnValue('dune') };
+        const dataTransfer = textTransfer('dune');
 
         const preventDefault = dispatch(trigger, 'drop', dataTransfer);
 
@@ -44,7 +48,7 @@ describe('SearchModal trigger drag-and-drop', () => {
     test('drop does not reopen an already-open modal', () => {
         const { modal, trigger } = setup();
         modal.open = true;
-        const dataTransfer = { getData: jest.fn().mockReturnValue('dune') };
+        const dataTransfer = textTransfer('dune');
 
         dispatch(trigger, 'drop', dataTransfer);
 
@@ -54,11 +58,29 @@ describe('SearchModal trigger drag-and-drop', () => {
 
     test('drop with no text does not forward anything', () => {
         const { modal, trigger } = setup();
-        const dataTransfer = { getData: jest.fn().mockReturnValue('') };
+        const dataTransfer = textTransfer('');
 
         dispatch(trigger, 'drop', dataTransfer);
 
-        expect(modal._openModal).toHaveBeenCalledWith('drag');
+        expect(modal._openModal).not.toHaveBeenCalled();
+        expect(modal._applyDroppedText).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        ['a file', ['Files']],
+        ['an image', ['text/uri-list', 'text/html']],
+        ['an ILE book selection', ['text/plain', 'application/x.ile+json']],
+    ])('ignores a drag of %s', (_label, types) => {
+        const { modal, trigger } = setup();
+        const dataTransfer = { types, dropEffect: '', getData: jest.fn().mockReturnValue('{"x":1}') };
+
+        const dragover = dispatch(trigger, 'dragover', dataTransfer);
+        const drop = dispatch(trigger, 'drop', dataTransfer);
+
+        expect(dragover).not.toHaveBeenCalled();
+        expect(dataTransfer.dropEffect).toBe('');
+        expect(drop).not.toHaveBeenCalled();
+        expect(modal._openModal).not.toHaveBeenCalled();
         expect(modal._applyDroppedText).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/js/searchModalTriggerDrag.test.js
+++ b/tests/unit/js/searchModalTriggerDrag.test.js
@@ -1,0 +1,64 @@
+import { SearchModal } from '../../../openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js';
+
+function dispatch(trigger, type, dataTransfer) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    event.dataTransfer = dataTransfer;
+    const preventDefault = jest.spyOn(event, 'preventDefault');
+    trigger.dispatchEvent(event);
+    return preventDefault;
+}
+
+function setup() {
+    const modal = new SearchModal();
+    modal._openModal = jest.fn();
+    modal._applyDroppedText = jest.fn();
+    const trigger = document.createElement('button');
+    modal.attachToTrigger(trigger);
+    return { modal, trigger };
+}
+
+describe('SearchModal trigger drag-and-drop', () => {
+    test('dragover shows the copy cursor without opening the modal', () => {
+        const { modal, trigger } = setup();
+        const dataTransfer = { dropEffect: '' };
+
+        const preventDefault = dispatch(trigger, 'dragover', dataTransfer);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(dataTransfer.dropEffect).toBe('copy');
+        expect(modal._openModal).not.toHaveBeenCalled();
+        expect(modal._applyDroppedText).not.toHaveBeenCalled();
+    });
+
+    test('drop opens the modal and forwards the dropped text', () => {
+        const { modal, trigger } = setup();
+        const dataTransfer = { getData: jest.fn().mockReturnValue('dune') };
+
+        const preventDefault = dispatch(trigger, 'drop', dataTransfer);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(modal._openModal).toHaveBeenCalledWith('drag');
+        expect(modal._applyDroppedText).toHaveBeenCalledWith('dune');
+    });
+
+    test('drop does not reopen an already-open modal', () => {
+        const { modal, trigger } = setup();
+        modal.open = true;
+        const dataTransfer = { getData: jest.fn().mockReturnValue('dune') };
+
+        dispatch(trigger, 'drop', dataTransfer);
+
+        expect(modal._openModal).not.toHaveBeenCalled();
+        expect(modal._applyDroppedText).toHaveBeenCalledWith('dune');
+    });
+
+    test('drop with no text does not forward anything', () => {
+        const { modal, trigger } = setup();
+        const dataTransfer = { getData: jest.fn().mockReturnValue('') };
+
+        dispatch(trigger, 'drop', dataTransfer);
+
+        expect(modal._openModal).toHaveBeenCalledWith('drag');
+        expect(modal._applyDroppedText).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Dragging selected text over the search modal's trigger button opened the modal immediately on `dragover` instead of waiting for `drop`. Since `dragover` fires continuously while hovering, the modal popped open before the patron had committed to the drop.

### Technical
- The trigger's `dragover` listener now only calls `preventDefault()` (required for `drop` to fire on the element at all) and sets `dataTransfer.dropEffect = 'copy'`, so the cursor shows the copy affordance while hovering instead of the modal opening.
- A new `drop` listener on the trigger opens the modal and forwards the dropped text into the search input via a new `_applyDroppedText()` helper, shared with the search input's own existing `@drop` handler.

### Testing
1. On any page with the search modal trigger, select some text and drag it over the trigger button.
2. Confirm the modal does **not** open while hovering, and the cursor shows a "copy" indicator.
3. Drop the text onto the trigger — the modal should open with the dropped text populated in the search input and autocomplete results loading.

### Screenshot


### Stakeholders
