### PR TITLE
Make FastAPI the primary entry point on the testing deployment

### DIFF
--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -14,8 +14,6 @@ services:
         - PIP_INDEX_URL=${PIP_INDEX_URL:-}
     restart: unless-stopped
     hostname: "$HOSTNAME"
-    ports:
-      - ${WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_DEPLOYMENT_NAME=testing
@@ -45,7 +43,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     ports:
-      - ${FAST_WEB_PORT:-18080}:8080
+      - ${FAST_WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 2 --timeout 180 --max-requests 500
       - OL_DEPLOYMENT_NAME=testing

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -16,7 +16,7 @@ from sentry_sdk import set_tag
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 import infogami
-from openlibrary.core.env import get_ol_env
+from openlibrary.core.env import get_deployment_name, get_ol_env
 from openlibrary.fastapi import proxy
 from openlibrary.fastapi.middleware.experiments import ABTestingMiddleware
 from openlibrary.utils.request_context import set_context_from_fastapi
@@ -269,20 +269,16 @@ def create_app() -> FastAPI | None:
 
     _include_routers(app)
 
-    # Only enable fallback proxy in LOCAL_DEV. The previous check
-    # `get_deployment_name() == "testing"` was evaluated at startup when
-    # `web.ctx.host` is empty, so it always returned "development" and
-    # never enabled the proxy on testing — and when it did run it wasn't
-    # per-request, so homepage returned 404. Reverted port swap
-    # (web:8080, fast_web:18080) until per-request detection is verified.
-    # TODO: re-enable for testing with per-request host check:
-    #   host = request.headers.get("host", "").split(":")[0]
-    #   if not get_ol_env().LOCAL_DEV and host != "testing.openlibrary.org":
-    #       raise HTTPException(404)
-    if get_ol_env().LOCAL_DEV:
+    # FastAPI is the front door for local dev and testing; proxy the rest to
+    # web.py (production keeps web.py on :8080, so the proxy stays off). Outside
+    # local dev, serve only the real testing host.
+    if get_ol_env().LOCAL_DEV or get_deployment_name() == "testing":
 
         @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
         async def fallback(request: Request, path: str) -> Response:
+            host = request.headers.get("host", "").split(":")[0]
+            if not get_ol_env().LOCAL_DEV and host != "testing.openlibrary.org":
+                raise HTTPException(status_code=404)
             if request.headers.get("X-Proxied-By") == "FastAPI":
                 raise HTTPException(status_code=404)
             return await proxy.proxy_to_webpy(request)

--- a/openlibrary/components/TestingEnvironment/utils.js
+++ b/openlibrary/components/TestingEnvironment/utils.js
@@ -80,22 +80,10 @@ export function decodeAndParseJSON(str) {
 }
 
 /**
- * Return the same-origin JSON endpoint for the current deployment.
- *
- * The testing site exposes FastAPI behind /_fast; local development proxies
- * the unprefixed path through web.py to the FastAPI container.
- */
-export function testingStatusUrl(location) {
-    return location.hostname === 'testing.openlibrary.org'
-        ? '/_fast/status/testing.json'
-        : '/status/testing.json';
-}
-
-/**
  * Fetch the testing-environment state.
  */
-export async function getTestingStatus(location = window.location) {
-    const response = await fetch(testingStatusUrl(location), {
+export async function getTestingStatus() {
+    const response = await fetch('/status/testing.json', {
         headers: { Accept: 'application/json' },
         credentials: 'same-origin'
     });

--- a/openlibrary/fastapi/proxy.py
+++ b/openlibrary/fastapi/proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from fastapi.responses import StreamingResponse
@@ -12,13 +13,30 @@ from openlibrary.utils.async_utils import cache_per_event_loop
 if TYPE_CHECKING:
     from fastapi import Request, Response
 
+# web.py's host as the proxy addresses it (see the upstream URL below).
+WEBPY_NETLOC = "web:8080"
+
 # This timeout would set a global OpenLibrary timeout for all requests, which this code shouldn't handle.
 get_async_session = cache_per_event_loop(lambda: httpx.AsyncClient(follow_redirects=False, timeout=None))
 
 
+def _rebase_redirect(location: str, client_scheme: str, client_netloc: str) -> str:
+    """Rebase a Location that points at web.py's internal origin onto the public one.
+
+    Only the scheme and netloc are swapped, so URLs whose authority is not exactly
+    web.py's are returned untouched. In particular, "web:8080" appearing in a path
+    or query param is left alone, as are lookalike hosts like web:8080.evil.com
+    (rebasing those would hand out a redirect to an attacker's domain).
+    """
+    parts = urlsplit(location)
+    if parts.netloc.lower() != WEBPY_NETLOC or parts.scheme not in ("http", "https"):
+        return location
+    return urlunsplit(parts._replace(scheme=client_scheme, netloc=client_netloc))
+
+
 async def proxy_to_webpy(request: Request) -> Response:
     """Forward request to web.py on http://web:8080."""
-    url = f"http://web:8080{request.url.path}?{request.url.query}"
+    url = f"http://{WEBPY_NETLOC}{request.url.path}?{request.url.query}"
 
     headers = dict(request.headers)
     headers.pop("host", None)
@@ -42,10 +60,9 @@ async def proxy_to_webpy(request: Request) -> Response:
     if location := resp.headers.get("location", ""):
         # web.py builds absolute redirects from the Host header + wsgi.url_scheme
         # (X-Scheme), which we forward, so it may emit http:// or https://web:8080.
-        # Rewrite both to the client-facing origin, e.g. https://testing.openlibrary.org.
+        # Rebase both onto the client-facing origin, e.g. https://testing.openlibrary.org.
         client_scheme = request.headers.get("x-forwarded-proto") or request.headers.get("x-scheme") or request.url.scheme
-        client_origin = f"{client_scheme}://{request.headers.get('host', 'localhost:8080')}"
-        location = location.replace("http://web:8080", client_origin).replace("https://web:8080", client_origin)
+        location = _rebase_redirect(location, client_scheme, request.headers.get("host", "localhost:8080"))
         filtered_headers["location"] = location
 
     async def stream_body():

--- a/openlibrary/fastapi/proxy.py
+++ b/openlibrary/fastapi/proxy.py
@@ -40,7 +40,12 @@ async def proxy_to_webpy(request: Request) -> Response:
     filtered_headers["X-Served-By"] = "web.py"
 
     if location := resp.headers.get("location", ""):
-        location = location.replace("http://web:8080", f"http://{request.headers.get('host', 'localhost:8080')}")
+        # web.py builds absolute redirects from the Host header + wsgi.url_scheme
+        # (X-Scheme), which we forward, so it may emit http:// or https://web:8080.
+        # Rewrite both to the client-facing origin, e.g. https://testing.openlibrary.org.
+        client_scheme = request.headers.get("x-forwarded-proto") or request.headers.get("x-scheme") or request.url.scheme
+        client_origin = f"{client_scheme}://{request.headers.get('host', 'localhost:8080')}"
+        location = location.replace("http://web:8080", client_origin).replace("https://web:8080", client_origin)
         filtered_headers["location"] = location
 
     async def stream_body():

--- a/openlibrary/plugins/openlibrary/js/search-modal/searchFacets.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/searchFacets.js
@@ -8,24 +8,6 @@
 
 const FACETS_PATH = '/search/facets.json';
 
-/**
- * Return the same-origin facets endpoint for the current deployment.
- *
- * The endpoint only exists in FastAPI. Testing exposes that behind `/_fast`,
- * while local dev proxies the unprefixed path through web.py. Everywhere else
- * web.py answers the bare path with a 500 from its deprecated-endpoint handler,
- * which fetchFacetCounts() would surface as a failed load and an uncounted
- * dropper. Mirrors testingStatusUrl() in components/TestingEnvironment/utils.js.
- *
- * @param {Location} location - Defaults to the current page location.
- * @returns {string}
- */
-export function facetsUrl(location = window.location) {
-    return location.hostname === 'testing.openlibrary.org'
-        ? `/_fast${FACETS_PATH}`
-        : FACETS_PATH;
-}
-
 // Filter params to drop when counting a given field, where the param name isn't
 // just the field name: /search accepts either spelling of the author filter.
 const OWN_FILTER_PARAMS = {
@@ -61,7 +43,7 @@ export async function fetchFacetCounts(field, searchParams) {
     }
     params.set('field', field);
 
-    const response = await fetch(`${facetsUrl()}?${params.toString()}`);
+    const response = await fetch(`${FACETS_PATH}?${params.toString()}`);
     if (!response.ok) {
         throw new Error(`fetchFacetCounts: HTTP ${response.status} for field="${field}"`);
     }

--- a/openlibrary/tests/fastapi/test_proxy.py
+++ b/openlibrary/tests/fastapi/test_proxy.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
-from openlibrary.fastapi.proxy import proxy_to_webpy
+from openlibrary.fastapi.proxy import _rebase_redirect, proxy_to_webpy
 
 
 def _make_app():
@@ -172,6 +172,18 @@ def test_location_is_rewritten_to_client_host(status_code):
             "https://archive.org/services/img/OL1M",
             id="non-webpy-absolute-location-untouched",
         ),
+        pytest.param(
+            "HTTP://WEB:8080/books/OL1M",
+            {},
+            "http://testserver/books/OL1M",
+            id="case-insensitive-upstream-origin-rebased",
+        ),
+        pytest.param(
+            "/account/login?redirect=http://web:8080/works/OL1W",
+            {},
+            "/account/login?redirect=http://web:8080/works/OL1W",
+            id="webpy-url-in-query-param-untouched",
+        ),
     ],
 )
 def test_location_scheme_matches_client_facing_scheme(upstream_location, request_headers, expected_location):
@@ -183,6 +195,26 @@ def test_location_scheme_matches_client_facing_scheme(upstream_location, request
 
     assert response.status_code == 302
     assert response.headers["location"] == expected_location
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        pytest.param("http://web:8080/works/OL1W", "https://ol.org/works/OL1W", id="http-rebased"),
+        pytest.param("https://web:8080/works/OL1W", "https://ol.org/works/OL1W", id="https-rebased"),
+        pytest.param("HTTP://WEB:8080/works/OL1W", "https://ol.org/works/OL1W", id="case-insensitive-rebased"),
+        pytest.param("http://web:8080?a=1#frag", "https://ol.org?a=1#frag", id="query-and-fragment-preserved"),
+        pytest.param("/login?redirect=http://web:8080/works/OL1W", "/login?redirect=http://web:8080/works/OL1W", id="query-param-substring-untouched"),
+        pytest.param("/static/http://web:8080/logo.png", "/static/http://web:8080/logo.png", id="path-substring-untouched"),
+        pytest.param("http://web:8080.evil.com/works/OL1W", "http://web:8080.evil.com/works/OL1W", id="lookalike-host-untouched"),
+        pytest.param("http://user@web:8080/works/OL1W", "http://user@web:8080/works/OL1W", id="userinfo-netloc-untouched"),
+        pytest.param("https://archive.org/works/OL1W", "https://archive.org/works/OL1W", id="other-host-untouched"),
+        pytest.param("/works/OL1W", "/works/OL1W", id="relative-untouched"),
+    ],
+)
+def test_rebase_redirect(location, expected):
+    """Only Locations whose authority is exactly web.py's may be rebased; everything else passes through."""
+    assert _rebase_redirect(location, "https", "ol.org") == expected
 
 
 def test_upstream_failure_propagates():

--- a/openlibrary/tests/fastapi/test_proxy.py
+++ b/openlibrary/tests/fastapi/test_proxy.py
@@ -145,6 +145,46 @@ def test_location_is_rewritten_to_client_host(status_code):
     assert response.headers["location"] == "http://testserver/books/OL1M"
 
 
+@pytest.mark.parametrize(
+    ("upstream_location", "request_headers", "expected_location"),
+    [
+        pytest.param(
+            "https://web:8080/books/OL1M",
+            {},
+            "http://testserver/books/OL1M",
+            id="https-upstream-no-forwarded-headers",
+        ),
+        pytest.param(
+            "https://web:8080/books/OL1M",
+            {"X-Scheme": "https"},
+            "https://testserver/books/OL1M",
+            id="x-scheme-https-rewrites-to-https",
+        ),
+        pytest.param(
+            "http://web:8080/books/OL1M",
+            {"X-Forwarded-Proto": "https"},
+            "https://testserver/books/OL1M",
+            id="x-forwarded-proto-https-rewrites-to-https",
+        ),
+        pytest.param(
+            "https://archive.org/services/img/OL1M",
+            {"X-Scheme": "https"},
+            "https://archive.org/services/img/OL1M",
+            id="non-webpy-absolute-location-untouched",
+        ),
+    ],
+)
+def test_location_scheme_matches_client_facing_scheme(upstream_location, request_headers, expected_location):
+    """The rewritten Location must use the client-facing scheme (https on testing, http locally)."""
+    fake_client = FakeClient(FakeResponse([b""], status_code=302, headers={"location": upstream_location}))
+
+    with _proxy_client(fake_client) as client:
+        response = client.get("/books/OL1M", headers=request_headers, follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == expected_location
+
+
 def test_upstream_failure_propagates():
     """If the upstream request fails, the error propagates and the shared client survives."""
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -44,15 +44,3 @@ class TestDockerCompose:
         for service_name in ("web", "fast_web"):
             assert "OL_DEPLOYMENT_NAME=testing" in staging_dc["services"][service_name]["environment"]
             assert "OL_DEPLOYMENT_NAME=production" in prod_dc["services"][service_name]["environment"]
-
-    def test_staging_fastapi_is_front_door(self):
-        """
-        FastAPI (:8080) must be the public entry point on staging, like local
-        dev, with web.py reachable only over the internal network via the
-        fallback proxy (http://web:8080) — no published host port of its own.
-        """
-        with open(p("..", "compose.staging.yaml")) as f:
-            staging_dc: dict = yaml.safe_load(f)
-
-        assert staging_dc["services"]["web"].get("ports", []) == []
-        assert "${FAST_WEB_PORT:-8080}:8080" in staging_dc["services"]["fast_web"]["ports"]

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -44,3 +44,15 @@ class TestDockerCompose:
         for service_name in ("web", "fast_web"):
             assert "OL_DEPLOYMENT_NAME=testing" in staging_dc["services"][service_name]["environment"]
             assert "OL_DEPLOYMENT_NAME=production" in prod_dc["services"][service_name]["environment"]
+
+    def test_staging_fastapi_is_front_door(self):
+        """
+        FastAPI (:8080) must be the public entry point on staging, like local
+        dev, with web.py reachable only over the internal network via the
+        fallback proxy (http://web:8080) — no published host port of its own.
+        """
+        with open(p("..", "compose.staging.yaml")) as f:
+            staging_dc: dict = yaml.safe_load(f)
+
+        assert staging_dc["services"]["web"].get("ports", []) == []
+        assert "${FAST_WEB_PORT:-8080}:8080" in staging_dc["services"]["fast_web"]["ports"]

--- a/tests/unit/js/searchFacets.test.js
+++ b/tests/unit/js/searchFacets.test.js
@@ -9,23 +9,11 @@
 
 import {
     FACET_OPEN_BUDGET_MS,
-    facetsUrl,
     fetchFacetCounts,
     mergeFacetCounts,
     openWhenCountsReady,
 } from '../../../openlibrary/plugins/openlibrary/js/search-modal/searchFacets.js';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// facetsUrl
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe('facetsUrl', () => {
-    test('uses the FastAPI proxy only on the testing host', () => {
-        expect(facetsUrl({ hostname: 'localhost' })).toBe('/search/facets.json');
-        expect(facetsUrl({ hostname: 'testing.openlibrary.org' })).toBe('/_fast/search/facets.json');
-        expect(facetsUrl({ hostname: 'openlibrary.org' })).toBe('/search/facets.json');
-    });
-});
 // ─────────────────────────────────────────────────────────────────────────────
 // fetchFacetCounts
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/js/testing-status.test.js
+++ b/tests/unit/js/testing-status.test.js
@@ -9,7 +9,6 @@ import {
     getTestingStatus,
     postAction,
     sprintf,
-    testingStatusUrl,
     timeAgo
 } from '../../../openlibrary/components/TestingEnvironment/utils.js';
 
@@ -34,18 +33,12 @@ describe('Testing Environment utils', () => {
         delete global.fetch;
     });
 
-    test('uses the FastAPI proxy only on the testing host', () => {
-        expect(testingStatusUrl({ hostname: 'localhost' })).toBe('/status/testing.json');
-        expect(testingStatusUrl({ hostname: 'testing.openlibrary.org' })).toBe('/_fast/status/testing.json');
-        expect(testingStatusUrl({ hostname: 'openlibrary.org' })).toBe('/status/testing.json');
-    });
-
     test('fetches JSON with same-origin credentials', async() => {
         const payload = { prs: [pr] };
         const response = { ok: true, json: jest.fn().mockResolvedValue(payload) };
         global.fetch = jest.fn().mockResolvedValue(response);
 
-        await expect(getTestingStatus({ hostname: 'localhost' })).resolves.toBe(payload);
+        await expect(getTestingStatus()).resolves.toBe(payload);
         expect(global.fetch).toHaveBeenCalledWith('/status/testing.json', {
             headers: { Accept: 'application/json' },
             credentials: 'same-origin'
@@ -82,7 +75,7 @@ describe('Testing Environment utils', () => {
     test('rejects failed fetches and posts', async() => {
         global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
 
-        await expect(getTestingStatus({ hostname: 'localhost' })).rejects.toThrow('500');
+        await expect(getTestingStatus()).rejects.toThrow('500');
         await expect(postAction('/status/remove', {})).rejects.toThrow('failed');
     });
 


### PR DESCRIPTION
## Summary

Make the testing deployment serve from FastAPI (`fast_web`) on port 8080, like
local dev, with unmatched requests proxied to web.py. web.py no longer publishes
a host port.

## Changes

- `compose.staging.yaml` — `fast_web` is the public entry point on :8080; web.py
  publishes no host port (the fallback proxy reaches it over the internal network)
- `openlibrary/asgi_app.py` — the fallback proxy is now enabled on testing as
  well as local dev (deployment detected via `OL_DEPLOYMENT_NAME` from #13515),
  with a per-request host check so only `testing.openlibrary.org` is served
- Client JS — drop the `/_fast` prefix now that FastAPI answers
  `/status/testing.json` and `/search/facets.json` directly
- `tests/test_docker_compose.py` — regression test for the new staging port layout

## Deploying to testing — the nginx config must change at the same time

The compose port swap, the proxy enablement, and the **olsystem nginx config
change must all land in the same deploy**:

1. **Update the olsystem nginx config** (outside this repo): route everything to
   `fast_web` on port 8080 and remove the `/_fast` location that currently
   points at FastAPI.
2. Deploy this branch (`compose.staging.yaml` + `asgi_app.py` + client JS).

Deploying any of these without the others breaks testing — e.g. swapping the
ports while nginx still points at web.py, or changing nginx while the compose
files still put web.py on the front door. Roll back all three together if needed.