### PR TITLE
chore(eslint): enforce Vue lint rules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -188,6 +188,13 @@ module.exports = [
         },
       },
     },
+    rules: {
+      "vue/require-prop-types": "error",
+      "vue/require-explicit-emits": "error",
+      "vue/require-default-prop": "error",
+      "vue/no-v-html": "error",
+      "vue/no-template-shadow": "error",
+    },
   },
 
   // JavaScript-specific configuration


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Closes #13510

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

fix

### Technical

Promotes five Vue ESLint rules from `warn` to `error` in `eslint.config.cjs`:

* `vue/require-prop-types`
* `vue/require-explicit-emits`
* `vue/require-default-prop`
* `vue/no-v-html`
* `vue/no-template-shadow`

### Testing

* npx eslint . → exit 0, no output (0 errors, 0 warnings)
* npm run lint → both lint:js and lint:css exited 0 (0 errors, 0 warnings)
* No inline `eslint-disable` comments were added.

### Stakeholders
@RayBB 