### PR TITLE
Add option for upper bound to `store_index` backfill script

### DIFF
--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -58,7 +58,7 @@ def main(args):
     init(args.config)
 
     # Find min new_id (for upper limit)
-    max_upper_bound = find_upper_bound()
+    max_upper_bound = args.upper_bound if args.upper_bound else find_upper_bound()
 
     # Backfill new IDs in batches
     lower_bound = args.lower_bound
@@ -88,6 +88,7 @@ def _parse_args():
         type=float,
         help="If non-zero, the script will stop if the WAL directory grows beyond this many GB",
     )
+    p.add_argument("-u", "--upper-bound", default=0, type=int)
     p.set_defaults(func=main)
     return p.parse_args()
 

--- a/scripts/backfill_store_index.py
+++ b/scripts/backfill_store_index.py
@@ -58,7 +58,7 @@ def main(args):
     init(args.config)
 
     # Find min new_id (for upper limit)
-    max_upper_bound = args.upper_bound if args.upper_bound else find_upper_bound()
+    max_upper_bound = args.upper_bound or find_upper_bound()
 
     # Backfill new IDs in batches
     lower_bound = args.lower_bound


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #13521

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds the following the the `store_index.new_id` backfill script:

- `--upper-bound` option for setting the upper bound ID

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
