### PR TITLE
13543 publishing history jinja

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "New Books Imported Per Day"
 msgstr ""
 
-#: PublishingHistory.html admin/imports.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja admin/imports.html publishers/view.html
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr ""
 
@@ -5379,7 +5379,7 @@ msgstr[1] ""
 msgid "0 ebooks"
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja publishers/view.html
 msgid "Publishing History"
 msgstr ""
 
@@ -5387,11 +5387,11 @@ msgstr ""
 msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja publishers/view.html
 msgid "Reset chart"
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja publishers/view.html
 msgid "or continue zooming in."
 msgstr ""
 
@@ -5399,11 +5399,11 @@ msgstr ""
 msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja publishers/view.html
 msgid "Editions Published"
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
+#: PublishingHistory.html PublishingHistory.html.jinja publishers/view.html
 msgid "Year of Publication"
 msgstr ""
 
@@ -7140,19 +7140,19 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: PublishingHistory.html
+#: PublishingHistory.html PublishingHistory.html.jinja
 msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
-#: PublishingHistory.html
+#: PublishingHistory.html PublishingHistory.html.jinja
 msgid "This graph charts editions published on this subject."
 msgstr ""
 
-#: PublishingHistory.html RelatedSubjects.html
+#: PublishingHistory.html PublishingHistory.html.jinja RelatedSubjects.html
 msgid "Something went wrong."
 msgstr ""
 
-#: PublishingHistory.html RelatedSubjects.html
+#: PublishingHistory.html PublishingHistory.html.jinja RelatedSubjects.html
 msgid "Retry"
 msgstr ""
 

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -1,0 +1,51 @@
+{% set async_load = async_load | default(false) %}
+
+<div id="subjectPublishingHistory" data-async-load="{{ async_load | tojson }}" data-key="{{ key | tojson }}">
+
+    <div class="head">
+        <h2 class="inline">{{ _("Publishing History") }}</h2>
+
+        <span class="shift">
+            {{ _('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.') | safe }}
+        </span>
+
+        {% if not async_load %}
+            <span class="count hidden chartZoom">
+                &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
+            </span>
+            <span class="count chartUnzoom">
+                &nbsp;{{ _('This graph charts editions published on this subject.') }}
+            </span>
+        {% endif %}
+    </div>
+
+    {% if async_load %}
+        <div class="chart">
+            <span class="loadingIndicator"></span>
+            <span class="small async-partial-retry hidden">
+                {{ _("Something went wrong.") }} <a href="#" class="retry-btn">{{ _("Retry") }}</a>
+            </span>
+        </div>
+    {% else %}
+        <script type="text/json+graph" id="graph-json-chartPubHistory">
+            {{ publishing_history | tojson }}
+        </script>
+
+        <div class="chart">
+            <div class="chartYaxis">{{ _("Editions Published") }}</div>
+
+            <div id="chartPubHistory" class="thisChart">
+                <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
+            </div>
+
+            <div class="chartXaxis">{{ _("Year of Publication") }}</div>
+        </div>
+    {% endif %}
+
+    {# 
+        .chart uses desktop CSS floats. 
+        Clearing floats here prevents the wrapper from collapsing to just the header height. 
+    #}
+
+    <div class="clearfix"></div>
+</div>

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -1,12 +1,15 @@
 {% set async_load = async_load | default(false) %}
 {% set publishing_history = publishing_history | default([]) %}
 {% set key = key | default("") %}
-<div class="head">
-    <h2 class="inline">{{ _("Publishing History") }}</h2>
-    <span class="shift">
-        {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
-    </span>
-    {% if not async_load %}
+<div id="subjectPublishingHistory"
+    data-async-load="{{ async_load | tojson }}"
+    data-key="{{ key | tojson }}">
+    <div class="head">
+        <h2 class="inline">{{ _("Publishing History") }}</h2>
+        <span class="shift">
+            {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
+        </span>
+        {% if not async_load %}
         <span class="count hidden chartZoom">
             &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
         </span>

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -2,40 +2,40 @@
 {% set publishing_history = publishing_history | default([]) %}
 {% set key = key | default("") %}
 <div id="subjectPublishingHistory"
-    data-async-load="{{ async_load | tojson }}"
-    data-key="{{ key | tojson }}">
+     data-async-load="{{ async_load | tojson }}"
+     data-key="{{ key | tojson }}">
     <div class="head">
         <h2 class="inline">{{ _("Publishing History") }}</h2>
         <span class="shift">
             {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
         </span>
         {% if not async_load %}
-        <span class="count hidden chartZoom">
-            &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
-        </span>
-        <span class="count chartUnzoom">&nbsp;{{ _("This graph charts editions published on this subject.") }}</span>
-    {% endif %}
-</div>
-{% if async_load %}
-    <div class="chart">
-        <span class="loadingIndicator"></span>
-        <span class="small async-partial-retry hidden">
-            {{ _("Something went wrong.") }} <a href="#" class="retry-btn">{{ _("Retry") }}</a>
-        </span>
+            <span class="count hidden chartZoom">
+                &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
+            </span>
+            <span class="count chartUnzoom">&nbsp;{{ _("This graph charts editions published on this subject.") }}</span>
+        {% endif %}
     </div>
-{% else %}
-    <script type="text/json+graph" id="graph-json-chartPubHistory">{{ publishing_history | tojson }}</script>
-    <div class="chart">
-        <div class="chartYaxis">{{ _("Editions Published") }}</div>
-        <div id="chartPubHistory" class="thisChart">
-            <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
+    {% if async_load %}
+        <div class="chart">
+            <span class="loadingIndicator"></span>
+            <span class="small async-partial-retry hidden">
+                {{ _("Something went wrong.") }} <a href="#" class="retry-btn">{{ _("Retry") }}</a>
+            </span>
         </div>
-        <div class="chartXaxis">{{ _("Year of Publication") }}</div>
-    </div>
-{% endif %}
-{#
+    {% else %}
+        <script type="text/json+graph" id="graph-json-chartPubHistory">{{ publishing_history | tojson }}</script>
+        <div class="chart">
+            <div class="chartYaxis">{{ _("Editions Published") }}</div>
+            <div id="chartPubHistory" class="thisChart">
+                <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
+            </div>
+            <div class="chartXaxis">{{ _("Year of Publication") }}</div>
+        </div>
+    {% endif %}
+    {#
         .chart uses desktop CSS floats.
         Clearing floats here prevents the wrapper from collapsing to just the header height.
 #}
-<div class="clearfix"></div>
+    <div class="clearfix"></div>
 </div>

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -1,24 +1,19 @@
 {% set async_load = async_load | default(false) %}
-
-<div id="subjectPublishingHistory" data-async-load="{{ async_load | tojson }}" data-key="{{ key | tojson }}">
-
+<div id="subjectPublishingHistory"
+     data-async-load="{{ async_load | tojson }}"
+     data-key="{{ key | tojson }}">
     <div class="head">
         <h2 class="inline">{{ _("Publishing History") }}</h2>
-
         <span class="shift">
-            {{ _('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.') | safe }}
+            {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
         </span>
-
         {% if not async_load %}
             <span class="count hidden chartZoom">
                 &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
             </span>
-            <span class="count chartUnzoom">
-                &nbsp;{{ _('This graph charts editions published on this subject.') }}
-            </span>
+            <span class="count chartUnzoom">&nbsp;{{ _("This graph charts editions published on this subject.") }}</span>
         {% endif %}
     </div>
-
     {% if async_load %}
         <div class="chart">
             <span class="loadingIndicator"></span>
@@ -27,25 +22,18 @@
             </span>
         </div>
     {% else %}
-        <script type="text/json+graph" id="graph-json-chartPubHistory">
-            {{ publishing_history | tojson }}
-        </script>
-
+        <script type="text/json+graph" id="graph-json-chartPubHistory">{{ publishing_history | tojson }}</script>
         <div class="chart">
             <div class="chartYaxis">{{ _("Editions Published") }}</div>
-
             <div id="chartPubHistory" class="thisChart">
                 <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
             </div>
-
             <div class="chartXaxis">{{ _("Year of Publication") }}</div>
         </div>
     {% endif %}
-
-    {# 
-        .chart uses desktop CSS floats. 
-        Clearing floats here prevents the wrapper from collapsing to just the header height. 
-    #}
-
+    {#
+        .chart uses desktop CSS floats.
+        Clearing floats here prevents the wrapper from collapsing to just the header height.
+#}
     <div class="clearfix"></div>
 </div>

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -1,7 +1,6 @@
 {% set async_load = async_load | default(false) %}
-<div id="subjectPublishingHistory"
-     data-async-load="{{ async_load | tojson }}"
-     data-key="{{ key | tojson }}">
+{% set publishing_history = publishing_history | default([]) %}
+{% set key = key | default("") %}
     <div class="head">
         <h2 class="inline">{{ _("Publishing History") }}</h2>
         <span class="shift">

--- a/openlibrary/macros/PublishingHistory.html.jinja
+++ b/openlibrary/macros/PublishingHistory.html.jinja
@@ -1,38 +1,38 @@
 {% set async_load = async_load | default(false) %}
 {% set publishing_history = publishing_history | default([]) %}
 {% set key = key | default("") %}
-    <div class="head">
-        <h2 class="inline">{{ _("Publishing History") }}</h2>
-        <span class="shift">
-            {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
+<div class="head">
+    <h2 class="inline">{{ _("Publishing History") }}</h2>
+    <span class="shift">
+        {{ _("This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>.") | safe }}
+    </span>
+    {% if not async_load %}
+        <span class="count hidden chartZoom">
+            &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
         </span>
-        {% if not async_load %}
-            <span class="count hidden chartZoom">
-                &nbsp;<a href="javascript:;" class="resetSelection small">{{ _("Reset chart") }}</a> {{ _("or continue zooming in.") }}
-            </span>
-            <span class="count chartUnzoom">&nbsp;{{ _("This graph charts editions published on this subject.") }}</span>
-        {% endif %}
-    </div>
-    {% if async_load %}
-        <div class="chart">
-            <span class="loadingIndicator"></span>
-            <span class="small async-partial-retry hidden">
-                {{ _("Something went wrong.") }} <a href="#" class="retry-btn">{{ _("Retry") }}</a>
-            </span>
-        </div>
-    {% else %}
-        <script type="text/json+graph" id="graph-json-chartPubHistory">{{ publishing_history | tojson }}</script>
-        <div class="chart">
-            <div class="chartYaxis">{{ _("Editions Published") }}</div>
-            <div id="chartPubHistory" class="thisChart">
-                <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
-            </div>
-            <div class="chartXaxis">{{ _("Year of Publication") }}</div>
-        </div>
+        <span class="count chartUnzoom">&nbsp;{{ _("This graph charts editions published on this subject.") }}</span>
     {% endif %}
-    {#
+</div>
+{% if async_load %}
+    <div class="chart">
+        <span class="loadingIndicator"></span>
+        <span class="small async-partial-retry hidden">
+            {{ _("Something went wrong.") }} <a href="#" class="retry-btn">{{ _("Retry") }}</a>
+        </span>
+    </div>
+{% else %}
+    <script type="text/json+graph" id="graph-json-chartPubHistory">{{ publishing_history | tojson }}</script>
+    <div class="chart">
+        <div class="chartYaxis">{{ _("Editions Published") }}</div>
+        <div id="chartPubHistory" class="thisChart">
+            <noscript>{{ _("You need to have JavaScript turned on to see the nifty chart!") }}</noscript>
+        </div>
+        <div class="chartXaxis">{{ _("Year of Publication") }}</div>
+    </div>
+{% endif %}
+{#
         .chart uses desktop CSS floats.
         Clearing floats here prevents the wrapper from collapsing to just the header height.
 #}
-    <div class="clearfix"></div>
+<div class="clearfix"></div>
 </div>

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -394,7 +394,7 @@ class SubjectPublishingHistoryPartial:
         )
 
         template = get_jinja_env().get_template("PublishingHistory.html.jinja")
-        html = render_template(
+        html = template.render(
             publishing_history=subject.get("publishing_history", []),
             async_load=False,
             key=key,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -392,14 +392,14 @@ class SubjectPublishingHistoryPartial:
             facet_fields=[{"name": "publish_year", "limit": -1}],
             request_label="SUBJECT_PUBLISHING_HISTORY",
         )
-        macro = render_macro(
-            "PublishingHistory",
-            (),
+
+        template = get_jinja_env().get_template("PublishingHistory.html.jinja")
+        html = render_template(
             publishing_history=subject.get("publishing_history", []),
             async_load=False,
             key=key,
         )
-        return {"partials": str(macro["__body__"])}
+        return {"partials": html}
 
 
 class SubjectRelatedPartial:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13543

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[refactor]

### Technical
Converts the subject page's publishing-history chart partial from a Templetor macro to Jinja, following the pattern established in #12776 (AffiliateLinks).

- Added `openlibrary/macros/PublishingHistory.html.jinja`, a port of the existing `PublishingHistory.html` Templetor macro's `async_load=False` rendering path (the chart itself), plus the `async_load=True` skeleton branch for parity with the source macro.
- Updated `SubjectPublishingHistoryPartial.generate_async()` in `openlibrary/plugins/openlibrary/partials.py` to render the new Jinja template via `get_jinja_env()` instead of calling `render_macro()`, matching `AffiliateLinksPartial.generate_async()`.
- **`openlibrary/macros/PublishingHistory.html` (the old Templetor macro) is intentionally left in place** — it's still called directly by `openlibrary/templates/subjects.html` (`$:macros.PublishingHistory(async_load=True, key=page.key)`) for the subject page's initial synchronous load, which hasn't been converted to Jinja yet. Only the FastAPI async-partial path was migrated.
- No new tests added, per the issue's "Done when" criteria — no existing test exercises `SubjectPublishingHistoryPartial.generate_async()` directly, so correctness was verified manually (see Testing below).

### Testing
1. `make test-py-uv` passes.
2. Manual before/after diff of the endpoint response to confirm no behavior change:
   - Checked out the base commit (before this change), started the dev server, and captured `GET /partials/SubjectPublishingHistory.json?key=/subjects/cooking`.
   - Checked out this branch, restarted the dev server, and captured the same request.
   - `diff before.json after.json` → **no differences**. Response HTML is byte-identical, including the JSON payload embedded in the `graph-json-chartPubHistory` script tag.
3. Reviewers can reproduce the same diff locally, or load `/subjects/cooking` (or any subject with publishing history) and confirm the chart renders and zoom/reset controls behave identically to production.

### Screenshot
N/A

### Stakeholders
@RayBB