### PR TITLE
Add docker troubleshooting entry for npm ENOTEMPTY caused by macOS Docker VMM (beta)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -204,6 +204,32 @@ No restart is required. If `webnet` no longer exists, recreating it _should_ fix
 
 To understand a bit more about what's going on here, there are docker networks configured in `compose.yaml`. The containers should be able to resolve one another based on the container names (e.g. `web` and `solr`), assuming `compose.yaml` has them on the same netork. For more, see [Networking in Compose](https://docs.docker.com/compose/networking/).
 
+### npm fails with `ENOTEMPTY: directory not empty, rmdir ...` (Docker Desktop on macOS)
+
+Commands that run npm inside a container (e.g. `make css`/`js`, `npm run build-assets`, or `npm install`) fail consistently with an error such as:
+
+```log
+npm error code ENOTEMPTY
+npm error syscall rmdir
+npm error path /openlibrary/node_modules/webpack/lib
+npm error ENOTEMPTY: directory not empty, rmdir '/openlibrary/node_modules/webpack/lib'
+make: *** [Makefile:20: node_modules] Error 217
+```
+
+Sometimes accompanied by `npm ls` reporting packages as `UNMET DEPENDENCY` even though the directories visibly exist. On macOS, one known cause is Docker Desktop's **Docker VMM (beta)** virtual machine backend corrupting writes to named volumes (such as `ol-nodemodules`, the volume backing `/openlibrary/node_modules`).
+
+To resolve:
+
+1. In Docker Desktop, go to Settings → General → **Virtual machine options** and switch from "Docker VMM" to the **Apple Virtualization framework** (it's fine to keep VirtioFS selected for file sharing), then Apply & restart.
+2. Recreate the corrupted volume so it's repopulated from a healthy state:
+
+   ```sh
+   docker rm openlibrary-web-1 openlibrary-home-1  # only if these exited containers still reference the volume
+   docker volume rm openlibrary_ol-nodemodules
+   ```
+
+3. Re-run your npm command, e.g. `docker compose run --rm web make css`. (If other `*_ol-nodemodules` volumes were populated while Docker VMM was active — e.g. volumes for other clones/worktrees — recreate them the same way.)
+
 ### Permission denied errors on SELinux
 
 SELinux implements [Mandatory Access Controls (MAC)](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/virtualization_security_guide/sect-virtualization_security_guide-svirt-mac). Even if normal file permissions (user/group/other) would allow access, SELinux can still block resulting in permission denied errors. By adding the `z` or `Z` [bind mount options for Docker/Podman](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label) this allows the container process to access the files, by changing the MAC label.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
N/A — docs-only troubleshooting entry from a locally diagnosed & verified failure; no existing issue covers it.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Docs fix.

### Technical
- Adds a Troubleshooting entry to `docker/README.md` for commands running npm inside containers failing **consistently** with `npm error ENOTEMPTY: directory not empty, rmdir '/openlibrary/node_modules/...'` (often with `npm ls` also reporting packages as `UNMET DEPENDENCY` despite the directories visibly existing).
- Root cause on macOS: Docker Desktop's **Docker VMM (beta)** virtual machine backend corrupting writes to named volumes (e.g. `ol-nodemodules`). The entry walks through the three-step fix: switch to the **Apple Virtualization framework** VM option, recreate affected `*_ol-nodemodules` volumes, re-run.
- Notes that other clones/worktrees' `*_ol-nodemodules` volumes populated while Docker VMM was active need the same treatment.

### Testing
- Reproduced the failure deterministically with the Docker VMM (beta) backend (`make css` died on `Makefile:20: node_modules`, ENOTEMPTY on rmdir).
- After switching to Apple Virtualization framework (keeping VirtioFS): `docker compose run --rm web make css` completes successfully; `npm ls --depth=0` reports 0 UNMET dependencies with the full 677-entry tree.

### Screenshot
N/A — no UI change.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
Module: Docker

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->