### PR TITLE
perf: batch edition lookups with get_many in openlibrary/plugins/opelibrary/api.py

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -681,7 +681,7 @@ class unlink_ia_ol(delegate.page):
         if not edition_keys:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
-        editions = [web.ctx.site.get(key) for key in edition_keys]
+        editions = web.ctx.site.get_many(edition_keys)
         logger.info(f"Disassociating {ocaid} from the following editions: {', '.join(edition_keys)}")
 
         # Update records

--- a/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
@@ -102,12 +102,14 @@ def test_post_passes_comment_through_to_make_dark():
         mock_verify.return_value = True
         mock_web_ctx.site = MagicMock()
         mock_web_ctx.site.things.side_effect = [["/books/OL1M"], []]
-        mock_web_ctx.site.get.return_value = FakeEdition({"key": "/books/OL1M"})
+        edition = FakeEdition({"key": "/books/OL1M"})
+        mock_web_ctx.site.get_many.return_value = [edition]
 
         result = json.loads(unlink_ia_ol().POST()["rawtext"])
 
         assert result == {"status": "ok"}
-        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "Wrong item, mismatched during digitization")
+        mock_web_ctx.site.get_many.assert_called_once_with(["/books/OL1M"])
+        mock_make_dark.assert_called_once_with(edition, "foo123", "Wrong item, mismatched during digitization")
 
 
 def test_post_missing_comment_passes_empty_string_through():
@@ -122,8 +124,10 @@ def test_post_missing_comment_passes_empty_string_through():
         mock_verify.return_value = True
         mock_web_ctx.site = MagicMock()
         mock_web_ctx.site.things.side_effect = [["/books/OL1M"], []]
-        mock_web_ctx.site.get.return_value = FakeEdition({"key": "/books/OL1M"})
+        edition = FakeEdition({"key": "/books/OL1M"})
+        mock_web_ctx.site.get_many.return_value = [edition]
 
         json.loads(unlink_ia_ol().POST()["rawtext"])
 
-        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "")
+        mock_web_ctx.site.get_many.assert_called_once_with(["/books/OL1M"])
+        mock_make_dark.assert_called_once_with(edition, "foo123", "")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
fix: part1 #12432

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix an N+1 database query pattern in the `/api/unlink` endpoint by batching edition lookups with `get_many()`.

### Technical
- Replaced per-edition `site.get()` calls with a single `site.get_many(edition_keys)` call.
- All edition keys are already known before fetching, so they can be safely batched.
- No functional behavior change; the same editions are fetched and processed.

### Testing
- Verified the `/api/unlink` endpoint before and after the change using a signed request.
- Verified the endpoint continues to return successfully after the change.

### Screenshot
Not applicable — this change affects an internal API endpoint and has no UI changes.

### Stakeholders
<!-- @ tag the lead and other stakeholders -->
@RayBB 