### PR TITLE
Add "Needs: Lead" label to PRs that have no discernible lead

### DIFF
--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -14,12 +14,13 @@
  * 1. Searches the given PR body for a "closes" statement
  * 2. Fetches the issue referenced by the "closes" statement, storing references
  *    to the first priority and lead label encountered
- * 3. Updates PR, adding same priority label as issue, and assigning the lead (if
- *    they are not also the author)
+ * 3. Updates PR, adding same priority label as issue, and assigning the lead (or labeling the issue
+ *    as "Needs: Lead")
  */
 import { Octokit } from "@octokit/action";
 
 const CLOSES_REGEX = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#(\d+)/i
+const DEFAULT_REQUEST_HEADERS = {"X-GitHub-Api-Version": "2022-11-28"}
 
 console.log('Script starting....')
 const octokit = new Octokit()
@@ -29,67 +30,45 @@ console.log('Script terminated....')
 async function main() {
     // Parse and assign all command-line variables
     const {fullRepoName, prAuthor, prNumber, prBody} = parseArgs()
-
-    // Look for "Closes:" statement, storing the issue number (if present)
-    const issueNumber = findLinkedIssue(prBody)
-
-    if (!issueNumber) {
-        console.log('No linked issue found for this pull request.')
-        return
-    }
-
-    // Fetch the issue
     const [repoOwner, repoName] = fullRepoName.split('/')
-    const linkedIssue = await octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
-        owner: repoOwner,
-        repo: repoName,
-        issue_number: issueNumber,
-        headers: {
-          'X-GitHub-Api-Version': '2022-11-28'
-        }
-      })
-    if (!linkedIssue) {
-        console.log(`An issue occurred while fetching issue #${issueNumber}`)
-        process.exit(1)
+
+    // Fetch linked issue, if any
+    const issue = await findLinkedIssue(prBody, repoOwner, repoName)
+    let prLabelSet = new Set()
+    if (!issue) {
+        console.log('No linked issue found for this pull request.')
+        prLabelSet.add("Needs: Lead")
     }
 
-    // Check the issue's labels for the priority and lead
-    let leadName
-    let priority
-    for (const label of linkedIssue.data.labels) {
-        if (!leadName && label.name.startsWith('Lead: @')) {
-            leadName = label.name.split('@')[1]
-        }
-        if (!priority && label.name.match(/Priority: [012]/)) {
-            priority = label.name
-        }
-    }
-
+    const {leadName, priority} = getLinkedIssueMetadata(issue)
     // Don't assign lead to PR if PR author is the issue lead
-    const assignLead = leadName && !(leadName === prAuthor)
+    const assignLead = (leadName && !(leadName === prAuthor))
 
-    // Update PR, adding assignee and priority label
+    // If lead was identified, assign lead to PR:
     if (assignLead) {
         await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
             owner: repoOwner,
             repo: repoName,
             issue_number: prNumber,
             assignees: [leadName],
-            headers: {
-              'X-GitHub-Api-Version': '2022-11-28'
-            }
+            headers: DEFAULT_REQUEST_HEADERS
           })
     }
 
     if (priority) {
+        prLabelSet.add(priority)
+    }
+    if (!assignLead) {
+        prLabelSet.add("Needs: Lead")
+    }
+    // Add labels to PR, if needed:
+    if (prLabelSet.size) {
         await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/labels', {
             owner: repoOwner,
             repo: repoName,
             issue_number: prNumber,
-            labels: [priority],
-            headers: {
-              'X-GitHub-Api-Version': '2022-11-28'
-            }
+            labels: Array.from(prLabelSet),
+            headers: DEFAULT_REQUEST_HEADERS
           })
     }
 }
@@ -117,14 +96,52 @@ function parseArgs() {
 
 /**
  * Finds first "Closes" statement in the given pull request body, then
- * returns the number of the linked issue or an empty string, if none exists.
+ * returns the linked issue (or `null` if no such issue exists).
  *
  * @param {string} body The body of a GitHub pull request
- * @returns {string} The number of the linked issue that will be closed
- *                   by this pull request, or an empty string if no
- *                   "Closes" statement is found.
+ * @param {string} repoOwner The owner of the repo (e.g. internetarchive)
+ * @param {string} repoName The name of the repo (e.g. openlibrary)
+ * @returns {Promise<OctokitResponse<T>>|null} The linked issue that will be closed by
+ *                         this pull request, or null if no "Closes"
+ *                         statement is found.
  */
-function findLinkedIssue(body) {
+async function findLinkedIssue(body, repoOwner, repoName) {
     const matches = body.match(CLOSES_REGEX)
-    return matches?.length ? Number(matches[1]) : ''
+    const issueNumber =  matches?.length ? Number(matches[1]) : null
+
+    if (!issueNumber) {
+        return null
+    }
+
+    return octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+            owner: repoOwner,
+            repo: repoName,
+            issue_number: issueNumber,
+            headers: DEFAULT_REQUEST_HEADERS
+          })
+}
+
+/**
+ * Returns the given issue's lead and priority, if any.
+ *
+ * @param {OctokitResponse<T>} issue
+ * @returns {{lead: string|undefined, priority: string|undefined}}
+ */
+function getLinkedIssueMetadata(issue) {
+    let leadName, priority
+    if (issue) {
+        for (const label of issue.data.labels) {
+            if (!leadName && label.name.startsWith('Lead: @')) {
+                leadName = label.name.split('@')[1]
+            }
+            if (!priority && label.name.match(/Priority: [012]/)) {
+                priority = label.name
+            }
+        }
+    }
+
+    return {
+        lead: leadName,
+        priority: priority
+    }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies PR auto-assignment workflow to add "Needs: Lead" labels to pull requests that either:

a. Lack a valid ["closes" statement](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
b. Are authored by the linked issue's lead.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
