### PR TITLE
 fix: preserve search state in advanced search

### DIFF
--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -25,6 +25,6 @@ $ q = query_param("q", "")
   </li>
   <li class="$('selected' if ctx.path=='/advancedsearch' else '')">
     <a data-ol-link-track="SearchNav|SearchAdvanced"
-       href="/advancedsearch">$_("Advanced Search")</a>
+       href="$changequery(_path='/advancedsearch', page=None)">$_("Advanced Search")</a>
   </li>
 </ul>

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -959,7 +959,7 @@ class advancedsearch(delegate.page):
     path = "/advancedsearch"
 
     def GET(self):
-        return render_template("search/advancedsearch.html")
+        return render_template("search/advancedsearch.html", web.input(_method="get"))
 
 
 @dataclass

--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -1,41 +1,50 @@
+$def with (param={})
+
 <div id="contentHead">
   <h1>$_('Advanced Search')</h1>
 </div>
 
 <div id="contentBody">
+  $ advanced_fields = set(['q', 'title', 'author', 'isbn', 'subject', 'place', 'person', 'publisher'])
+  $ sticky = set(['sort', 'author_facet', 'language', 'first_publish_year', 'publisher_facet', 'subject_facet', 'person_facet', 'place_facet', 'time_facet', 'public_scan_b', 'has_fulltext', 'public_scan', 'print_disabled'])
   $:macros.SearchNavigation()
   <form method="get" action="/search" class="siteSearch olform siteSearch--advanced">
     <fieldset class="home">
       <legend>$_('Advanced Search')</legend>
-      <input type="hidden" name="q" id="qtop">
+      <input type="hidden" name="q" id="qtop" value="$query_param('q', '')">
       <div class="formElement">
         <label for="qtop-title">$_('Title')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="title" id="qtop-title" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="title" id="qtop-title" placeholder="" size="35" value="$query_param('title', '')">
       </div>
       <div class="formElement">
         <label for="qtop-author">$_('Author')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="author" id="qtop-author" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="author" id="qtop-author" placeholder="" size="35" value="$query_param('author', '')">
       </div>
       <div class="formElement">
         <label for="qtop-isbn">$_('ISBN')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="isbn" id="qtop-isbn" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="isbn" id="qtop-isbn" placeholder="" size="35" value="$query_param('isbn', '')">
       </div>
       <div class="formElement">
         <label for="qtop-subject">$_('Subject')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="subject" id="qtop-subject" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="subject" id="qtop-subject" placeholder="" size="35" value="$query_param('subject', '')">
       </div>
       <div class="formElement">
         <label for="qtop-place">$_('Place')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="place" id="qtop-place" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="place" id="qtop-place" placeholder="" size="35" value="$query_param('place', '')">
       </div>
       <div class="formElement">
         <label for="qtop-person">$_('Person')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="person" id="qtop-person" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="person" id="qtop-person" placeholder="" size="35" value="$query_param('person', '')">
       </div>
       <div class="formElement">
         <label for="qtop-publisher">$_('Publisher')</label><br>
-        <input type="text" class="siteSearch--advanced-input" name="publisher" id="qtop-publisher" placeholder="" size="35">
+        <input type="text" class="siteSearch--advanced-input" name="publisher" id="qtop-publisher" placeholder="" size="35" value="$query_param('publisher', '')">
       </div>
+      $for k, values in param.items():
+        $if k in advanced_fields or k not in sticky:
+          $continue
+        $for v in values if isinstance(values, list) else [values]:
+          <input type="hidden" name="$k" value="$v.replace('"', '&quot;')" />
     </fieldset>
     <button type="submit" class="cta-btn cta-btn--search">$_('Search')</button>
     <div class="searchPlus">

--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -60,10 +60,10 @@ def test_advanced_search_preserves_search_state():
     nav = Path("openlibrary/macros/SearchNavigation.html").read_text(encoding="utf-8")
     advanced = Path("openlibrary/templates/search/advancedsearch.html").read_text(encoding="utf-8")
 
-    assert 'href="$changequery(_path=\'/advancedsearch\', page=None)"' in nav
-    assert 'value="$query_param(\'q\', \'\')"' in advanced
-    assert 'value="$query_param(\'title\', \'\')"' in advanced
-    assert 'value="$query_param(\'author\', \'\')"' in advanced
+    assert "href=\"$changequery(_path='/advancedsearch', page=None)\"" in nav
+    assert "value=\"$query_param('q', '')\"" in advanced
+    assert "value=\"$query_param('title', '')\"" in advanced
+    assert "value=\"$query_param('author', '')\"" in advanced
     assert "$for k, values in param.items():" in advanced
     assert '<input type="hidden" name="$k"' in advanced
 

--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -56,6 +56,18 @@ def test_login_template_does_not_bind_password_value():
     assert "$form.password.value" not in template
 
 
+def test_advanced_search_preserves_search_state():
+    nav = Path("openlibrary/macros/SearchNavigation.html").read_text(encoding="utf-8")
+    advanced = Path("openlibrary/templates/search/advancedsearch.html").read_text(encoding="utf-8")
+
+    assert 'href="$changequery(_path=\'/advancedsearch\', page=None)"' in nav
+    assert 'value="$query_param(\'q\', \'\')"' in advanced
+    assert 'value="$query_param(\'title\', \'\')"' in advanced
+    assert 'value="$query_param(\'author\', \'\')"' in advanced
+    assert "$for k, values in param.items():" in advanced
+    assert '<input type="hidden" name="$k"' in advanced
+
+
 def test_no_role_trio_in_source():
     """No source file should use all three of is_admin(), is_librarian(),
     is_super_librarian() on the same line -- use is_librarian_or_higher() instead.


### PR DESCRIPTION
 ## What

  Preserves the current search query and selected filters when navigating to Advanced Search.

  ## Why

  Closes #13488.

  Previously, the Advanced Search tab linked directly to `/advancedsearch`, which discarded the current query and selected filters. The advanced search form also did not prefill existing query fields.

  ## Changes

  - Uses `changequery()` for the Advanced Search navigation link.
  - Passes current GET params into the advanced search template.
  - Prefills advanced search fields from the current query params.
  - Preserves sticky search filters as hidden form inputs.
  - Adds a regression test for the preserved search state behavior.

  ## Testing

  - Confirmed changed templates compile.
  - Full pytest could not be run locally because `psycopg2` requires missing `libpq.5.dylib` on this machine.