### PR TITLE
fix: rename audiences field to audience

### DIFF
--- a/openlibrary/plugins/openlibrary/types/work.type
+++ b/openlibrary/plugins/openlibrary/types/work.type
@@ -245,7 +245,7 @@
             "type": {
                 "key": "/type/property"
             },
-            "name": "audiences"
+            "name": "audience"
         }
     ],
     "revision": 14

--- a/openlibrary/schemata/work.schema.json
+++ b/openlibrary/schemata/work.schema.json
@@ -40,7 +40,7 @@
     "subjects":            { "$ref": "shared_definitions.json#/string_array" },
     "genres":              { "$ref": "shared_definitions.json#/string_array" },
     "subgenres":           { "$ref": "shared_definitions.json#/string_array" },
-    "audiences":           { "$ref": "shared_definitions.json#/string_array" },
+    "audience":           { "$ref": "shared_definitions.json#/string_array" },
 
     "first_publish_date": { "type": "string" },
 


### PR DESCRIPTION
## Summary

- Rename `audiences` to `audience` in `work.type`
- Rename `audiences` to `audience` in `work.schema.json`
- Align the Open Library Work schema with the existing tag infrastructure

## Context

Follow-up fix for #13431.

The tag infrastructure uses `audience` (singular) throughout the
classifier, mappings, and migrator.

The migrator returns `result["audience"]` and the backfill stores it
as `work["audience"]`.

This change aligns the Open Library Work schema with that convention.

## Related PR

Follow-up to #13431