### PR TITLE
Skip fetching a PR's head if its pinned commit is already available locally

### DIFF
--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -70,9 +70,13 @@ if [[ -f "$TESTING_STATE_FILE" ]]; then
         echo -e "---\norigin pull/$pr_num/head  # pinned at $pinned_sha"
         # Only fetch if the pinned commit isn't already available locally
         if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
+            echo "Pinned commit $pinned_sha not found locally, fetching pull/$pr_num/head"
             git fetch origin "pull/$pr_num/head"
+        else
+            echo "Pinned commit $pinned_sha already available locally, skipping fetch"
         fi
         if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
+            echo "Still missing $pinned_sha after head fetch, trying direct fetch"
             git fetch origin "$pinned_sha" 2>/dev/null || true
         fi
         if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -68,8 +68,10 @@ if [[ -f "$TESTING_STATE_FILE" ]]; then
     # State file exists: merge pinned commits for all active PRs
     while IFS=' ' read -r pr_num pinned_sha; do
         echo -e "---\norigin pull/$pr_num/head  # pinned at $pinned_sha"
-        git fetch origin "pull/$pr_num/head"
-        # Ensure the pinned SHA is locally available
+        # Only fetch if the pinned commit isn't already available locally
+        if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
+            git fetch origin "pull/$pr_num/head"
+        fi
         if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
             git fetch origin "$pinned_sha" 2>/dev/null || true
         fi


### PR DESCRIPTION
The slowest part of testing deploys now is the git checkout step! Try to speed this up by avoiding a git fetch request for SHAs that are already loaded locally.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This can't be tested by PR deploying ; I think it's low risk though and can be merged after a CR, and then we can see the testing perf impact.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
