### PR TITLE
perf(lending): prevent redundant Archive.org loan API calls

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -643,10 +643,14 @@ def get_loan(identifier: str, user_key: str | None = None):
     except Exception:  # TODO: Narrow exception scope
         logger.exception(f"get_loan({identifier}) 1 of 2")
 
-    try:
-        _loan = _get_ia_loan(identifier, account and account.itemname)
-    except Exception:  # TODO: Narrow exception scope
-        logger.exception(f"get_loan({identifier}) 2 of 2")
+    # Only look up by the linked IA account when the OL-username lookup found
+    # nothing; an unconditional second call would duplicate the anonymous query
+    # and overwrite a loan found above.
+    if account and account.itemname and not _loan:
+        try:
+            _loan = _get_ia_loan(identifier, account.itemname)
+        except Exception:  # TODO: Narrow exception scope
+            logger.exception(f"get_loan({identifier}) 2 of 2")
 
     return _loan
 

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -208,6 +208,57 @@ class TestGetLendingState:
             assert lending.get_lending_state(doc, user=mock_user, check_loan_status=True) == "open"
 
 
+class TestGetLoan:
+    """get_loan should make at most the necessary IA loan-API calls."""
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self, monkeypatch):
+        mock_site = Mock()
+        mock_site.get.return_value.store.get.return_value = None
+        monkeypatch.setattr(lending, "site", mock_site)
+        self.mock_get_ia_loan = Mock(return_value=None)
+        monkeypatch.setattr(lending, "_get_ia_loan", self.mock_get_ia_loan)
+
+    def make_account(self, monkeypatch, username="mek", itemname="@mek"):
+        account = Mock()
+        account.username = username
+        account.itemname = itemname
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_key", Mock(return_value=account))
+        return account
+
+    def test_anonymous_lookup_calls_api_once(self):
+        loan = Mock()
+        self.mock_get_ia_loan.return_value = loan
+
+        assert lending.get_loan("foo00bar") is loan
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", None)
+
+    def test_loan_found_by_username_is_not_clobbered(self, monkeypatch):
+        self.make_account(monkeypatch)
+        loan = Mock()
+        self.mock_get_ia_loan.return_value = loan
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is loan
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", "ol:mek")
+
+    def test_falls_back_to_itemname_when_username_finds_nothing(self, monkeypatch):
+        self.make_account(monkeypatch)
+        loan = Mock()
+        self.mock_get_ia_loan.side_effect = [None, loan]
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is loan
+        assert self.mock_get_ia_loan.call_args_list == [
+            (("foo00bar", "ol:mek"),),
+            (("foo00bar", "@mek"),),
+        ]
+
+    def test_account_without_itemname_calls_api_once(self, monkeypatch):
+        self.make_account(monkeypatch, itemname=None)
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is None
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", "ol:mek")
+
+
 @pytest.mark.usefixtures("request_context_fixture")
 class TestGetLoanHistoryData:
     """parse_s3_cookie() is annotated `dict | None` and legitimately returns


### PR DESCRIPTION
<!-- What issue does this PR close? -->
follows #13502 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
perf: Prevent redundant Archive.org loan API calls.

### Technical

`get_loan()` was making the Archive.org loan lookup twice, even when the
second lookup was unnecessary.

Previously, the second lookup ran unconditionally:

```python
try:
    _loan = _get_ia_loan(
        identifier,
        account and userkey2userid(account.username),
    )
except Exception:
    logger.exception(f"get_loan({identifier}) 1 of 2")

try:
    _loan = _get_ia_loan(
        identifier,
        account and account.itemname,
    )
except Exception:
    logger.exception(f"get_loan({identifier}) 2 of 2")
```

For the common anonymous path, account is None, so both calls became the same Archive.org loan.query request with no userid, so both calls became the same Archive.org loan.query request with no userid. The second request then overwrote the result of the first.

The second lookup is now only performed when an authenticated account has a linked Archive.org itemname and the first lookup finds no loan:

```python
if account and account.itemname and not _loan:
    try:
        _loan = _get_ia_loan(identifier, account.itemname)
    except Exception:
        logger.exception(f"get_loan({identifier}) 2 of 2")
```

This reduces anonymous get_loan() calls from 2 Archive.org API requests to 1, while preserving the @itemname fallback for authenticated users.

Performance: get_loan() previously issued two identical Archive.org loan.query requests for anonymous lookups. The change reduces this to a single request, eliminating one unnecessary network round trip per call.

Added regression tests covering:

- anonymous lookups making only one API call;
- successful ol: lookups not being overwritten;
- fallback to @itemname when the first lookup finds nothing;
- accounts without a linked itemname avoiding an unfiltered lookup.

### Testing
- pytest openlibrary/tests/core/test_lending.py
- 19 passed
- git diff --check passes

<img width="1385" height="245" alt="image" src="https://github.com/user-attachments/assets/2dfe054c-8305-46f6-892d-b91acef718b7" />

### Stakeholders

@mekarpeles 