### PR TITLE
Make FastAPI the primary entry point in production

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -11,8 +11,6 @@ services:
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: unless-stopped
     hostname: "$HOSTNAME"
-    ports:
-      - ${WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 25 --timeout 300 --max-requests 1500
       - OL_DEPLOYMENT_NAME=production
@@ -31,7 +29,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     ports:
-      - ${FAST_WEB_PORT:-18080}:8080
+      - ${FAST_WEB_PORT:-8080}:8080
     environment:
       - GUNICORN_OPTS= --workers 7 --timeout 300 --max-requests 5000 --max-requests-jitter 500
       - OL_DEPLOYMENT_NAME=production

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -16,7 +16,7 @@ from sentry_sdk import set_tag
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 import infogami
-from openlibrary.core.env import get_deployment_name, get_ol_env
+from openlibrary.core.env import get_ol_env
 from openlibrary.fastapi import proxy
 from openlibrary.fastapi.middleware.experiments import ABTestingMiddleware
 from openlibrary.utils.request_context import set_context_from_fastapi
@@ -269,19 +269,24 @@ def create_app() -> FastAPI | None:
 
     _include_routers(app)
 
-    # FastAPI is the front door for local dev and testing; proxy the rest to
-    # web.py (production keeps web.py on :8080, so the proxy stays off). Outside
-    # local dev, serve only the real testing host.
-    if get_ol_env().LOCAL_DEV or get_deployment_name() == "testing":
+    # FastAPI is the front door everywhere; proxy anything it doesn't
+    # handle to web.py. Outside local dev, only serve the real public hosts
+    # (plus TestClient's default host, so tests exercise real routing).
+    KNOWN_HOSTS = {
+        "testing.openlibrary.org",
+        "openlibrary.org",
+        "www.openlibrary.org",
+        "testserver",
+    }
 
-        @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
-        async def fallback(request: Request, path: str) -> Response:
-            host = request.headers.get("host", "").split(":")[0]
-            if not get_ol_env().LOCAL_DEV and host != "testing.openlibrary.org":
-                raise HTTPException(status_code=404)
-            if request.headers.get("X-Proxied-By") == "FastAPI":
-                raise HTTPException(status_code=404)
-            return await proxy.proxy_to_webpy(request)
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
+    async def fallback(request: Request, path: str) -> Response:
+        host = request.headers.get("host", "").split(":")[0]
+        if not get_ol_env().LOCAL_DEV and host not in KNOWN_HOSTS:
+            raise HTTPException(status_code=404)
+        if request.headers.get("X-Proxied-By") == "FastAPI":
+            raise HTTPException(status_code=404)
+        return await proxy.proxy_to_webpy(request)
 
     return app
 

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from openlibrary.fastapi.auth import (
@@ -18,7 +19,13 @@ from openlibrary.plugins.worksearch.code import SearchResponse
 @pytest.fixture(scope="session")
 def fastapi_client():
     """Create a test client for the FastAPI app (session-scoped for speed)."""
-    with patch("openlibrary.asgi_app.set_context_from_fastapi", autospec=True):
+    with (
+        patch("openlibrary.asgi_app.set_context_from_fastapi", autospec=True),
+        patch(
+            "openlibrary.fastapi.proxy.proxy_to_webpy",
+            side_effect=HTTPException(status_code=404),
+        ),
+    ):
         from openlibrary.asgi_app import create_app  # noqa: PLC0415
 
         app = create_app()

--- a/openlibrary/tests/fastapi/test_cdn.py
+++ b/openlibrary/tests/fastapi/test_cdn.py
@@ -45,10 +45,17 @@ class TestIaJsCdn:
 
     @pytest.mark.parametrize(
         "bad_name",
-        ["evil.js", "../../etc/passwd", "donate.js.map", "athena.min.js", ""],
+        ["evil.js", "donate.js.map", "athena.min.js"],
     )
     def test_various_invalid_filenames_return_404(self, fastapi_client, mock_upstream, bad_name):
         """Any filename that is not donate.js or athena.js must be rejected with 404."""
+        response = fastapi_client.get(f"/cdn/archive.org/{bad_name}")
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("bad_name", ["../../etc/passwd", ""])
+    def test_unroutable_filenames_fall_through_to_proxy(self, fastapi_client, mock_upstream, bad_name):
+        """Filenames that don't match the route path fall through to the
+        web.py proxy, which is stubbed to 404 in tests."""
         response = fastapi_client.get(f"/cdn/archive.org/{bad_name}")
         assert response.status_code == 404
 

--- a/openlibrary/tests/fastapi/test_hide_banner.py
+++ b/openlibrary/tests/fastapi/test_hide_banner.py
@@ -99,5 +99,7 @@ class TestHideBannerEndpoint:
         get_response = fastapi_client.get("/hide_banner")
         json_suffix_response = fastapi_client.post("/hide_banner.json", json={"cookie-name": "wrong-path-banner"})
 
-        assert get_response.status_code == 405
+        # A GET request has no FastAPI handler and falls through to the
+        # web.py proxy, which is stubbed to 404 in tests.
+        assert get_response.status_code == 404
         assert json_suffix_response.status_code == 404

--- a/openlibrary/tests/fastapi/test_qrcode.py
+++ b/openlibrary/tests/fastapi/test_qrcode.py
@@ -47,4 +47,6 @@ class TestQRCodeEndpoint:
     def test_only_get_is_registered(self, fastapi_client):
         response = fastapi_client.post("/qrcode", data={"path": "/books/OL1M"})
 
-        assert response.status_code == 405
+        # A non-GET request has no FastAPI handler and falls through to the
+        # web.py proxy, which is stubbed to 404 in tests.
+        assert response.status_code == 404


### PR DESCRIPTION
FastAPI now serves all requests in production. Unmatched requests go to web.py through the proxy.

- Remove the environment check for the fallback proxy in asgi_app.py.
- Allow only known public hosts outside local development.
- Swap the port bindings in compose.production.yaml. FastAPI uses 8080. web.py has no host port.

Similar to https://github.com/internetarchive/openlibrary/pull/13516 we'll need to:
1. Deploy this to prod
2. Update the nginx config
3. Monitor for any issues
