### PR TITLE
Fix: drop unusable url template from itan_technologies identifier

### DIFF
--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -354,5 +354,4 @@ identifiers:
 -   label: ITAN Book ID
     name: itan_technologies
     notes: "Unique book identifier assigned by ITAN Global Publishing, an African literature digital marketplace"
-    url: https://itan.app/bookstore/@@@
     website: https://itan.app


### PR DESCRIPTION
ITAN book pages use a full slug (category-title-authorName-bookId), not the bare ID, so https://itan.app/bookstore/@@@ renders a 500 on every ITAN identifier. The slug is not derivable from the ID, so a @@@ template cannot express it. Drop url and keep website; the real per-book link is carried in the edition's links.

<!-- What issue does this PR close? -->
Subtask of #13409 (PR 1 of 3). Follows up on the identifier added in #12947.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**fix.** Every ITAN Book ID currently renders as a hyperlink to a broken page. `identifiers.yml` sets `url: https://itan.app/bookstore/@@@`; at render time [`models.py:309`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/models.py#L309) substitutes the ID into `@@@`, and `type/edition/view.html` wraps the result in an anchor. ITAN book pages use a full slug (`category-title-authorName-bookId`), not the bare ID, and the slug is not derivable from the ID, so no `@@@` template can express it.

This drops the `url` line and keeps `website`. The ID then renders as plain text, and the real per-book link is carried in the edition's `links`, populated from ITAN's own `url` field in #13413.

### Technical
<!-- What should be noted about the implementation? -->

- `website`-without-`url` is an existing pattern in this file — 7 other identifiers already do it.
- With `url` absent, `id.get("url")` is falsy, so `models.py` sets `url=None` and the `$if id.url:` guard in `type/edition/view.html` falls through to the plain-text branch.
- No production impact: no ITAN identifier data has been imported yet, so no live record changes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verified against a real catalog record, `boo1109`:

| URL | Status |
|---|---|
| `https://itan.app/bookstore/boo1109` (what the template builds) | 500 |
| `https://itan.app/bookstore/african-literature-fiction-shadows-of-the-continent-urunna-ikemefuna-boo1109` (ITAN's own `url` field) | 200 |

To reproduce:
```
curl -o /dev/null -w "%{http_code}\n" -L https://itan.app/bookstore/boo1109
```

Also confirmed:
- The YAML parses and all 82 identifiers remain intact.
- No test asserts on this identifier.
- `pre-commit` passes on the changed file.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
n/a 

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles:  this touches the identifier you added in #12947, so flagging for a check that dropping `url` is the approach you want.

Also still open on #13409: one-off script or recurring provider job, and whether there is an import path for `ebook_access` I have missed.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
