### PR TITLE
perf: batch readinglog work lookups

### DIFF
--- a/openlibrary/tests/views/test_loanstats.py
+++ b/openlibrary/tests/views/test_loanstats.py
@@ -1,0 +1,121 @@
+"""Tests for the /stats/readinglog view (openlibrary.views.loanstats).
+
+Covers the batch-fetch of works missed by Solr (internetarchive/openlibrary#12432),
+which replaced per-work web.ctx.site.get() calls with a single get_many() lookup.
+"""
+
+import web
+
+from openlibrary.views import loanstats
+
+FAKE_LEADERBOARD = {
+    "reading_log": {},
+    "leaderboard": {
+        "most_read": [{"work_id": 1, "cnt": 100}],
+        "most_wanted_all": [{"work_id": 2, "cnt": 50}, {"work_id": 3, "cnt": 30}],
+        "most_wanted_month": [{"work_id": 4, "cnt": 20}],
+        "most_rated_all": [{"work_id": 5, "cnt": 10}],
+    },
+}
+
+ALL_WORK_IDS = tuple(w["work_id"] for board in FAKE_LEADERBOARD["leaderboard"].values() for w in board)
+ALL_WORK_KEYS = [f"/works/OL{i}W" for i in ALL_WORK_IDS]
+
+
+def seed_works(mock_site, work_ids):
+    """Save simple /works/OL<N>W docs into the mock site."""
+    for work_id in work_ids:
+        mock_site.quicksave(f"/works/OL{work_id}W", type="/type/work", title=f"Work {work_id}")
+
+
+class TestReadinglogStats:
+    def _call_view(self, mock_site, monkeypatch, solr_docs, seed=(), expect_typeerror=False):
+        """Seed works, stub out solr/stats/availability/templates and call GET().
+
+        Returns (get_many_calls, leaderboard_items) so tests can assert on the
+        batching behavior and on the works attached to each leaderboard item.
+        """
+        seed_works(mock_site, seed)
+
+        def fake_stats(limit):
+            return FAKE_LEADERBOARD
+
+        def no_availabilities(works):
+            return {}
+
+        monkeypatch.setattr(loanstats, "get_cached_reading_log_stats", fake_stats)
+        monkeypatch.setattr(loanstats, "get_solr_works", solr_docs)
+        monkeypatch.setattr(loanstats, "get_availabilities", no_availabilities)
+        monkeypatch.setattr(loanstats.app, "render_template", lambda *a, **kw: web.storage())
+
+        original_get_many = mock_site.get_many
+        get_many_calls = []
+
+        def counting_get_many(keys):
+            get_many_calls.append(list(keys))
+            return original_get_many(keys)
+
+        monkeypatch.setattr(mock_site, "get_many", counting_get_many)
+
+        # Let web.input() see defaults as a real GET request would.
+        web.ctx.env = web.ctx.environ = web.storage(REQUEST_METHOD="GET", QUERY_STRING="limit=10&mode=all")
+
+        try:
+            loanstats.readinglog_stats().GET()
+        except TypeError:
+            # A work missing from both Solr and the DB resolves to None in
+            # item["work"], and the (pre-existing) availability-injection loop
+            # crashes on it. That behavior is unchanged by this refactor.
+            if not expect_typeerror:
+                raise
+
+        all_items = [item for board in FAKE_LEADERBOARD["leaderboard"].values() for item in board]
+        return get_many_calls, all_items
+
+    def _assert_batched(self, get_many_calls, expected_keys):
+        assert len(get_many_calls) <= 1
+        if expected_keys:
+            assert len(get_many_calls) == 1
+            assert {key for keys in get_many_calls for key in keys} == set(expected_keys)
+        else:
+            assert get_many_calls == []
+
+    def test_all_solr_hits_does_not_call_get_many(self, mock_site, monkeypatch):
+        # Solr returns every work, so there is nothing to batch-fetch from the DB.
+        solr_docs = {key: {"key": key} for key in ALL_WORK_KEYS}
+
+        get_many_calls, all_items = self._call_view(mock_site, monkeypatch, lambda keys: solr_docs)
+
+        self._assert_batched(get_many_calls, [])
+
+        for item in all_items:
+            assert item["work"]["key"] == f"/works/OL{item['work_id']}W"
+
+    def test_mixed_solr_hit_and_miss_batches_missing_keys(self, mock_site, monkeypatch):
+        # Solr returns half the works; the other half must be batch-fetched from the DB.
+        hit_ids = (1, 2)
+        miss_ids = (3, 4, 5)
+        solr_docs = {f"/works/OL{i}W": {"key": f"/works/OL{i}W", "title": f"Solr {i}"} for i in hit_ids}
+
+        get_many_calls, all_items = self._call_view(mock_site, monkeypatch, lambda keys: solr_docs, seed=ALL_WORK_IDS)
+
+        self._assert_batched(get_many_calls, [f"/works/OL{i}W" for i in miss_ids])
+
+        for item in all_items:
+            assert item["work"]["key"] == f"/works/OL{item['work_id']}W"
+
+    def test_missing_work_yields_none_keeps_found_ones(self, mock_site, monkeypatch):
+        # No Solr hits at all; every leaderboard work is fetched from the DB,
+        # but works 3 and 5 don't exist there either. They resolve to None
+        # (matching the old per-key site.get() behavior), which crashes the
+        # pre-existing availability-injection loop -- so expect a TypeError.
+        get_many_calls, all_items = self._call_view(mock_site, monkeypatch, lambda keys: {}, seed=(1, 2, 4), expect_typeerror=True)
+
+        self._assert_batched(get_many_calls, ALL_WORK_KEYS)
+
+        works_by_id = {item["work_id"]: item["work"] for item in all_items}
+        assert works_by_id[1]["key"] == "/works/OL1W"
+        assert works_by_id[2]["key"] == "/works/OL2W"
+        assert works_by_id[3] is None
+        assert works_by_id[4]["key"] == "/works/OL4W"
+        assert works_by_id[5] is None

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -193,7 +193,13 @@ class readinglog_stats(app.view):
 
         stats = get_cached_reading_log_stats(limit)
 
-        solr_docs = get_solr_works({f"/works/OL{item['work_id']}W" for leaderboard in stats["leaderboard"].values() for item in leaderboard})
+        all_keys = {f"/works/OL{item['work_id']}W" for leaderboard in stats["leaderboard"].values() for item in leaderboard}
+        solr_docs = get_solr_works(all_keys)
+
+        # Batch-fetch any works Solr missed in a single call instead of
+        # one web.ctx.site.get() per work (N+1).
+        miss_keys = [key for key in all_keys if key not in solr_docs]
+        db_works = {w.key: w for w in web.ctx.site.get_many(miss_keys)} if miss_keys else {}
 
         # Fetch works from solr and inject into leaderboard
         for leaderboard in stats["leaderboard"].values():
@@ -202,7 +208,7 @@ class readinglog_stats(app.view):
                 if key in solr_docs:
                     item["work"] = solr_docs[key]
                 else:
-                    item["work"] = web.ctx.site.get(key)
+                    item["work"] = db_works.get(key)
 
         works = [item["work"] for leaderboard in stats["leaderboard"].values() for item in leaderboard]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
fix: part3 #12432
follow after #13583 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces per-work `site.get()` calls with a batched `get_many()` when Solr misses works, removing the N+1 lookup pattern.

### Technical
- Collects Solr-missed work keys before the injection loop.
- Fetches all missed works with a single `get_many()` call.
- Keeps the existing Solr-first behavior and output unchanged.
- Added regression tests covering all-Solr hits, mixed Solr/DB results, and missing works.

### Testing
- 3/3 new loanstats tests pass.
- 30 related tests pass.
- Broader test suite: 1928 passed, 4 pre-existing unrelated failures.
- Pre-commit hooks pass.
- Live `GET /stats/readinglog?limit=10&mode=all` returns HTTP 200.
- Verified old path: N `site.get()` calls.
- Verified new path: 1 `get_many()` call.
- Verified output equivalence between old and new paths.

Test file is generated by AI

### Stakeholders
@RayBB 