### PR TITLE
refactor: route site layout through Jinja (first step) (#13524)

### DIFF
--- a/openlibrary/core/jinja.py
+++ b/openlibrary/core/jinja.py
@@ -12,11 +12,15 @@ from markupsafe import escape as _markupsafe_escape
 def render_jinja_template(template_name: str, **kwargs: Any) -> str:
     """Render a Jinja template and return the resulting HTML string.
 
-    This is a generic helper to render any Jinja template from the macros
-    directory and pass it values from Templetor templates.
+    A generic helper to render any Jinja template from the macros or
+    templates directory and pass it values, from Templetor templates,
+    other Jinja templates, or plain Python.
 
     Usage in Templetor template:
         $:render_template("MyTemplate.html.jinja", foo="bar")
+
+    Usage in Python (e.g. serving the site layout):
+        render_jinja_template("site.html.jinja", page=page)
     """
     env = get_jinja_env()
     template = env.get_template(template_name)
@@ -82,7 +86,16 @@ def get_jinja_env() -> Environment:
     # Import is deferred to avoid circular imports at module level.
     from infogami.utils.view import render_template
 
-    env.globals["render_templetor_template"] = render_template
+    def _render_templetor_template(name: str, *args: Any, **kwargs: Any) -> Markup:
+        """Render a Templetor template and return it as trusted HTML.
+
+        ``Markup`` because a rendered template is HTML by construction and
+        the env autoescapes — without it every call site would need
+        ``|safe`` (see ``icon`` below for the same rationale).
+        """
+        return Markup(str(render_template(name, *args, **kwargs)))
+
+    env.globals["render_templetor_template"] = _render_templetor_template
 
     def _icon(name: str, size: str = "md", label: str = "", extra_class: str = "") -> Markup:
         """Draw an icon from the icon sprite. See /developers/design/icons.
@@ -119,3 +132,27 @@ def get_jinja_env() -> Environment:
     # ``install_gettext_callables`` auto-registers ``_``, ``gettext``, and
     # ``ngettext`` in ``env.globals`` — no manual globals registration needed.
     return env
+
+
+class _SiteLayoutTemplate:
+    """``site`` pile entry whose ``filename`` satisfies saferender()'s error path."""
+
+    filename = "openlibrary/templates/site.html.jinja"
+
+    def __call__(self, page: Any) -> str:
+        return render_jinja_template("site.html.jinja", page=page)
+
+
+def register_site_layout() -> None:
+    """Serve infogami's ``site`` page wrapper from Jinja.
+
+    Infogami wraps every rendered page in a ``site`` template looked up
+    from a pile of template sources (``render.site(...)`` in
+    ``infogami/utils/delegate.py``); openlibrary's Templetor ``site.html``
+    used to win that lookup.  Adding this source makes the Jinja layout
+    win instead, so the layout needs no Templetor wrapper file at all.
+    """
+    # Import is deferred to avoid circular imports at module level.
+    from infogami.utils import template
+
+    template.render.add_source({"site": _SiteLayoutTemplate()})

--- a/openlibrary/core/jinja.py
+++ b/openlibrary/core/jinja.py
@@ -141,18 +141,3 @@ class _SiteLayoutTemplate:
 
     def __call__(self, page: Any) -> str:
         return render_jinja_template("site.html.jinja", page=page)
-
-
-def register_site_layout() -> None:
-    """Serve infogami's ``site`` page wrapper from Jinja.
-
-    Infogami wraps every rendered page in a ``site`` template looked up
-    from a pile of template sources (``render.site(...)`` in
-    ``infogami/utils/delegate.py``); openlibrary's Templetor ``site.html``
-    used to win that lookup.  Adding this source makes the Jinja layout
-    win instead, so the layout needs no Templetor wrapper file at all.
-    """
-    # Import is deferred to avoid circular imports at module level.
-    from infogami.utils import template
-
-    template.render.add_source({"site": _SiteLayoutTemplate()})

--- a/openlibrary/core/jinja.py
+++ b/openlibrary/core/jinja.py
@@ -134,7 +134,7 @@ def get_jinja_env() -> Environment:
     return env
 
 
-class _SiteLayoutTemplate:
+class SiteLayoutTemplate:
     """``site`` pile entry whose ``filename`` satisfies saferender()'s error path."""
 
     filename = "openlibrary/templates/site.html.jinja"

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -23,7 +23,7 @@ from openlibrary.core.batch_imports import (
     batch_import,
 )
 from openlibrary.core.env import get_deployment_name, get_ol_env
-from openlibrary.core.jinja import register_site_layout, render_jinja_template
+from openlibrary.core.jinja import _SiteLayoutTemplate, render_jinja_template
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import get_coverstore_public_url, setup_requests
 from openlibrary.utils.request_context import (
@@ -1165,8 +1165,8 @@ def setup():
     i18n.load_strings("openlibrary/plugins/openlibrary")
 
     # Infogami wraps every page in its Templetor ``site`` template; serve
-    # the site layout from Jinja instead (openlibrary/core/jinja.py).
-    register_site_layout()
+    # the site layout from Jinja instead.
+    template.render.add_source({"site": _SiteLayoutTemplate()})
 
     sentry.setup()
     home.setup()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -23,7 +23,7 @@ from openlibrary.core.batch_imports import (
     batch_import,
 )
 from openlibrary.core.env import get_deployment_name, get_ol_env
-from openlibrary.core.jinja import render_jinja_template
+from openlibrary.core.jinja import register_site_layout, render_jinja_template
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import get_coverstore_public_url, setup_requests
 from openlibrary.utils.request_context import (
@@ -1163,6 +1163,10 @@ def setup():
     template.load_templates("openlibrary/plugins/openlibrary", lazy=True)
     macro.load_macros("openlibrary/plugins/openlibrary", lazy=True)
     i18n.load_strings("openlibrary/plugins/openlibrary")
+
+    # Infogami wraps every page in its Templetor ``site`` template; serve
+    # the site layout from Jinja instead (openlibrary/core/jinja.py).
+    register_site_layout()
 
     sentry.setup()
     home.setup()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -23,7 +23,7 @@ from openlibrary.core.batch_imports import (
     batch_import,
 )
 from openlibrary.core.env import get_deployment_name, get_ol_env
-from openlibrary.core.jinja import _SiteLayoutTemplate, render_jinja_template
+from openlibrary.core.jinja import SiteLayoutTemplate, render_jinja_template
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import get_coverstore_public_url, setup_requests
 from openlibrary.utils.request_context import (
@@ -1166,7 +1166,7 @@ def setup():
 
     # Infogami wraps every page in its Templetor ``site`` template; serve
     # the site layout from Jinja instead.
-    template.render.add_source({"site": _SiteLayoutTemplate()})
+    template.render.add_source({"site": SiteLayoutTemplate()})
 
     sentry.setup()
     home.setup()

--- a/openlibrary/templates/site.html
+++ b/openlibrary/templates/site.html
@@ -1,2 +1,0 @@
-$def with (page)
-$:render_jinja_template("site/layout.html.jinja", page=page, title=page.title)

--- a/openlibrary/templates/site.html
+++ b/openlibrary/templates/site.html
@@ -1,7 +1,2 @@
 $def with (page)
-
-$:render_template("site/head.tmpl", title=page.title)
-
-$:render_template("site/body", page)
-
-$:render_template("site/footer", page)
+$:render_jinja_template("site/layout.html.jinja", page=page, title=page.title)

--- a/openlibrary/templates/site.html.jinja
+++ b/openlibrary/templates/site.html.jinja
@@ -1,0 +1,3 @@
+{{ render_templetor_template("site/head", title=page.title) }}
+{{ render_templetor_template("site/body", page) }}
+{{ render_templetor_template("site/footer", page) }}

--- a/openlibrary/templates/site/layout.html.jinja
+++ b/openlibrary/templates/site/layout.html.jinja
@@ -1,0 +1,3 @@
+{{ render_templetor_template("site/head", title=title) |safe }}
+{{ render_templetor_template("site/body", page) |safe }}
+{{ render_templetor_template("site/footer", page) |safe }}

--- a/openlibrary/templates/site/layout.html.jinja
+++ b/openlibrary/templates/site/layout.html.jinja
@@ -1,3 +1,0 @@
-{{ render_templetor_template("site/head", title=title) |safe }}
-{{ render_templetor_template("site/body", page) |safe }}
-{{ render_templetor_template("site/footer", page) |safe }}

--- a/openlibrary/tests/core/test_jinja.py
+++ b/openlibrary/tests/core/test_jinja.py
@@ -126,7 +126,7 @@ def test_site_layout_template_uses_jinja_template(monkeypatch):
 
     monkeypatch.setattr(jinja_module, "render_jinja_template", mock_render)
 
-    site_template = jinja_module._SiteLayoutTemplate()
+    site_template = jinja_module.SiteLayoutTemplate()
     assert site_template.filename == "openlibrary/templates/site.html.jinja"
     assert site_template("page") == rendered
 

--- a/openlibrary/tests/core/test_jinja.py
+++ b/openlibrary/tests/core/test_jinja.py
@@ -65,19 +65,13 @@ def _create_validation_env() -> jinja2.Environment:
     env.install_gettext_callables(_gettext, _ngettext, newstyle=True)
     env.policies["ext.i18n.trimmed"] = True
 
-    try:
-        from infogami.utils.view import render_template as _render_templetor  # noqa: PLC0415
+    # Stubbed: this env only validates template structure, without infogami's
+    # runtime template disk-loading or template globals.
+    def _stub_render_templetor(*a, **kw):
+        return ""
 
-        env.globals["render_templetor_template"] = _render_templetor
-    except ImportError:
+    env.globals["render_templetor_template"] = _stub_render_templetor
 
-        def _stub(*a, **kw):
-            return ""
-
-        env.globals["render_templetor_template"] = _stub
-
-    # Stubbed: this env only validates template structure, and the real macro
-    # needs infogami's template globals.
     env.globals["icon"] = lambda *a, **kw: ""
 
     # The TestingEnvironment macro renders a Vue component via
@@ -148,6 +142,12 @@ class TestGetJinjaEnv:
         env = get_jinja_env()
         assert "icon" in env.globals
         assert callable(env.globals["icon"])
+
+    def test_has_render_templetor_template_global(self):
+        """Should expose render_templetor_template in globals."""
+        env = get_jinja_env()
+        assert "render_templetor_template" in env.globals
+        assert callable(env.globals["render_templetor_template"])
 
     def test_has_autoescape_enabled(self):
         """Should have autoescaping enabled."""
@@ -278,7 +278,7 @@ def test_all_jinja_templates_render_valid_html(request_context_fixture, subtests
 
     for path in sorted(templates):
         rel = path.relative_to(TEMPLATES_DIR)
-        with subtests.test(template=str(rel)):
-            tpl = env.get_template(str(rel))
+        with subtests.test(template=rel.as_posix()):
+            tpl = env.get_template(rel.as_posix())
             output = tpl.render()
             assert_valid_html(output)

--- a/openlibrary/tests/core/test_jinja.py
+++ b/openlibrary/tests/core/test_jinja.py
@@ -115,16 +115,8 @@ def assert_valid_html(html_string: str) -> None:
         pytest.fail(f"Rendered HTML contains orphan/mismatched tags: {e}")
 
 
-def test_register_site_layout_uses_jinja_template(monkeypatch):
-    """The registered Infogami source should delegate to the Jinja site wrapper."""
-    registered = {}
-
-    class Render:
-        def add_source(self, source):
-            registered.update(source)
-
-    monkeypatch.setattr("infogami.utils.template.render", Render())
-
+def test_site_layout_template_uses_jinja_template(monkeypatch):
+    """The ``site`` pile entry should delegate to the Jinja site wrapper."""
     rendered = "<html>"
 
     def mock_render(template_name, **kwargs):
@@ -133,9 +125,8 @@ def test_register_site_layout_uses_jinja_template(monkeypatch):
         return rendered
 
     monkeypatch.setattr(jinja_module, "render_jinja_template", mock_render)
-    jinja_module.register_site_layout()
 
-    site_template = registered["site"]
+    site_template = jinja_module._SiteLayoutTemplate()
     assert site_template.filename == "openlibrary/templates/site.html.jinja"
     assert site_template("page") == rendered
 

--- a/openlibrary/tests/core/test_jinja.py
+++ b/openlibrary/tests/core/test_jinja.py
@@ -11,6 +11,7 @@ from lxml.etree import ParseError as LxmlParseError
 from markupsafe import escape as _markupsafe_escape
 
 from openlibrary import i18n as i18n_module
+from openlibrary.core import jinja as jinja_module
 from openlibrary.core.jinja import get_jinja_env
 from openlibrary.i18n import load_translations
 from openlibrary.utils.request_context import req_context
@@ -33,6 +34,14 @@ class RenderableUndefined(jinja2.Undefined):
     """
 
     __eq__ = __ne__ = __lt__ = __gt__ = __le__ = __ge__ = lambda s, o: s
+
+    def __getattr__(self, name: str) -> RenderableUndefined:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return RenderableUndefined()
+
+    def __getitem__(self, key: object) -> RenderableUndefined:
+        return RenderableUndefined()
 
 
 def _create_validation_env() -> jinja2.Environment:
@@ -104,6 +113,31 @@ def assert_valid_html(html_string: str) -> None:
         lxml_html.fromstring(html_string, parser=parser)
     except LxmlParseError as e:
         pytest.fail(f"Rendered HTML contains orphan/mismatched tags: {e}")
+
+
+def test_register_site_layout_uses_jinja_template(monkeypatch):
+    """The registered Infogami source should delegate to the Jinja site wrapper."""
+    registered = {}
+
+    class Render:
+        def add_source(self, source):
+            registered.update(source)
+
+    monkeypatch.setattr("infogami.utils.template.render", Render())
+
+    rendered = "<html>"
+
+    def mock_render(template_name, **kwargs):
+        assert template_name == "site.html.jinja"
+        assert kwargs == {"page": "page"}
+        return rendered
+
+    monkeypatch.setattr(jinja_module, "render_jinja_template", mock_render)
+    jinja_module.register_site_layout()
+
+    site_template = registered["site"]
+    assert site_template.filename == "openlibrary/templates/site.html.jinja"
+    assert site_template("page") == rendered
 
 
 class TestGetJinjaEnv:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13524

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor: routes the top-level site layout through Jinja as the first step of the layout modernization roadmap.

### Technical
<!-- What should be noted about the implementation? -->
- **Jinja Layout:** Added `openlibrary/templates/site.html.jinja` to render the existing Templetor partials (`site/head`, `site/body`, and `site/footer`) using the reverse bridge helper `render_templetor_template`.
- **Autoescape Safety:** `render_templetor_template` returns `Markup` so Jinja autoescape does not entity-escape the returned HTML; no `| safe` needed at call sites.
- **Direct Wiring:** Deleted Templetor `openlibrary/templates/site.html`; `setup()` in `openlibrary/plugins/openlibrary/code.py` registers `SiteLayoutTemplate` via `template.render.add_source({"site": ...})` so Infogami's `render.site()` serves Jinja directly.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run Jinja test suite:
   ```bash
   uv run --with-requirements requirements_test.txt pytest openlibrary/tests/core/test_jinja.py
   ```
2. Verify pre-commit hooks pass:
   ```bash
   pre-commit run --files openlibrary/core/jinja.py openlibrary/plugins/openlibrary/code.py openlibrary/templates/site.html.jinja openlibrary/tests/core/test_jinja.py
   ```
3. Start local docker environment (`docker compose up`) and verify that pages (`/`, `/works/OL...`, `/authors/OL...`, `/status`) render normally with intact chrome.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A — UI output and DOM structure are diff-clean (unchanged).

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB
