### PR TITLE
Add node exporter metrics to our prod cluster

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -386,6 +386,28 @@ services:
         max-size: "512m"
         max-file: "4"
 
+  node-exporter:
+    profiles: ["ol-web0", "ol-web1", "ol-web2", "ol-web3", "ol-covers0", "ol-www0", "ol-solr0", "ol-solr1", "ol-solr2", "ol-home0"]
+    image: prom/node-exporter:v1.12.1
+    restart: unless-stopped
+    hostname: "$HOSTNAME"
+    # Needed to see the host's network/PIDs instead of the container's
+    network_mode: host
+    pid: host
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|run)($$|/)
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+
 volumes:
     archive-webserver-logs-data:
     letsencrypt-data:

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -61,6 +61,27 @@ services:
   memcached:
     restart: unless-stopped
 
+  node-exporter:
+    image: prom/node-exporter:v1.12.1
+    restart: unless-stopped
+    hostname: "$HOSTNAME"
+    # Needed to see the host's network/PIDs instead of the container's
+    network_mode: host
+    pid: host
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|run)($$|/)
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+
 volumes:
   ol-vendor:
   ol-build:

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -44,3 +44,20 @@ class TestDockerCompose:
         for service_name in ("web", "fast_web"):
             assert "OL_DEPLOYMENT_NAME=testing" in staging_dc["services"][service_name]["environment"]
             assert "OL_DEPLOYMENT_NAME=production" in prod_dc["services"][service_name]["environment"]
+
+    def test_node_exporter_matches_across_environments(self):
+        """
+        node-exporter should be configured identically in staging and production
+        (aside from production's per-server 'profiles' field) so that the metrics
+        we collect are consistent across environments.
+        """
+        with open(p("..", "compose.staging.yaml")) as f:
+            staging_dc: dict = yaml.safe_load(f)
+        with open(p("..", "compose.production.yaml")) as f:
+            prod_dc: dict = yaml.safe_load(f)
+
+        staging_node_exporter = dict(staging_dc["services"]["node-exporter"])
+        prod_node_exporter = dict(prod_dc["services"]["node-exporter"])
+        del prod_node_exporter["profiles"]
+
+        assert staging_node_exporter == prod_node_exporter, "node-exporter config differs between staging and production"


### PR DESCRIPTION
This is the new recommended way for metrics over our old collectd setup. It also gives us a number of useful metrics; eg https://grafana.prod.archive.org/d/rYdddlPWk/node-exporter-full?orgId=1&from=now-24h&to=now&timezone=utc&var-DS_PROMETHEUS=default&var-job=node_exporter&var-node=ol-solr0&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Deployed/tested on ol-solr0 and ol-covers0. Note this requires modifying ferm rules.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
