### PR TITLE
Fix tar-index cache never hitting due to float shard key

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -354,9 +354,9 @@ class cover:
         except TypeError, ValueError:
             return False
 
-    def get_tar_filename(self, coverid, size):
+    def get_tar_filename(self, coverid: int, size):
         """Returns tarfile:offset:size for given coverid."""
-        tarindex = coverid / 10000
+        tarindex = coverid // 10000
         index = coverid % 10000
         array_offset, array_size = get_tar_index(tarindex, size)
 
@@ -376,8 +376,12 @@ class cover:
         return _query(category, key, value)
 
 
+# mypy can't check callers against this signature: functools.cache's stub types its
+# wrapper's __call__ as taking *args: Hashable, erasing the real parameter types.
+# https://github.com/python/mypy/issues/16261
 @functools.cache
-def get_tar_index(tarindex, size):
+def get_tar_index(tarindex: int, size):
+    assert config.data_root is not None
     path = os.path.join(config.data_root, get_tarindex_path(tarindex, size))
     if not os.path.exists(path):
         return None, None


### PR DESCRIPTION
Fix bug in `get_tar_index` which was never caching because it was incorrectly being passed in a `float` instead of an `int`.

### Technical
`get_tar_filename` computed `tarindex = coverid / 10000`, which is float true-division in Python 3 (this line dates back to when the codebase was Python 2, where `/` on two ints was floor division). Since `@functools.cache` keys on the exact argument value, every cover ID produced its own distinct float (e.g. `719.4561` vs `719.4562` for two IDs in the same shard), so the cache never actually hit across the 10,000 covers a shard's index file covers. Switching to `//` (floor division) restores the intended per-shard cache key.

### Testing
Ran the full `openlibrary/coverstore/tests/` suite (51 passed, 7 skipped, no change from before the fix). Also verified directly that two cover IDs in the same shard now share one `get_tar_index` cache entry (`CacheInfo(hits=1, misses=1, currsize=1)`) instead of two separate ones.

### Screenshot
N/A - no UI change.

### Stakeholders
