### PR TITLE
perf(lending): avoid duplicate loan fetch in account_loans.GET

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1264,7 +1264,6 @@ class account_loans(delegate.page):
 
     @require_login
     def GET(self):
-        from openlibrary.core.lending import get_loans_of_user
         from openlibrary.plugins.openlibrary.home import get_cached_featured_subjects
 
         i = web.input(page=1)
@@ -1273,10 +1272,9 @@ class account_loans(delegate.page):
         except ValueError:
             page = 1
         user = accounts.get_current_user()
-        user.update_loan_status()
+        docs = user.update_loan_status()
         username = user["key"].split("/")[-1]
         mb = MyBooksTemplate(username, "loans")
-        docs = get_loans_of_user(user.key)
         loan_history_data = get_loan_history_data(username, page=page)
         featured_subjects = get_cached_featured_subjects()
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -858,14 +858,14 @@ class User(models.User):
         return len(lending.get_loans_of_user(self.key))
 
     def get_loans(self):
-        self.update_loan_status()
-        return lending.get_loans_of_user(self.key)
+        return self.update_loan_status()
 
     def update_loan_status(self):
         """Update the status of this user's loans."""
         loans = lending.get_loans_of_user(self.key)
         for loan in loans:
             lending.sync_loan(loan["ocaid"])
+        return loans
 
     def get_safe_mode(self):
         return (self.get_users_settings() or {}).get("safe_mode", "").lower()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows - #13505 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refector (perf)

### Technical
<!-- What should be noted about the implementation? -->

`account_loans.GET` was fetching the user's loans twice per request:
`update_loan_status()` already fetched the loans, followed by a second
`get_loans_of_user()` call.

`update_loan_status()` now returns the fetched loan list, allowing
`account_loans.GET` and `User.get_loans()` to reuse it and avoid the
redundant fetch.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Existing lending and account-loans tests pass.
- `ruff check` passes on changed files.
- `git diff --check` passes.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Not applicable — no UI changes.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @cdrini 