### PR TITLE
refactor: pass request params as args to 3 pref helpers (#13537)

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -753,14 +753,11 @@ ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name("ia"))
 prefer_ia_provider_order = uniq([ia_provider, *PROVIDER_ORDER])
 
 
-def get_provider_order(
-    prefer_ia: bool = False, provider_pref: str | None = None
-) -> list[AbstractBookProvider]:
+def get_provider_order(prefer_ia: bool = False, provider_pref: str | None = None) -> list[AbstractBookProvider]:
     default_order = prefer_ia_provider_order if prefer_ia else PROVIDER_ORDER
 
     provider_order = default_order
-    provider_overrides = provider_pref
-    if provider_overrides:
+    if provider_overrides := provider_pref:
         new_order: list[AbstractBookProvider] = []
         for name in provider_overrides.split(","):
             if name == "*":
@@ -778,9 +775,7 @@ def get_provider_order(
     return provider_order
 
 
-def get_book_providers(
-    ed_or_solr: Edition | dict, provider_pref: str | None = None
-) -> Iterator[AbstractBookProvider]:
+def get_book_providers(ed_or_solr: Edition | dict, provider_pref: str | None = None) -> Iterator[AbstractBookProvider]:
     # On search results which don't have an edition selected, we want to display
     # IA copies first.
     # Issue is that an edition can be provided by multiple providers; we can easily

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -818,7 +818,10 @@ def get_best_edition(
     editions: list[Edition],
     provider_pref: str | None = None,
 ) -> tuple[Edition | None, AbstractBookProvider | None]:
-    provider_order = get_provider_order(True, provider_pref=provider_pref)
+    if provider_pref:
+        provider_order = get_provider_order(True, provider_pref=provider_pref)
+    else:
+        provider_order = get_provider_order(True)
 
     # Map provider name to position/ranking
     provider_rank_lookup: dict[AbstractBookProvider | None, int] = {provider: i for i, provider in enumerate(provider_order)}

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -753,14 +753,13 @@ ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name("ia"))
 prefer_ia_provider_order = uniq([ia_provider, *PROVIDER_ORDER])
 
 
-def get_provider_order(prefer_ia: bool = False) -> list[AbstractBookProvider]:
+def get_provider_order(
+    prefer_ia: bool = False, provider_pref: str | None = None
+) -> list[AbstractBookProvider]:
     default_order = prefer_ia_provider_order if prefer_ia else PROVIDER_ORDER
 
     provider_order = default_order
-    provider_overrides = None
-    # Need this to work in test environments
-    if "env" in web.ctx:
-        provider_overrides = web.input(providerPref=None, _method="GET").providerPref
+    provider_overrides = provider_pref
     if provider_overrides:
         new_order: list[AbstractBookProvider] = []
         for name in provider_overrides.split(","):
@@ -779,7 +778,9 @@ def get_provider_order(prefer_ia: bool = False) -> list[AbstractBookProvider]:
     return provider_order
 
 
-def get_book_providers(ed_or_solr: Edition | dict) -> Iterator[AbstractBookProvider]:
+def get_book_providers(
+    ed_or_solr: Edition | dict, provider_pref: str | None = None
+) -> Iterator[AbstractBookProvider]:
     # On search results which don't have an edition selected, we want to display
     # IA copies first.
     # Issue is that an edition can be provided by multiple providers; we can easily
@@ -798,7 +799,7 @@ def get_book_providers(ed_or_solr: Edition | dict) -> Iterator[AbstractBookProvi
         ]
         prefer_ia = bool(ia_ocaids)
 
-    provider_order = get_provider_order(prefer_ia)
+    provider_order = get_provider_order(prefer_ia, provider_pref=provider_pref)
     for provider in provider_order:
         if provider.get_identifiers(ed_or_solr):
             yield provider
@@ -820,8 +821,9 @@ def get_acquisitions(solr_edition: dict, edition: Edition) -> list[Acquisition]:
 
 def get_best_edition(
     editions: list[Edition],
+    provider_pref: str | None = None,
 ) -> tuple[Edition | None, AbstractBookProvider | None]:
-    provider_order = get_provider_order(True)
+    provider_order = get_provider_order(True, provider_pref=provider_pref)
 
     # Map provider name to position/ranking
     provider_rank_lookup: dict[AbstractBookProvider | None, int] = {provider: i for i, provider in enumerate(provider_order)}

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -382,7 +382,9 @@ def _select_edition(editions, requested, provider, selected_id, page, provider_p
         return next((e for e in editions if selected_id in provider.get_identifiers(e)), editions[0]), provider
     from openlibrary.book_providers import get_best_edition
 
-    return get_best_edition(editions, provider_pref=provider_pref)
+    if provider_pref:
+        return get_best_edition(editions, provider_pref=provider_pref)
+    return get_best_edition(editions)
 
 
 def _attach_availability(edition, availabilities):

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -371,7 +371,7 @@ def _fetch_editions(work, requested, provider, selected_id, mode):
     return editions, editions_limit
 
 
-def _select_edition(editions, requested, provider, selected_id, page):
+def _select_edition(editions, requested, provider, selected_id, page, provider_pref: str | None = None):
     """Pick the edition to render: the explicitly requested one, the one
     matching a requested provider/id, else the default best edition."""
     if not editions:
@@ -382,7 +382,7 @@ def _select_edition(editions, requested, provider, selected_id, page):
         return next((e for e in editions if selected_id in provider.get_identifiers(e)), editions[0]), provider
     from openlibrary.book_providers import get_best_edition
 
-    return get_best_edition(editions)
+    return get_best_edition(editions, provider_pref=provider_pref)
 
 
 def _attach_availability(edition, availabilities):
@@ -433,7 +433,14 @@ def prepare_book_page(page, query_params, user=None) -> BookPageContext:
 
     previews = [e for e in editions if e.get("ocaid")]
 
-    edition, provider = _select_edition(editions, requested, provider, selected_id, page)
+    edition, provider = _select_edition(
+        editions,
+        requested,
+        provider,
+        selected_id,
+        page,
+        provider_pref=query_params.get("providerPref"),
+    )
     _attach_availability(edition, availabilities)
 
     lending_state = lending.get_lending_state(

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1428,12 +1428,9 @@ def create_thing(data: dict) -> Thing:
 
 
 @public
-def get_ia_host(allow_dev: bool = False) -> str:
-    if allow_dev:
-        web_input = web.input()
-        dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
-        if dev_host and re.match("^[a-zA-Z0-9-.]+$", dev_host):
-            return dev_host + ".archive.org"
+def get_ia_host(allow_dev: bool = False, dev_host: str = "") -> str:
+    if allow_dev and dev_host and re.match("^[a-zA-Z0-9-.]+$", dev_host):
+        return dev_host + ".archive.org"
 
     return "archive.org"
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -318,19 +318,12 @@ execute_solr_query = async_bridge.wrap(execute_solr_query_async)
 
 
 @public
-def get_remembered_layout():
-    def read_query_string():
-        return web.input(layout=None).get("layout")
+def get_remembered_layout(layout: str | None = None, cookie: str | None = None) -> str:
+    if layout:
+        return layout
 
-    def read_cookie():
-        if "LBL" in web.ctx.env.get("HTTP_COOKIE", ""):
-            return web.cookies().get("LBL")
-
-    if (qs_value := read_query_string()) is not None:
-        return qs_value
-
-    if (cookie_value := read_cookie()) is not None:
-        return cookie_value
+    if cookie:
+        return cookie
 
     return "details"
 

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,6 +4,6 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     title="$_('Sign in with a third-party account')"
-    src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
+    src="https://$get_ia_host(allow_dev=True, dev_host=query_param('dev_host', ''))/account/login.thirdparty.php?$(urlencode(params))"
     style="border:0; width: auto; height: 44px"
 ></iframe>

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -71,7 +71,7 @@ $add_metatag(property="og:image", content=meta_photo_url)
         $if not is_filtered:
           $:render_template("search/sort_options.html", sort_order, default_sort='desc', search_scheme='reading_log')
 
-        $ layout = get_remembered_layout()
+        $ layout = get_remembered_layout(query_param('layout'), cookies().get('LBL'))
         $:render_template("search/layout_options.html", selected_layout=layout)
       </div>
     </div>

--- a/openlibrary/templates/site/donation_banner.html
+++ b/openlibrary/templates/site/donation_banner.html
@@ -1,4 +1,4 @@
-$ ia_host = get_ia_host(allow_dev=True)
+$ ia_host = get_ia_host(allow_dev=True, dev_host=query_param('dev_host', ''))
 
 $# The following allows archive.org staff to test banners without
 $# needing to reload openlibrary services

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -40,7 +40,7 @@ $add_metatag(property="og:description", content=description)
 
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
-$ layout = get_remembered_layout()
+$ layout = get_remembered_layout(query_param('layout'), cookies().get('LBL'))
 $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 <div id="contentHead">
 

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -87,7 +87,7 @@ $def seed_attrs(seed):
         <div class="search-results-stats">
             $if not list.key.startswith('/series/'):
                 $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
-            $ layout = get_remembered_layout()
+            $ layout = get_remembered_layout(query_param('layout'), cookies().get('LBL'))
             $:render_template("search/layout_options.html", selected_layout=layout)
         </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,6 +1,6 @@
 $def with (q_param, search_response, works, param, page, rows, readable_count, author_suggestions, has_solr_editions_enabled)
 
-$ layout = get_remembered_layout()
+$ layout = get_remembered_layout(query_param('layout'), cookies().get('LBL'))
 $ bodyclass = ctx.setdefault('bodyclass', [])
 $ bodyclass.append('search-page')
 


### PR DESCRIPTION
Closes #13537

Part of #13536

Remove hidden `web.input()` and `web.cookies()` reads from 3 pref helpers (`get_provider_order`, `get_ia_host`, and `get_remembered_layout`), threading values as explicit arguments from callers/handlers in preparation for FastAPI migration.

### Technical
- `openlibrary/book_providers.py`:
  - `get_provider_order(prefer_ia=False, provider_pref=None)`: accepts `provider_pref` explicitly; removed internal `web.input(providerPref=None, _method="GET")` call.
  - Updated callers `get_book_providers` and `get_best_edition` to accept and forward `provider_pref`.
- `openlibrary/plugins/upstream/code.py`:
  - `prepare_book_page()`: threads `query_params.get("providerPref")` into `_select_edition()` -> `get_best_edition()`.
- `openlibrary/plugins/upstream/utils.py`:
  - `get_ia_host(allow_dev=False, dev_host="")`: accepts `dev_host` as explicit argument; removed internal `web.input()` call.
  - Updated callers in `ia_thirdparty_logins.html` and `donation_banner.html` to pass `dev_host=query_param('dev_host', '')`.
- `openlibrary/plugins/worksearch/code.py`:
  - `get_remembered_layout(layout=None, cookie=None)`: accepts `layout` query value and `cookie` value as explicit arguments; removed internal `web.input()` and `web.cookies()` calls.
  - Updated callers in `reading_log.html`, `author/view.html`, `list/view_body.html`, and `work_search.html` to pass `query_param('layout')` and `cookies().get('LBL')`.

### Testing
- Verified syntax compilation of all modified Python files via `python3 -m py_compile`.
- Verified helper logic and default fallbacks with unit assertion tests.
- Verified exact argument parity with previous `web.input()` and `cookies()` defaults across all 10 modified files.

### Stakeholders
@RayBB
