### PR TITLE
Updates to `store_index` backfill script

### DIFF
--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -14,7 +14,7 @@ from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_re
 
 DEFAULT_CONFIG_PATH = "conf/openlibrary.yml"
 DEFAULT_BATCH_SIZE = 20_000
-
+DEFAULT_LOWER_BOUND = 0
 
 def init(conf_path):
     init_signal_handler()
@@ -48,7 +48,7 @@ def main(args):
     max_upper_bound = find_upper_bound()
 
     # Backfill new IDs in batches
-    lower_bound = 0
+    lower_bound = args.lower_bound
     while lower_bound < max_upper_bound and not was_shutdown_requested():
         start = time.perf_counter()
         backfill_rows(lower_bound, lower_bound + args.batch_size)
@@ -61,6 +61,7 @@ def _parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("-c", "--config", default=DEFAULT_CONFIG_PATH, help="Path to openlibrary configuration yaml")
     p.add_argument("-b", "--batch-size", default=DEFAULT_BATCH_SIZE, type=int)
+    p.add_argument("-l", "--lower-bound", default=DEFAULT_LOWER_BOUND, type=int)
     p.set_defaults(func=main)
     return p.parse_args()
 

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Backfills new ID column in the `store_index` table.
 """

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -26,9 +26,9 @@ def find_upper_bound():
     oldb = db.get_db()
 
     query = """
-        SELECT MIN(new_id) as min from store_index
+        SELECT MAX(id) as ubound from store_index WHERE new_id IS NULL
     """
-    return next(iter(oldb.query(query)))["min"]
+    return next(iter(oldb.query(query)))["ubound"]
 
 
 def backfill_rows(lower_bound, upper_bound):

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG_PATH = "conf/openlibrary.yml"
 DEFAULT_BATCH_SIZE = 20_000
 DEFAULT_LOWER_BOUND = 0
 
+
 def init(conf_path):
     init_signal_handler()
     setup_for_script(conf_path)

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -55,7 +55,7 @@ def main(args):
         backfill_rows(lower_bound, lower_bound + args.batch_size)
         lower_bound += args.batch_size
         elapsed = time.perf_counter() - start
-        print(f"Chunk updated in {elapsed:.6f} seconds")
+        print(f"Block updated in {elapsed:.6f} seconds.  Next block starts with ID {lower_bound}", flush=True)
 
 
 def _parse_args():

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -17,6 +17,7 @@ DEFAULT_BATCH_SIZE = 20_000
 DEFAULT_LOWER_BOUND = 0
 DEFAULT_WAL_DIR_MAX_SIZE = 0
 
+
 def init(conf_path):
     init_signal_handler()
     setup_for_script(conf_path)
@@ -64,7 +65,7 @@ def main(args):
     iterations = 0
     while lower_bound < max_upper_bound and not was_shutdown_requested():
         if iterations % 10 == 0 and args.wal_threshold:
-            if args.wal_threshold * (1024 ** 3) > get_wal_dir_size():
+            if args.wal_threshold * (1024**3) > get_wal_dir_size():
                 print("WAL directory has grown larger than threshold.  Stopping script.", flush=True)
                 break
         start = time.perf_counter()
@@ -74,12 +75,19 @@ def main(args):
         print(f"Block updated in {elapsed:.6f} seconds.  Next block starts with ID {lower_bound}", flush=True)
         iterations += 1
 
+
 def _parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("-c", "--config", default=DEFAULT_CONFIG_PATH, help="Path to openlibrary configuration yaml")
     p.add_argument("-b", "--batch-size", default=DEFAULT_BATCH_SIZE, type=int)
     p.add_argument("-l", "--lower-bound", default=DEFAULT_LOWER_BOUND, type=int)
-    p.add_argument("-t", "--wal-threshold", default=DEFAULT_WAL_DIR_MAX_SIZE, type=float, help="If non-zero, the script will stop if the WAL directory grows beyond this many GB")
+    p.add_argument(
+        "-t",
+        "--wal-threshold",
+        default=DEFAULT_WAL_DIR_MAX_SIZE,
+        type=float,
+        help="If non-zero, the script will stop if the WAL directory grows beyond this many GB",
+    )
     p.set_defaults(func=main)
     return p.parse_args()
 

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -65,7 +65,7 @@ def main(args):
     iterations = 0
     while lower_bound < max_upper_bound and not was_shutdown_requested():
         if iterations % 10 == 0 and args.wal_threshold:
-            if args.wal_threshold * (1024**3) > get_wal_dir_size():
+            if args.wal_threshold * (1024**3) < get_wal_dir_size():
                 print("WAL directory has grown larger than threshold.  Stopping script.", flush=True)
                 break
         start = time.perf_counter()

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -64,7 +64,7 @@ def main(args):
     lower_bound = args.lower_bound
     iterations = 0
     while lower_bound < max_upper_bound and not was_shutdown_requested():
-        if iterations % 10 == 0 and args.wal_threshold:
+        if iterations % 10 == 0 and args.wal_threshold:  # noqa: SIM102
             if args.wal_threshold * (1024**3) < get_wal_dir_size():
                 print("WAL directory has grown larger than threshold.  Stopping script.", flush=True)
                 break

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -15,7 +15,7 @@ from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_re
 DEFAULT_CONFIG_PATH = "conf/openlibrary.yml"
 DEFAULT_BATCH_SIZE = 20_000
 DEFAULT_LOWER_BOUND = 0
-
+DEFAULT_WAL_DIR_MAX_SIZE = 0
 
 def init(conf_path):
     init_signal_handler()
@@ -30,6 +30,17 @@ def find_upper_bound():
         SELECT MAX(id) as ubound from store_index WHERE new_id IS NULL
     """
     return next(iter(oldb.query(query)))["ubound"]
+
+
+def get_wal_dir_size():
+    oldb = db.get_db()
+
+    query = """
+        SELECT count(*) AS file_count,
+            sum(size) AS total_bytes
+        FROM pg_ls_waldir();
+    """
+    return next(iter(oldb.query(query)))["total_bytes"]
 
 
 def backfill_rows(lower_bound, upper_bound):
@@ -50,19 +61,25 @@ def main(args):
 
     # Backfill new IDs in batches
     lower_bound = args.lower_bound
+    iterations = 0
     while lower_bound < max_upper_bound and not was_shutdown_requested():
+        if iterations % 10 == 0 and args.wal_threshold:
+            if args.wal_threshold * (1024 ** 3) > get_wal_dir_size():
+                print("WAL directory has grown larger than threshold.  Stopping script.", flush=True)
+                break
         start = time.perf_counter()
         backfill_rows(lower_bound, lower_bound + args.batch_size)
         lower_bound += args.batch_size
         elapsed = time.perf_counter() - start
         print(f"Block updated in {elapsed:.6f} seconds.  Next block starts with ID {lower_bound}", flush=True)
-
+        iterations += 1
 
 def _parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("-c", "--config", default=DEFAULT_CONFIG_PATH, help="Path to openlibrary configuration yaml")
     p.add_argument("-b", "--batch-size", default=DEFAULT_BATCH_SIZE, type=int)
     p.add_argument("-l", "--lower-bound", default=DEFAULT_LOWER_BOUND, type=int)
+    p.add_argument("-t", "--wal-threshold", default=DEFAULT_WAL_DIR_MAX_SIZE, type=float, help="If non-zero, the script will stop if the WAL directory grows beyond this many GB")
     p.set_defaults(func=main)
     return p.parse_args()
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #13483

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies the `store_index` ID backfill script in the following ways:

- Adds shebang to the script
- Improve query for the upper bound `id` value
- Adds option to begin updates starting from a given `id`

TODO:
- `chmod a+x scripts/backfill_store_index.py`
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
