### PR TITLE
deploy.sh: gate on `nginx -t` after olsystem deploy, add partial-deploy option

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -676,6 +676,92 @@ prune_docker () {
     return 0
 }
 
+# Which compose service runs nginx on each host; the compose profile is the
+# hostname. Hosts absent from this list don't run nginx.
+nginx_service_for() {
+    case "$1" in
+        ol-www0)    echo "web_nginx" ;;
+        ol-home0)   echo "infobase_nginx" ;;
+        ol-covers0) echo "covers_nginx" ;;
+        *)          echo "" ;;
+    esac
+}
+
+# Validate the nginx config that the olsystem deploy just shipped.
+#
+# olsystem carries the ModSecurity ruleset, and docker/ol-nginx-start.sh execs
+# `nginx -g` with no prior `nginx -t` -- so a bad rule is not a failed deploy, it
+# is an [emerg] at startup that crash-loops the container and takes the site
+# down. See internetarchive/olsystem#420. Catching it here, immediately after the
+# olsystem deploy, means the running containers are still serving the previous
+# (good) config and nothing is user-visible yet.
+#
+# `exec` against the live container is the right call at THIS point in the
+# deploy: olsystem is bind-mounted as a directory (../olsystem:/olsystem), so the
+# running container already sees the freshly deployed rules. Do not reuse this
+# after an openlibrary code transfer -- copy_to_servers replaces /opt/openlibrary
+# wholesale (rm -rf + mv), which leaves the single-FILE bind mounts
+# (nginx.conf, web_nginx.conf) as orphaned inodes still holding the previous
+# deploy's config. A check there would need `run --rm --no-deps` instead, and
+# never --service-ports, which would contend for :80/:443 with the live container.
+check_nginx_config() {
+    if [[ "$SKIP_NGINX_CHECK" == "1" ]]; then
+        echo "[Warning] Skipping nginx config test (SKIP_NGINX_CHECK=1)"
+        return 0
+    fi
+
+    HOSTNAMES=${SERVERS:-$ALL_HOSTNAMES}
+    local COMPOSE_FILE="compose.yaml:compose.production.yaml"
+    local FAILED=0
+    local CHECKED=0
+    local SERVICE
+    local SERVER
+
+    echo "[Now] Testing nginx config against the newly deployed olsystem rules..."
+    for SERVER_NAME in $HOSTNAMES; do
+        SERVICE=$(nginx_service_for "$SERVER_NAME")
+        if [[ -z "$SERVICE" ]]; then
+            continue
+        fi
+        CHECKED=1
+
+        SERVER="${SERVER_NAME}${SERVER_SUFFIX}"
+        echo -n "   $SERVER ($SERVICE) ... "
+
+        if OUTPUT=$(ssh "$SERVER" "
+            set -e
+            cd /opt/openlibrary
+            COMPOSE_FILE='$COMPOSE_FILE' HOSTNAME=\$HOSTNAME docker compose --profile $SERVER_NAME exec -T $SERVICE nginx -t
+        " 2>&1); then
+            echo "✓"
+        else
+            echo "⚠"
+            echo "$OUTPUT"
+            FAILED=1
+        fi
+    done
+
+    if [ $CHECKED -eq 0 ]; then
+        echo "   No nginx hosts in this deploy; nothing to test."
+        return 0
+    fi
+
+    if [ $FAILED -eq 1 ]; then
+        echo ""
+        echo "[Error] nginx config test FAILED on one or more hosts (see output above)."
+        echo "        olsystem is already deployed, but the new config is invalid --"
+        echo "        restarting nginx now would take the site down (olsystem#420)."
+        echo "        The running containers are still serving the previous config."
+        echo ""
+        echo "        Fix the ruleset in olsystem and deploy it again, or roll back"
+        echo "        using the copy left in /opt/olsystem_previous on each host."
+        echo "        To proceed anyway (NOT recommended), set SKIP_NGINX_CHECK=1."
+        clean_exit
+    fi
+
+    return 0
+}
+
 recreate_services() {
     echo "[Now] Restarting services, keep an eye on sentry/grafana (~3m as of 2024-12-09)"
     echo "- Sentry: https://sentry.archive.org/organizations/ia-ux/issues/?project=7&statsPeriod=1d"
@@ -716,6 +802,10 @@ deploy_wizard() {
     answer=${answer:-Y}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         time deploy_olsystem
+        # Gate on `nginx -t` here, not at restart time: olsystem ships the
+        # ModSecurity ruleset, and a bad rule only surfaces as an nginx [emerg]
+        # once something restarts. Fail now, while the site is still up.
+        check_nginx_config
     fi
     echo ""
 
@@ -724,20 +814,35 @@ deploy_wizard() {
     done
     echo ""
 
-    read -p "[Now] Run openlibrary deploy? [Y/n]..." answer
+    # Y = run every step with its default; p = pick the steps individually.
+    read -p "[Now] Run openlibrary deploy? [Y/n/p]..." answer
     answer=${answer:-Y}
-    if [[ "$answer" =~ ^[Yy]$ ]]; then
-        read -p "[Now] Transfer codebase to servers? [Y/n]..." answer
-        answer=${answer:-Y}
-        [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_CODE=1
+    if [[ "$answer" =~ ^[YyPp]$ ]]; then
+        if [[ "$answer" =~ ^[Pp]$ ]]; then
+            read -p "[Now] Transfer codebase to servers? [Y/n]..." step_answer
+            step_answer=${step_answer:-Y}
+            if [[ "$step_answer" =~ ^[Nn]$ ]]; then
+                SKIP_OL_TRANSFER_CODE=1
+            fi
 
-        read -p "[Now] Deploy Docker Images? [Y/n]..." answer
-        answer=${answer:-Y}
-        [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_IMAGES=1
+            read -p "[Now] Deploy Docker Images? [Y/n]..." step_answer
+            step_answer=${step_answer:-Y}
+            if [[ "$step_answer" =~ ^[Nn]$ ]]; then
+                SKIP_OL_TRANSFER_IMAGES=1
+            fi
 
-        read -p "[Now] Tag deploy? [Y/n]..." answer
-        answer=${answer:-Y}
-        [[ "$answer" =~ ^[Yy]$ ]] && TAG_DEPLOY=1
+            read -p "[Now] Tag deploy? [Y/n]..." step_answer
+            step_answer=${step_answer:-Y}
+            if [[ "$step_answer" =~ ^[Yy]$ ]]; then
+                TAG_DEPLOY=1
+            fi
+        else
+            # Full deploy. TAG_DEPLOY must be set explicitly here: it is otherwise
+            # only ever set by the "Tag deploy?" sub-prompt above, so without this
+            # line tagging silently stops happening while the deploy still reports
+            # success.
+            TAG_DEPLOY=1
+        fi
 
         time deploy_openlibrary
         echo ""
@@ -805,6 +910,7 @@ else
     echo "Env vars: SKIP_OL_TRANSFER_CODE=1  skip SCP+git-init+prune step"
     echo "          SKIP_OL_TRANSFER_IMAGES=1 skip docker image pull step"
     echo "          TAG_DEPLOY=1              tag this commit as the deploy (set automatically by wizard)"
+    echo "          SKIP_NGINX_CHECK=1        skip the \`nginx -t\` test run after the olsystem deploy"
     exit 1
 fi
 


### PR DESCRIPTION
Closes #13534

Two changes to `scripts/deployment/deploy.sh`.

## 1. `[Now] Run openlibrary deploy?` becomes `[Y/n/p]`

- `Y` — run all three steps with today's defaults, no sub-prompts
- `p` — partial: ask the three existing sub-prompts (Transfer codebase / Deploy Docker Images / Tag deploy)
- `n` — fall through to the servers-in-sync check, unchanged

**The plain-`Y` path sets `TAG_DEPLOY=1` explicitly.** `TAG_DEPLOY` was previously only ever set by the "Tag deploy?" sub-prompt, so skipping the sub-prompts without setting it would have silently stopped tagging while the deploy still reported success.

The three sub-prompts also move from `[[ ... ]] && VAR=1` to explicit `if` blocks. Under `set -e` with the `ERR` trap, that construct aborts the deploy when it is the terminal command of a function — it's currently safe only because of where it sits. Explicit `if` blocks remove the hazard regardless of where the code later moves.

## 2. `nginx -t` gate directly after the olsystem deploy

olsystem ships the ModSecurity ruleset, and `docker/ol-nginx-start.sh` ends with `nginx -g "daemon off;"` — there is no `nginx -t` anywhere ahead of it. So a bad rule is not a failed deploy: it's an nginx `[emerg]` at container startup that crash-loops nginx and takes the site down, while the deploy itself reports success. See internetarchive/olsystem#420.

The check runs immediately after the olsystem deploy step, **not** at restart time. At that point the bad ruleset is on disk but nothing has restarted, so the running containers are still serving the previous good config and nothing is user-visible — the operator finds out while the site is still up and rollback is cheap.

`SKIP_NGINX_CHECK=1` overrides, documented in the usage text alongside `SKIP_OL_TRANSFER_CODE` etc.

### Why `exec` is the right call *here*

olsystem is bind-mounted as a **directory** (`../olsystem:/olsystem`), so the running container already sees the freshly deployed rules and a plain `docker compose exec <svc> nginx -t` is correct and cheap.

This deliberately does not generalise to a check placed after an openlibrary code transfer: that path replaces `/opt/openlibrary` wholesale (`rm -rf` + `mv`), leaving the single-**file** bind mounts (`nginx.conf`, `web_nginx.conf`) as orphaned inodes still holding the previous deploy's config. A check there would need `docker compose --profile <host> run --rm --no-deps <svc> nginx -t`, and must never pass `--service-ports` (it would contend for :80/:443 with the live container). There's a comment in the source recording this.

## Testing

`bash -n scripts/deployment/deploy.sh` passes.

The new wizard block was extracted from the file as-is (not a retyped copy) and exercised under `set -e` with the `ERR` trap and stubbed deploy functions. All six inputs exit 0 with no trap:

| input | result |
|---|---|
| `Y` | `TAG_DEPLOY=1`, no skips, deploy + sync ran |
| `<enter>` | same (defaults to `Y`) |
| `p` + defaults | `TAG_DEPLOY=1`, no skips |
| `p` + `n/n/n` | `SKIP_CODE=1`, `SKIP_IMAGES=1`, `TAG_DEPLOY` unset |
| `p` + `n/n/Y` | `SKIP_CODE=1`, `SKIP_IMAGES=1`, `TAG_DEPLOY=1` |
| `n` | in-sync check only |
| `x` (garbage) | falls through to `else`, same as `n` does today |

The `nginx -t` call itself has not been exercised against production hosts.

## Notes for review

Three deliberate scope decisions, flagged for a reviewer rather than settled here:

1. **The gate only runs in the wizard path.** `./deploy.sh olsystem` standalone gets no check — and `deploy_olsystem`'s own `[Next]` output advertises exactly that standalone invocation. Moving the call into the end of `deploy_olsystem` would cover both paths and is still "directly after the olsystem deploy step". One line, happy to move it.
2. **No `deploy.sh nginx-check` subcommand.** The failure message tells the operator to fix olsystem and deploy again; without a subcommand there's no way to re-test the fix short of re-running the whole olsystem deploy.
3. **Plain `Y` does not force-unset `SKIP_OL_TRANSFER_CODE` / `SKIP_OL_TRANSFER_IMAGES`.** An operator who exported either still gets it honoured. This matches the existing sub-prompt behaviour (answering `Y` there doesn't unset them either) and keeps the documented env vars authoritative — but it does mean "`Y` = run all three" is a statement about the prompts, not unconditionally about the run.
