### PR TITLE
fix(lending): don't let an empty availability response raise out of sync_loan()

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -717,8 +717,7 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
 
     responses = get_availability("identifier", [identifier])
     response = responses[identifier] if responses else {}
-    if response:
-        num_waiting = int(response.get("num_waitlist", 0) or 0)
+    num_waiting = int(response.get("num_waitlist", 0) or 0)
 
     ebook = EBookRecord.find(identifier)
 
@@ -735,7 +734,7 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
         "type": "ebook",
         "identifier": identifier,
         "loan": ebook_loan_data,
-        "borrowed": str(response["status"] not in ["open", "borrow_available"]).lower(),
+        "borrowed": str(response.get("status") not in ["open", "borrow_available"]).lower(),
         "wl_size": num_waiting,
     }
     try:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows - #13518 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical

`sync_loan()` could raise when the availability API returned an empty
response. `num_waiting` was only initialized when a response existed,
and the code accessed `response["status"]` unconditionally.

This change defaults `num_waiting` to `0` and safely reads the status with
`response.get()`, allowing `sync_loan()` to complete when availability
data is unavailable.

### Testing

- Existing lending tests: 15 passed.
- `ruff check` passed.
- `ruff format --check` passed.
- `git diff --check` passed.


### Stakeholders

@mekarpeles @cdrini 