### PR TITLE
Fix deployment name detection at startup

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -15,6 +15,7 @@ services:
       - ${WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 25 --timeout 300 --max-requests 1500
+      - OL_DEPLOYMENT_NAME=production
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
       - ../olsystem:/olsystem
@@ -33,6 +34,7 @@ services:
       - ${FAST_WEB_PORT:-18080}:8080
     environment:
       - GUNICORN_OPTS= --workers 7 --timeout 300 --max-requests 5000 --max-requests-jitter 500
+      - OL_DEPLOYMENT_NAME=production
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
       - ../olsystem:/olsystem

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -18,6 +18,7 @@ services:
       - ${WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
+      - OL_DEPLOYMENT_NAME=testing
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PIP_INDEX_URL=${PIP_INDEX_URL:-}
     env_file:
@@ -47,6 +48,7 @@ services:
       - ${FAST_WEB_PORT:-18080}:8080
     environment:
       - GUNICORN_OPTS= --workers 2 --timeout 180 --max-requests 500
+      - OL_DEPLOYMENT_NAME=testing
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PIP_INDEX_URL=${PIP_INDEX_URL:-}
     env_file:

--- a/openlibrary/core/env.py
+++ b/openlibrary/core/env.py
@@ -1,6 +1,6 @@
 import os
 from functools import cached_property
-from typing import Literal, cast
+from typing import Literal
 
 import web
 
@@ -19,19 +19,26 @@ DeploymentName = Literal["development", "testing", "production"]
 
 
 def get_deployment_name() -> DeploymentName:
-    """Which deployment this request is served from, based on the host.
+    """Which deployment serves this process.
+
+    Returns the OL_DEPLOYMENT_NAME environment variable (set per deployment
+    in the compose files) when present, otherwise falls back to the request
+    host, and finally to "development" when there is no request context
+    (e.g. at application startup).
 
     Drives dev-facing UI cues (favicon, logo badge) so localhost,
     testing.openlibrary.org, and production tabs are distinguishable.
     """
     if deployment_name := os.environ.get("OL_DEPLOYMENT_NAME"):
-        return cast(DeploymentName, deployment_name)
+        match deployment_name:
+            case "development" | "testing" | "production":
+                return deployment_name
+            case _:
+                raise ValueError(f'Invalid OL_DEPLOYMENT_NAME {deployment_name!r}; expected "development", "testing", or "production"')
 
     try:
         host = web.ctx.host
-    except AttributeError:
-        host = ""
-    except KeyError:
+    except AttributeError, KeyError:
         host = ""
 
     match host:

--- a/openlibrary/core/env.py
+++ b/openlibrary/core/env.py
@@ -1,5 +1,6 @@
 import os
 from functools import cached_property
+from typing import Literal, cast
 
 import web
 
@@ -14,13 +15,26 @@ class OLEnv:
         return os.environ.get("LOCAL_DEV") == "true"
 
 
-def get_deployment_name() -> str:
+DeploymentName = Literal["development", "testing", "production"]
+
+
+def get_deployment_name() -> DeploymentName:
     """Which deployment this request is served from, based on the host.
 
     Drives dev-facing UI cues (favicon, logo badge) so localhost,
     testing.openlibrary.org, and production tabs are distinguishable.
     """
-    match web.ctx.host:
+    if deployment_name := os.environ.get("OL_DEPLOYMENT_NAME"):
+        return cast(DeploymentName, deployment_name)
+
+    try:
+        host = web.ctx.host
+    except AttributeError:
+        host = ""
+    except KeyError:
+        host = ""
+
+    match host:
         case "openlibrary.org" | "www.openlibrary.org":
             return "production"
         case "testing.openlibrary.org":

--- a/openlibrary/tests/core/test_env.py
+++ b/openlibrary/tests/core/test_env.py
@@ -1,0 +1,31 @@
+import web
+
+from openlibrary.core.env import get_deployment_name
+
+
+def test_deployment_name_defaults_to_development_without_context(monkeypatch):
+    monkeypatch.delenv("OL_DEPLOYMENT_NAME", raising=False)
+    monkeypatch.delattr(web.ctx, "host", raising=False)
+
+    assert get_deployment_name() == "development"
+
+
+def test_deployment_name_prefers_environment(monkeypatch):
+    monkeypatch.setenv("OL_DEPLOYMENT_NAME", "testing")
+    web.ctx.host = "openlibrary.org"
+
+    assert get_deployment_name() == "testing"
+
+
+def test_deployment_name_uses_request_host_without_environment(monkeypatch):
+    monkeypatch.delenv("OL_DEPLOYMENT_NAME", raising=False)
+    web.ctx.host = "www.openlibrary.org"
+
+    assert get_deployment_name() == "production"
+
+
+def test_deployment_name_uses_testing_host_without_environment(monkeypatch):
+    monkeypatch.delenv("OL_DEPLOYMENT_NAME", raising=False)
+    web.ctx.host = "testing.openlibrary.org"
+
+    assert get_deployment_name() == "testing"

--- a/openlibrary/tests/core/test_env.py
+++ b/openlibrary/tests/core/test_env.py
@@ -1,3 +1,4 @@
+import pytest
 import web
 
 from openlibrary.core.env import get_deployment_name
@@ -12,20 +13,27 @@ def test_deployment_name_defaults_to_development_without_context(monkeypatch):
 
 def test_deployment_name_prefers_environment(monkeypatch):
     monkeypatch.setenv("OL_DEPLOYMENT_NAME", "testing")
-    web.ctx.host = "openlibrary.org"
+    monkeypatch.setattr(web.ctx, "host", "openlibrary.org", raising=False)
 
     assert get_deployment_name() == "testing"
 
 
+def test_deployment_name_rejects_invalid_environment_value(monkeypatch):
+    monkeypatch.setenv("OL_DEPLOYMENT_NAME", "staging")
+
+    with pytest.raises(ValueError, match="Invalid OL_DEPLOYMENT_NAME"):
+        get_deployment_name()
+
+
 def test_deployment_name_uses_request_host_without_environment(monkeypatch):
     monkeypatch.delenv("OL_DEPLOYMENT_NAME", raising=False)
-    web.ctx.host = "www.openlibrary.org"
+    monkeypatch.setattr(web.ctx, "host", "www.openlibrary.org", raising=False)
 
     assert get_deployment_name() == "production"
 
 
 def test_deployment_name_uses_testing_host_without_environment(monkeypatch):
     monkeypatch.delenv("OL_DEPLOYMENT_NAME", raising=False)
-    web.ctx.host = "testing.openlibrary.org"
+    monkeypatch.setattr(web.ctx, "host", "testing.openlibrary.org", raising=False)
 
     assert get_deployment_name() == "testing"

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -34,3 +34,13 @@ class TestDockerCompose:
             prod_dc: dict = yaml.safe_load(f)
         for serv, opts in prod_dc["services"].items():
             assert "profiles" in opts, f"{serv} is missing 'profiles' field"
+
+    def test_web_services_set_deployment_name(self):
+        with open(p("..", "compose.staging.yaml")) as f:
+            staging_dc: dict = yaml.safe_load(f)
+        with open(p("..", "compose.production.yaml")) as f:
+            prod_dc: dict = yaml.safe_load(f)
+
+        for service_name in ("web", "fast_web"):
+            assert "OL_DEPLOYMENT_NAME=testing" in staging_dc["services"][service_name]["environment"]
+            assert "OL_DEPLOYMENT_NAME=production" in prod_dc["services"][service_name]["environment"]


### PR DESCRIPTION
### Implementation
- Add `OL_DEPLOYMENT_NAME` support to `get_deployment_name()` and type it as `DeploymentName`.
- Preserve the existing host-based detection when the environment variable is unset.
- Return `development` instead of raising when called outside a request context.
- Set `OL_DEPLOYMENT_NAME` for `web` and `fast_web` in staging and production compose files.
- Add focused unit coverage for the startup fallback, env override, host fallback, and compose wiring.

### Testing
- [x] `make git`
- [x] `make test-py-uv PYTEST_ARGS='openlibrary/tests/core/test_env.py tests/test_docker_compose.py'` — 7 passed
- [x] `uv tool run pre-commit run --files openlibrary/core/env.py openlibrary/tests/core/test_env.py tests/test_docker_compose.py compose.staging.yaml compose.production.yaml`
- [x] `python -m compileall -q openlibrary/core/env.py openlibrary/tests/core/test_env.py tests/test_docker_compose.py`
- [x] `git diff --check`

Closes #13514
