### PR TITLE
refactor: pass request params as args to is_spam and Recaptcha.validate (#13538)

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -23,7 +23,7 @@ class Recaptcha(web.form.Input):
     def __init__(self, public_key, private_key):
         self.public_key = public_key
         self._private_key = private_key
-        validator = web.form.Validator("Recaptcha failed", self.validate)
+        validator = web.form.Validator("Recaptcha failed", self._validate_form)
 
         web.form.Input.__init__(self, "recaptcha", validator)
         self.description = "Validator for recaptcha v2"
@@ -31,16 +31,21 @@ class Recaptcha(web.form.Input):
 
         self.error = None
 
-    def validate(self, value=None):
+    def _validate_form(self, value=None):
+        return self.validate(
+            response=web.input().get("g-recaptcha-response"),
+            remoteip=web.ctx.ip,
+        )
+
+    def validate(self, response: str | None = None, remoteip: str | None = None):
         def accept_error(error_codes: list[str]) -> bool:
             return not any(error in INVALIDATING_ERRORS for error in error_codes)
 
-        i = web.input()
         url = config.get("recaptcha_url")
         params = {
             "secret": self._private_key,
-            "response": i.get("g-recaptcha-response"),
-            "remoteip": web.ctx.ip,
+            "response": response,
+            "remoteip": remoteip,
         }
 
         try:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -249,7 +249,10 @@ class addbook(delegate.page):
 
         if not accounts.get_current_user():
             recap = get_recaptcha()
-            if recap and not recap.validate():
+            if recap and not recap.validate(
+                response=i.get("g-recaptcha-response"),
+                remoteip=web.ctx.ip,
+            ):
                 return render_template(
                     "message.html",
                     "Recaptcha solution was incorrect",
@@ -813,12 +816,16 @@ class book_edit(delegate.page):
 
     def POST(self, key):
         i = web.input(v=None, work_key=None, _method="GET")
+        form_data = web.input()
 
-        if spamcheck.is_spam(allow_privileged_edits=True):
+        if spamcheck.is_spam(form_data, allow_privileged_edits=True):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
-        if recap and not recap.validate():
+        if recap and not recap.validate(
+            response=form_data.get("g-recaptcha-response"),
+            remoteip=web.ctx.ip,
+        ):
             return render_template(
                 "message.html",
                 "Recaptcha solution was incorrect",
@@ -876,13 +883,17 @@ class work_edit(delegate.page):
 
     def POST(self, key):
         i = web.input(v=None, _method="GET")
+        form_data = web.input()
 
-        if spamcheck.is_spam(allow_privileged_edits=True):
+        if spamcheck.is_spam(form_data, allow_privileged_edits=True):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
 
-        if recap and not recap.validate():
+        if recap and not recap.validate(
+            response=form_data.get("g-recaptcha-response"),
+            remoteip=web.ctx.ip,
+        ):
             return render_template(
                 "message.html",
                 "Recaptcha solution was incorrect",

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -84,7 +84,7 @@ class edit(core.edit):
             return core.edit.GET(self, key)
 
     def POST(self, key):
-        if re.compile("/(people/[^/]+)").match(key) and spamcheck.is_spam():
+        if re.compile("/(people/[^/]+)").match(key) and spamcheck.is_spam(web.input()):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
         return core.edit.POST(self, key)
 

--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -1,8 +1,6 @@
 import re
 from collections.abc import Iterable
 
-import web
-
 from openlibrary.utils.request_context import site
 
 
@@ -32,7 +30,7 @@ def _update_spam_doc(**kwargs) -> None:
     site.get().store["spamwords"] = doc
 
 
-def is_spam(i=None, allow_privileged_edits: bool = False) -> bool:
+def is_spam(i, allow_privileged_edits: bool = False) -> bool:
     user = site.get().get_user()
 
     if user:
@@ -56,8 +54,6 @@ def is_spam(i=None, allow_privileged_edits: bool = False) -> bool:
         return True
 
     spamwords = get_spam_words()
-    if i is None:
-        i = web.input()
     text = str(dict(i)).lower()
     return any(re.search(w.lower(), text) for w in spamwords)
 


### PR DESCRIPTION
Closes #13538

Part of #13536

Thread spam and captcha parameters (`is_spam`, `Recaptcha.validate`) as explicit arguments from callers, removing hidden `web.input()` and `web.ctx.ip` reads in preparation for FastAPI migration.

### Technical
- `openlibrary/plugins/upstream/spamcheck.py`:
  - `is_spam(i, allow_privileged_edits=False)`: Required `i` from caller and removed `web.input()` fallback as well as unused `import web`.
- `openlibrary/plugins/recaptcha/recaptcha.py`:
  - `Recaptcha.validate(response=None, remoteip=None)`: Accepts explicit `response` and `remoteip` parameters with zero `web.input()` or `web.ctx.ip` calls.
  - Added `_validate_form(self, value=None)` to preserve the `web.form.Validator` shim for web.py form compatibility.
- `openlibrary/plugins/upstream/addbook.py`:
  - Updated `add_book.POST` to pass `response=i.get("g-recaptcha-response")` and `remoteip=web.ctx.ip` to `recap.validate`.
  - Updated `book_edit.POST` and `work_edit.POST` to pass `form_data` to `spamcheck.is_spam` and `response` + `remoteip` to `recap.validate`.
- `openlibrary/plugins/upstream/code.py`:
  - Updated `edit.POST` to pass `web.input()` into `spamcheck.is_spam`.

### Testing
- Verified syntax compilation across all modified files using `python3 -m py_compile`.
- Verified formatting and whitespace clean via `git diff --check`.
- Ran unit verification tests validating:
  1. `spamcheck.is_spam` requires caller-provided `i` (raising `TypeError` if omitted).
  2. `spamcheck.is_spam` detects spam words from explicit input dictionary.
  3. `Recaptcha.validate` passes explicit `response` and `remoteip` parameters without referencing web globals.
  4. `Recaptcha._validate_form` preserves `web.form.Validator` behavior for web.py forms.

### Stakeholders
@RayBB
