### PR TITLE
refactor: pass request params as args to Author.get_books (#13539)

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -480,19 +480,18 @@ class Author(models.Author):
     def get_olid(self):
         return self.key.split("/")[-1]
 
-    def get_books(self, q=""):
-        i = web.input(sort="editions", page=1, rows=20, mode="")
+    def get_books(self, q="", sort="editions", page=1, rows=20, mode=""):
         try:
             # safeguard from passing zero/negative offsets to solr
-            page = max(1, int(i.page))
-        except ValueError:
+            page = max(1, int(page))
+        except (ValueError, TypeError):
             page = 1
         return works_by_author(
             self.get_olid(),
-            sort=i.sort,
+            sort=sort or "editions",
             page=page,
-            rows=i.rows,
-            has_fulltext=i.mode == "ebooks",
+            rows=rows or 20,
+            has_fulltext=mode == "ebooks",
             query=q,
             facet=True,
             request_label="AUTHOR_BOOKS_PAGE",

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -484,7 +484,7 @@ class Author(models.Author):
         try:
             # safeguard from passing zero/negative offsets to solr
             page = max(1, int(page))
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             page = 1
         return works_by_author(
             self.get_olid(),

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -488,9 +488,9 @@ class Author(models.Author):
             page = 1
         return works_by_author(
             self.get_olid(),
-            sort=sort or "editions",
+            sort=sort,
             page=page,
-            rows=rows or 20,
+            rows=rows,
             has_fulltext=mode == "ebooks",
             query=q,
             facet=True,

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -20,7 +20,7 @@ $var history: $page.history
 
 $ olid = page.key.split('/')[-1]
 
-$ books = page.get_books(q=query_param('q'))
+$ books = page.get_books(q=query_param('q'), sort=query_param('sort', 'editions'), page=query_param('page', 1), rows=20, mode=query_param('mode', ''))
 $ book_list_excerpt = ''
 $if books and books.docs:
     $ book_titles_excerpt = [work.title for work in books.docs[:8]]

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -20,7 +20,7 @@ $var history: $page.history
 
 $ olid = page.key.split('/')[-1]
 
-$ books = page.get_books(q=query_param('q'), sort=query_param('sort', 'editions'), page=query_param('page', 1), rows=20, mode=query_param('mode', ''))
+$ books = page.get_books(q=query_param('q'), sort=query_param('sort', 'editions'), page=query_param('page', 1), rows=query_param('rows', 20), mode=query_param('mode', ''))
 $ book_list_excerpt = ''
 $if books and books.docs:
     $ book_titles_excerpt = [work.title for work in books.docs[:8]]


### PR DESCRIPTION
Closes #13539

Part of #13536

Refactor `Author.get_books()` to take explicit arguments for `sort`, `page`, `rows`, and `mode`, removing hidden `web.input()` reads in preparation for FastAPI.

### Technical
- Updated `Author.get_books()` in `openlibrary/plugins/upstream/models.py` to accept `sort="editions"`, `page=1`, `rows=20`, and `mode=""` as explicit arguments with sensible defaults instead of calling `web.input()` internally.
- Safeguarded against invalid or negative page numbers using `max(1, int(page))` with fallback to `1` on `(ValueError, TypeError)`.
- Updated the caller in `openlibrary/templates/type/author/view.html:23` to explicitly pass `sort`, `page`, `rows`, and `mode` from `query_param`.

### Testing
- Verified syntax compilation via `python3 -m py_compile openlibrary/plugins/upstream/models.py`.
- Verified exact argument parity with previous `web.input` defaults.

### Stakeholders
@RayBB
