### PR TITLE
Convert MyBooksDropperLists partial to Jinja

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -22,7 +22,7 @@ from openlibrary.core.vendors import (
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.code import is_bot
 from openlibrary.plugins.openlibrary.lists import get_lists_async, get_user_lists
-from openlibrary.plugins.upstream.utils import entity_decode, render_macro
+from openlibrary.plugins.upstream.utils import entity_decode, json_encode, render_macro
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
 from openlibrary.plugins.worksearch.code import (
     compute_work_search_html_fields,
@@ -78,7 +78,8 @@ class MyBooksDropperListsPartial:
     def generate(cls) -> dict:
         user_lists = get_user_lists(None)
 
-        dropper = render_template("lists/dropper_lists", user_lists)
+        template = get_jinja_env().get_template("lists/dropper_lists.html.jinja")
+        dropper = template.render(lists=user_lists, json_encode=json_encode)
         list_data = {
             list_data["key"]: {
                 "members": list_data["list_items"],
@@ -88,7 +89,7 @@ class MyBooksDropperListsPartial:
         }
 
         return {
-            "dropper": str(dropper),
+            "dropper": dropper,
             "listData": list_data,
         }
 

--- a/openlibrary/templates/lists/dropper_lists.html
+++ b/openlibrary/templates/lists/dropper_lists.html
@@ -1,8 +1,0 @@
-$def with (lists)
-
-$for list in lists:
-  $ list_active = "list--active" if list['active'] else ""
-  <p class="list $list_active">
-    <span class="list__status-indicator"></span>
-    <a href="$list.key" class="modify-list" data-list-cover-url="$list.get('cover_url')" data-list-key="$list.key" data-list-items="$(json_encode(list.list_items))">$list.name</a>
-  </p>

--- a/openlibrary/templates/lists/dropper_lists.html.jinja
+++ b/openlibrary/templates/lists/dropper_lists.html.jinja
@@ -1,0 +1,11 @@
+{% for list in lists %}
+    {% set list_active = "list--active" if list['active'] else "" %}
+    <p class="list {{ list_active }}">
+        <span class="list__status-indicator"></span>
+        <a href="{{ list.key }}"
+           class="modify-list"
+           data-list-cover-url="{{ list.get('cover_url') or '' }}"
+           data-list-key="{{ list.key }}"
+           data-list-items="{{ json_encode(list.list_items) }}">{{ list.name }}</a>
+    </p>
+{% endfor %}

--- a/openlibrary/templates/my_books/dropdown_content.html
+++ b/openlibrary/templates/my_books/dropdown_content.html
@@ -69,7 +69,7 @@ $def list_selections(user_lists, work_key, edition_key, async_load):
           $ work_attr = 'data-work-key=%s' % work_key if work_key else ''
           <div class="list-loading-indicator" $ed_attr $work_attr>$_("Loading")<span class="loading-ellipsis">...</span></div>
       $else:
-        $:render_template('lists/dropper_lists', user_lists)
+        $:render_jinja_template("lists/dropper_lists.html.jinja", lists=user_lists, json_encode=json_encode)
     </div>
     $if edition_key:
       <p class="create checkboxes">


### PR DESCRIPTION
Closes #13542

Refactor: converts the `MyBooksDropperLists` partial from Templetor to Jinja, following `AffiliateLinksPartial`. No behavior change.

### Technical
- New `openlibrary/templates/lists/dropper_lists.html.jinja` — a direct port of the 8-line Templetor template (one loop, one `set`).
- `MyBooksDropperListsPartial.generate()` renders it via `get_jinja_env().get_template("lists/dropper_lists.html.jinja")`. `json_encode` is passed as a render kwarg rather than an env global, as `core/jinja.py` suggests for one-off helpers. The `str(dropper)` wrapper is gone since `render()` already returns `str`.
- `{{ list.get('cover_url') or '' }}`: `get_user_lists()` builds these dicts with `include_cover_url=False`, so the key is absent. Templetor's `websafe` rendered a missing value as `""`; Jinja would print `None`. The `or ''` keeps the attribute identical.
- `openlibrary/templates/lists/dropper_lists.html` is kept because `my_books/dropdown_content.html:72` still renders it on the non-async path. I kept the diff to the issue's scope (the partial), but I'm happy to switch that caller to `render_jinja_template(...)` and delete the Templetor file in this PR if you'd prefer no duplicate.
- The template has no `_()` calls, so `messages.pot` is unchanged.

### Testing
Rendered the old Templetor template and the new Jinja template with the same four fixture lists (active/inactive, empty `list_items`, `<script>` / `&` / quotes in list names, `cover_url` absent / `None` / set) and compared the results:
- Parsed DOM (tags, decoded attribute values, text nodes): identical.
- `data-list-items` decodes back to the original list for every entry.
- Byte-level differences only: indentation from djlint's formatting, and `&#34;` (markupsafe) vs `&quot;` (web.py) for the same `"` character. The same DOM-vs-bytes question is open on #13556; whichever ruling lands there applies here too.

Endpoint: `GET /partials/MyBooksDropperLists.json` while logged in. `listData` is untouched.

I have not yet run `make test-py-uv` locally (Docker setup pending on my machine); relying on CI for the test run.

### Screenshot
N/A — the partial's HTML is DOM-identical (see Testing).

### Stakeholders
@RayBB
