### PR TITLE
perf: batch work lookups in bulk tagging

### DIFF
--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -35,9 +35,10 @@ class bulk_tag_works(delegate.page):
         # Number of tags removed per work:
         docs_removing = 0
 
-        for work in works:
-            w = web.ctx.site.get(f"/works/{work}")
+        keys = [f"/works/{work}" for work in works]
+        ws = web.ctx.site.get_many(keys)
 
+        for w in ws:
             current_subjects = {
                 # XXX : Should an empty list be the default for these?
                 "subjects": uniq(w.get("subjects", "")),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
fix: part2 #12432 
followup of #13574

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Technical
Batch work lookups in `bulk_tag.py` by replacing individual `site.get()` calls with `site.get_many()`.

This changes the lookup pattern from N individual requests to batched requests (up to 100 keys per batch), while keeping the existing tagging and removal logic unchanged.

### Testing
Verified against the live Docker dev app:

- Multi-work add/remove — passed
- Single-work `book_page_edit=true` — passed
- Missing work ID handling — passed
- 220 work IDs — passed, including `get_many()` batching
- Test data cleaned up after testing

### Performance
The change removes the N+1 work lookup pattern:

`N × get()` → `ceil(N / 100) × get_many()`

### Screenshot
Not applicable — this PR does not change the UI.

### Stakeholders
@RayBB 