### PR TITLE
perf(lending): avoid redundant loan lookups during status sync

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -888,7 +888,7 @@ class User(models.User):
         """Update the status of this user's loans."""
         loans = lending.get_loans_of_user(self.key)
         for loan in loans:
-            lending.sync_loan(loan["ocaid"])
+            lending.sync_loan(loan["ocaid"], loan)
 
     def get_safe_mode(self):
         return (self.get_users_settings() or {}).get("safe_mode", "").lower()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor: avoid redundant loan lookup during status synchronization

### Technical
`User.update_loan_status()` already retrieves the user's `Loan` objects through `lending.get_loans_of_user()`.

Previously, it passed only the OCAID to `lending.sync_loan()`. Since `sync_loan()` accepts an optional `loan` argument and calls `get_loan()` when it is not provided, each loan could be fetched from Archive.org again during synchronization.

This changes:

```python
lending.sync_loan(loan["ocaid"])
```
to:
```python
lending.sync_loan(loan["ocaid"], loan)
```
in file `openlibrary/plugins/upstream/models.py:891`

This reuses the Loan object already available at the call site and avoids the redundant get_loan() lookup and its associated external requests. This one argument. Removes 2 external calls per active loan.

### Stakeholders:
@mekarpeles
@jimchamp

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
