### PR TITLE
BookWorm: stop discarding acquisition/borrow links

### DIFF
--- a/openlibrary/bookworm/opds.py
+++ b/openlibrary/bookworm/opds.py
@@ -8,8 +8,11 @@ Built on pydantic models so heterogeneous feeds validate and map uniformly:
 - **Better World Books** — ISBN identifier, ``acquisition/buy`` links with a price.
 - **Project Gutenberg** — identifier is a ``gutenberg.org/ebooks/<id>`` URL,
   ``acquisition/open-access`` (free) links.
-- **Lenny** — no ``metadata.identifier``; the id comes from the ``self`` link,
-  ``acquisition/open-access`` links.
+- **Lenny** — no ``metadata.identifier``; the id comes from the ``self`` link.
+  Open-access titles carry ``acquisition/open-access``; borrowable ones carry
+  ``acquisition/borrow`` with ``properties.availability`` and an
+  ``properties.authenticate`` pointer to the provider's OPDS Authentication
+  Document. Most of a Lenny catalogue is the latter.
 
 Feeds also vary in shape (``author`` may be a dict or a list; ``language`` a str
 or a list), which the models normalize. Extends the OPDS types drafted in #12852.
@@ -26,8 +29,13 @@ from openlibrary.plugins.upstream.utils import get_marc21_language
 
 BUY_REL = "http://opds-spec.org/acquisition/buy"
 OPEN_ACCESS_REL = "http://opds-spec.org/acquisition/open-access"
+BORROW_REL = "http://opds-spec.org/acquisition/borrow"
 # rel -> the access value we store on the acquisition
-ACQUISITION_ACCESS = {BUY_REL: "buy", OPEN_ACCESS_REL: "open-access"}
+ACQUISITION_ACCESS = {
+    BUY_REL: "buy",
+    OPEN_ACCESS_REL: "open-access",
+    BORROW_REL: "borrow",
+}
 
 
 def _as_list(value: Any) -> list:
@@ -42,9 +50,15 @@ class Price(BaseModel):
     value: float
 
 
+class Availability(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    state: str | None = None
+
+
 class LinkProperties(BaseModel):
     model_config = ConfigDict(extra="allow")
     price: Price | None = None
+    availability: Availability | None = None
 
 
 class Link(BaseModel):
@@ -154,6 +168,11 @@ def build_acquisitions(pub: Publication, feed: Feed, local_id: str) -> list[dict
             data["title"] = link.title
         if link.properties and link.properties.price:
             data["price"] = link.properties.price.model_dump()
+        # Whether the copy can be borrowed right now. Without it a borrow CTA
+        # cannot tell "available" from "all copies out", and the flat fields
+        # would be the only thing a consumer reads.
+        if link.properties and (avail := link.properties.availability) and avail.state:
+            data["availability"] = avail.state
         data["link"] = link.model_dump(mode="json", exclude_none=True)
         items.append({"provider_name": feed.provider_name, "local_id": local_id, "data": data})
     return items

--- a/openlibrary/bookworm/tests/samples/lenny_borrow.json
+++ b/openlibrary/bookworm/tests/samples/lenny_borrow.json
@@ -1,0 +1,67 @@
+[
+  {
+    "metadata": {
+      "title": "An African abroad",
+      "type": "http://schema.org/Book",
+      "language": [
+        "en"
+      ],
+      "description": "One section of book on Australian Aborigines; Condition of La Perouse settlement, work of missionaries; Govt. policy, welfare.",
+      "author": [
+        {
+          "name": "Olabisi Ajala",
+          "links": [
+            {
+              "href": "https://openlibrary.org/authors/OL2203723A",
+              "type": "text/html",
+              "rel": "author"
+            }
+          ]
+        }
+      ],
+      "numberOfPages": 256,
+      "modified": "2026-08-28T04:14:10.205247Z"
+    },
+    "links": [
+      {
+        "href": "https://lennyforlibraries.org/v1/api/opds/46539165",
+        "type": "application/opds-publication+json",
+        "rel": "self",
+        "templated": false
+      },
+      {
+        "href": "https://lennyforlibraries.org/v1/api/items/46539165/borrow",
+        "type": "application/opds-publication+json",
+        "rel": "http://opds-spec.org/acquisition/borrow",
+        "title": "Lenny",
+        "templated": false,
+        "properties": {
+          "authenticate": {
+            "type": "application/opds-authentication+json",
+            "href": "https://lennyforlibraries.org/v1/api/oauth/implicit"
+          },
+          "availability": {
+            "state": "available"
+          },
+          "indirectAcquisition": [
+            {
+              "type": "application/vnd.readium.lcp.license.v1.0+json",
+              "child": [
+                {
+                  "type": "application/epub+zip"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "images": [
+      {
+        "href": "https://covers.openlibrary.org/b/id/13259021-L.jpg",
+        "type": "image/jpeg",
+        "rel": "cover"
+      }
+    ]
+  }
+]

--- a/openlibrary/bookworm/tests/test_opds.py
+++ b/openlibrary/bookworm/tests/test_opds.py
@@ -87,3 +87,46 @@ def test_no_cover_field_emitted():
             rec = to_import_record(pub, feed)
             assert rec is not None, f"{name}: record should parse"
             assert "cover" not in rec, f"{name}: cover should be omitted"
+
+
+def test_lenny_borrow_acquisition_is_not_discarded():
+    """A borrowable Lenny publication must import with its acquisition.
+
+    Only `buy` and `open-access` were mapped, so a publication whose only
+    acquisition link was `acquisition/borrow` produced an import record with no
+    `acquisitions` at all — measured at 70 of 95 publications on
+    lennyforlibraries.org (2026-09-04). Nothing downstream can render what was
+    never imported. See #13552.
+
+    The sample is a real publication captured from the live feed.
+    """
+    rec = to_import_record(_pubs("lenny_borrow")[0], LENNY)
+    assert rec is not None, "a borrowable publication produced no import record"
+    acq = rec["acquisitions"]
+    assert len(acq) == 1, f"expected one acquisition, got {acq}"
+    assert acq[0]["provider_name"] == "lenny"
+    assert acq[0]["data"]["access"] == "borrow"
+    assert acq[0]["data"]["url"].endswith("/borrow")
+
+
+def test_lenny_borrow_keeps_availability_and_auth_document():
+    """`properties.availability` says whether the book can be borrowed right
+    now, and `properties.authenticate` points at the provider's OPDS
+    Authentication Document — where a patron is sent to log in. Both are needed
+    for a borrow CTA, and both would be lost if only the flat fields were kept.
+    """
+    rec = to_import_record(_pubs("lenny_borrow")[0], LENNY)
+    data = rec["acquisitions"][0]["data"]
+    assert data["availability"] == "available"
+    props = data["link"]["properties"]
+    assert props["authenticate"]["href"].endswith("/oauth/implicit")
+
+
+def test_borrow_rel_is_recognised_as_an_acquisition_link():
+    pub = Publication(
+        links=[
+            Link(rel="http://opds-spec.org/acquisition/borrow", href="https://x/borrow"),
+            Link(rel="self", href="https://x/opds/1"),
+        ]
+    )
+    assert [link.rel for link in pub.acquisition_links()] == ["http://opds-spec.org/acquisition/borrow"]


### PR DESCRIPTION
Closes #13552. Part of #12844 / #13270.

## The bug

`ACQUISITION_ACCESS` mapped only `buy` and `open-access`, and `Publication.acquisition_links()` filters on it. A publication whose only acquisition link is `acquisition/borrow` therefore produces an import record with **no `acquisitions` at all** — not mismapped, dropped.

## Measured against the live feed

Both mappings, same `lennyforlibraries.org` feed, today:

```
buy + open-access only    records= 94  with acquisitions= 25  lost= 69
with borrow mapped        records= 94  with acquisitions= 94  lost=  0

69 of 95 publications (73%) were being imported with no acquisition at all.
```

Nothing downstream can render what was never imported, so this blocks **every** form of Lenny borrow UX — including the simplest one, just linking a patron to the provider's own login.

## Also: `properties.availability`

The parser ignored it entirely. It is the difference between a Borrow button that works and one that fails on click — the same live feed reports **68 available, 1 unavailable**. The raw `link` blob already preserved it, but only the flat `data` fields are ergonomic for a consumer to read, so it is lifted out alongside `access` and `url`.

`properties.authenticate` — the pointer to the provider's OPDS Authentication Document, i.e. where a patron gets sent to log in — rides along in that blob and now has a test so it cannot quietly disappear.

## Testing

Three new tests, driven by a **real publication captured from the live feed** rather than a hand-written fixture:

- a borrowable publication imports with its acquisition
- `availability` and the `authenticate` pointer survive the round trip
- `acquisition/borrow` is recognised as an acquisition link

All 19 bookworm tests pass; pre-commit clean.

Worth noting: the existing `samples/lenny.json` fixture contains only an open-access link, which is not representative of the live feed. That is why this looked correct — the sample agreed with the code. The new `lenny_borrow.json` sample is real.

## One thing for the reviewer to decide

The `access` vocabulary now includes `borrow`, which needs to agree with whatever #13395 settles for the read side. `AcquisitionAccessLiteral` in `openlibrary/book_providers.py` already includes `borrow`, so the vocabulary exists — but the two halves should land coherently.

Separately, and not fixed here: a Lenny edition still has no `LennyProvider`, so `get_lending_state()` falls through to `locate`. That is the next blocker after this one.

https://claude.ai/code/session_01UViYm1nKqJkiKJWJUr1eas