### PR TITLE
fix(docker): bump mockservices python base image to 3.14

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -225,7 +225,7 @@ services:
       - ${MOCKSERVICES_PORT:-8025}:8025
     healthcheck:
       # wget is purged from the image after installing mailpit (see Dockerfile);
-      # use python, which is always present in the python:3.12-slim base, instead.
+      # use python, which is always present in the python:3.14-slim base, instead.
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/health', timeout=2)"]
       interval: 10s
       start_period: 5s

--- a/docker/mockservices/Dockerfile
+++ b/docker/mockservices/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Install mailpit (SMTP capture + web UI)
 ARG MAILPIT_VERSION=1.21.6


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Bumps the `mockservices` Docker base image from Python 3.12 to 3.14 (`python:3.14-slim`) to match Open Library's Python 3.14 environment and support Python 3.14 syntax/features used across services and mocks.

### Technical
<!-- What should be noted about the implementation? -->
- Updated `docker/mockservices/Dockerfile` base image to `python:3.14-slim`.
- Updated healthcheck comment in `compose.override.yaml` referencing `python:3.14-slim`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ran `docker/mockservices/tests`: passed.
- Ran `openlibrary/mocks/tests` and `tests/test_docker_compose.py`: passed.
- Ran `pre-commit`: passed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
