### PR TITLE
fix: resolve remaining Vue lint warnings

### DIFF
--- a/openlibrary/components/BulkSearch/components/MatchRow.vue
+++ b/openlibrary/components/BulkSearch/components/MatchRow.vue
@@ -14,10 +14,10 @@
           title="View results in Open Library"
         >🔎</a>
         <BookCard
-          v-for="(doc, index) in bookMatch.solrDocs.docs"
-          :key="index"
+          v-for="(doc, docIndex) in bookMatch.solrDocs.docs"
+          :key="docIndex"
           :doc="doc"
-          :is-primary="index === 0"
+          :is-primary="docIndex === 0"
         />
         <NoBookCard v-if="bookMatch.solrDocs.numFound===0" />
       </div>

--- a/openlibrary/components/LibraryExplorer/components/BookRoom.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookRoom.vue
@@ -176,6 +176,7 @@ export default {
             type: String
         },
         features: {
+            type: Object,
             default: () => ({
                 book3d: true,
                 cover: 'image',

--- a/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
+++ b/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
@@ -43,6 +43,7 @@ export default {
             validator: val => ['image', 'text'].includes(val)
         }
     },
+    emits: ['load'],
 
     computed: {
         byline() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -142,6 +142,7 @@ export default {
             default: null
         },
         sort: {
+            type: String,
             default: 'editions',
         },
         limit: {

--- a/openlibrary/components/MergeUI/MergeRowField.vue
+++ b/openlibrary/components/MergeUI/MergeRowField.vue
@@ -146,6 +146,7 @@ export default {
             required: true
         },
         value: {
+            type: [String, Number, Boolean, Object, Array],
             required: true
         },
         merged: {

--- a/openlibrary/components/ObservationForm/components/CategorySelector.vue
+++ b/openlibrary/components/ObservationForm/components/CategorySelector.vue
@@ -17,9 +17,13 @@
       >
         <template #before>
           <span
+            v-if="hasSelectedValues(o.label)"
             class="symbol"
-            v-html="displaySymbol(o.label)"
-          />
+          >&#10004;</span>
+          <span
+            v-else
+            class="symbol"
+          >&bull;</span>
         </template>
       </OLChip>
     </div>
@@ -74,6 +78,7 @@ export default {
             default: 0
         }
     },
+    emits: ['update-selected'],
     data: function() {
         return {
             /**
@@ -116,19 +121,13 @@ export default {
             return this.selectedId === id;
         },
         /**
-         * Returns an HTML code denoting what symbol to display in a book tag type chip.
+         * Returns `true` if any book tags of the given type have been selected.
          *
-         * Will return a bullet symbol if no book tags of a chip's type have been selected,
-         * and a heavy checkmark otherwise.
-         *
-         * @returns {String} An HTML code representing selections of a type.
+         * @param {String} type A book tag type.
+         * @returns {boolean} Whether any selected values exist for the given type.
          */
-        displaySymbol: function(type) {
-            if (this.allSelectedValues[type] && this.allSelectedValues[type].length) {
-                // &#10004; - Heavy checkmark
-                return '&#10004;';
-            }
-            return '&bull;';
+        hasSelectedValues: function(type) {
+            return !!(this.allSelectedValues[type] && this.allSelectedValues[type].length);
         }
     }
 };

--- a/openlibrary/components/ObservationForm/components/OLChip.vue
+++ b/openlibrary/components/ObservationForm/components/OLChip.vue
@@ -51,6 +51,7 @@ export default {
             default: ''
         }
     },
+    emits: ['update-selected'],
     data: function() {
         return {
             /**


### PR DESCRIPTION
 ## What

  Resolves the remaining Vue lint warnings listed in #13477.

  ## Changes

  - Adds missing prop types.
  - Adds missing `emits` declarations.
  - Renames a shadowed template loop variable.
  - Replaces `v-html` symbol rendering with normal template output.

  ## Testing

  - Ran `npx eslint openlibrary/components`
  - Result: 0 errors, 0 warnings

  Closes #13477.

