### PR TITLE
fix(eslint): promote 5 clean Vue lint rules to error (#13510)

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -136,6 +136,11 @@ module.exports = [
           ignores: ["Bookshelf", "Shelf"],
         },
       ],
+      "vue/require-prop-types": "error",
+      "vue/require-explicit-emits": "error",
+      "vue/require-default-prop": "error",
+      "vue/no-v-html": "error",
+      "vue/no-template-shadow": "error",
       // jQuery deprecated rules
       "no-jquery/no-box-model": "warn",
       "no-jquery/no-browser": "warn",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13510

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix]

Promotes 5 Vue ESLint rules from `warn` to `error` in `eslint.config.cjs`, now that all existing violations were cleaned up by #13473 and #13479. This prevents new violations of these rules from silently accumulating again.

### Technical
Added the following to the `**/*.vue` / `**/*.js` rules block in `eslint.config.cjs`, next to the existing `vue/multi-word-component-names` entry:

```js
"vue/require-prop-types": "error",
"vue/require-explicit-emits": "error",
"vue/require-default-prop": "error",
"vue/no-v-html": "error",
"vue/no-template-shadow": "error",
```

These rules previously came from `eslint-plugin-vue`'s `flat/recommended` config at the `warn` level, and CI does not fail on warnings — so violations could merge unnoticed. All 5 were already at zero violations on master before this change (confirmed by prior cleanup PRs #13473 and #13479), so this flip is zero-cost today and only affects future PRs.

Per the issue, the other ~25 `warn` rules in `flat/recommended` (mostly formatting rules like `vue/html-indent`) were intentionally *not* promoted, since they'd add CI friction without meaningful safety value.

### Testing
- Ran `npm run lint` (`eslint .` + `stylelint`) on the branch — both exit with code 0, 0 errors, 0 warnings.
- Confirmed via `git diff --stat master` that only `eslint.config.cjs` was changed (5 insertions, 0 deletions).
- Confirmed via `git grep -n "eslint-disable" $(git diff --name-only master)` that no `eslint-disable` comments were added anywhere to force the pass, per the acceptance criteria.

### Screenshot
N/A — config-only change, no UI impact.

### Stakeholders
@RayBB

<!-- Attribution Disclaimer -->