### PR TITLE
ci: add zizmor ignore for auto_assign_reviewer trigger

### DIFF
--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -8,7 +8,7 @@ name: Auto-assign Code Review
 # The usual pull_request_target caveat (it can expose secrets to untrusted fork code)
 # does not apply here: this job checks out no code at all -- it only calls the GitHub
 # API via actions/github-script, using payload metadata. Nothing from the fork is executed.
-on:
+on:  # zizmor: ignore[dangerous-triggers] -- safe: no checkout, no fork code executed; only GitHub API calls via actions/github-script using payload metadata
   pull_request_target:
     types: [opened, ready_for_review]
 


### PR DESCRIPTION
Adds an inline `zizmor: ignore[dangerous-triggers]` on the `pull_request_target` trigger in auto_assign_reviewer.yml, matching the existing house style in new_pr_labeler.yml and pr_update_labeler.yml. The trigger is safe here: the job has no checkout step and never executes fork code — it only calls the GitHub API via actions/github-script using payload metadata. Fixes the pre-commit.ci push failure on master introduced after #13210.