### PR TITLE
fix(css): style 'Add to List' button to match reading-log btn on orphaned editions and author pages #13421

### DIFF
--- a/openlibrary/templates/my_books/primary_action.html
+++ b/openlibrary/templates/my_books/primary_action.html
@@ -47,13 +47,8 @@ $def reading_log_cta(work_key, edition_key, user_key, read_status, title):
 
 $def list_cta(user_key, page_url, title):
   $ data_attr = get_preserve_intent_attrs(_('Add to List'), title, "book")
-  $if user_key:
-    <h3 class="primary-action" $:data_attr>$_('Add to List')</h3>
-  $else:
-    $# XXX: Check if classes are needed here
-    <a href="/account/login?redirect=$page_url" class="dropclick plain js-login-intent" $:data_attr>
-      <h3>$_('Add to List')</h3>
-    </a>
+  $ login_class = "js-login-intent" if not user_key else ""
+  <button class="book-progress-btn primary-action $(login_class)" type="button" $:data_attr>$_('Add to List')</button>
 
 $if work_key:
   $:reading_log_cta(work_key, edition_key, user_key, read_status, title)

--- a/static/css/components/mybooks-dropper.css
+++ b/static/css/components/mybooks-dropper.css
@@ -1,14 +1,33 @@
 /* Styling overrides for author and orphaned edition pages */
-.old-style-lists h3 {
-  font-size: 0.75em;
-  text-align: left;
-  padding: var(--spacing-inset-sm);
-  min-width: 150px;
-  font-weight: bold;
+/* Make the "Add to List" h3 visually match the .book-progress-btn reading-log button */
+.old-style-lists .generic-dropper__primary h3 {
+  font-size: var(--font-size-label-large);
+  font-weight: normal;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.old-style-lists h3:hover {
-  text-decoration: underline;
+.old-style-lists .generic-dropper__primary a {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.old-style-lists .generic-dropper__primary a h3 {
+  height: 100%;
+  width: 100%;
 }
 
 /* Hide "My Reading Lists" heading */

--- a/static/css/components/mybooks-dropper.css
+++ b/static/css/components/mybooks-dropper.css
@@ -1,35 +1,4 @@
 /* Styling overrides for author and orphaned edition pages */
-/* Make the "Add to List" h3 visually match the .book-progress-btn reading-log button */
-.old-style-lists .generic-dropper__primary h3 {
-  font-size: var(--font-size-label-large);
-  font-weight: normal;
-  text-align: center;
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.old-style-lists .generic-dropper__primary a {
-  display: flex;
-  height: 100%;
-  width: 100%;
-  text-decoration: none;
-  color: inherit;
-}
-
-.old-style-lists .generic-dropper__primary a h3 {
-  height: 100%;
-  width: 100%;
-}
-
 /* Hide "My Reading Lists" heading */
 .old-style-lists .reading-list-title {
   display: none;


### PR DESCRIPTION
Closes #13421

fix

### Technical
For orphaned editions and author pages, `work_key` is empty so the dropper falls back to a plain `<h3>` "Add to List" with legacy `.old-style-lists` styles — producing a tiny, left-aligned heading inconsistent with the rest of the UI.

This PR replaces those overrides with scoped rules on `.old-style-lists .generic-dropper__primary h3` to match the `.book-progress-btn` appearance: full width/height, centered, `--font-size-label-large`, and pointer cursor. The logged-out `<a>` wrapper is also made full-width so the click target fills the slot.

### Testing
1. `docker compose up` → visit `/books/OL9298375M` (orphaned edition) and an author page
2. "Add to List" button should now match the height/style of "Want to Read" on normal edition pages
3. Verify no regression on a normal edition (e.g. `/books/OL7353617M`)



### Stakeholders
@lokesh


By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate.
