### PR TITLE
fix(models): only save known user preference keys

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -11,7 +11,6 @@ from urllib.parse import urlencode
 
 import requests
 import web
-
 from infogami.infobase import client
 from infogami.utils import types
 
@@ -902,6 +901,21 @@ class Author(Thing):
 
 
 class User(Thing):
+    #: Preference keys that may be written via :meth:`save_preferences`.
+    #: ``type`` is managed internally and always forced to ``preferences``.
+    PREFERENCE_KEYS = frozenset(
+        {
+            "notify",
+            "pda",
+            "public_readlog",
+            "rpd",
+            "safe_mode",
+            "update",
+            "updates",
+            "yrg_banner_pref",
+        }
+    )
+
     def get_default_preferences(self) -> dict[str, str]:
         return {"update": "no", "public_readlog": "no", "type": "preferences"}
         # New users are now public by default for new patrons
@@ -938,7 +952,7 @@ class User(Thing):
     def save_preferences(self, new_prefs) -> None:
         key = f"{self.key}/preferences"
         prefs = self.preferences()
-        prefs.update(new_prefs)
+        prefs.update({k: v for k, v in new_prefs.items() if k in self.PREFERENCE_KEYS})
         prefs["_rev"] = None
         prefs["type"] = "preferences"
         site.get().store[key] = prefs

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 
 import requests
 import web
+
 from infogami.infobase import client
 from infogami.utils import types
 

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -5,9 +5,9 @@ Capture some of the unintuitive aspects of Storage, Things, and Works
 from unittest.mock import patch
 
 import web
-from infogami.infobase import client
 
 import openlibrary.core.lists.model as list_model
+from infogami.infobase import client
 from openlibrary.core.cache import _get_cache
 from openlibrary.mocks.mock_infobase import MockSite
 from openlibrary.utils.request_context import site as site_context

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -5,9 +5,9 @@ Capture some of the unintuitive aspects of Storage, Things, and Works
 from unittest.mock import patch
 
 import web
+from infogami.infobase import client
 
 import openlibrary.core.lists.model as list_model
-from infogami.infobase import client
 from openlibrary.core.cache import _get_cache
 from openlibrary.mocks.mock_infobase import MockSite
 from openlibrary.utils.request_context import site as site_context
@@ -99,6 +99,31 @@ class TestModels:
         assert user.get_safe_mode() == "no"
         user.save_preferences({"safe_mode": "yes"})
         assert user.get_safe_mode() == "yes"
+
+    def test_save_preferences_ignores_unknown_keys(self, mock_site):
+        user = models.User(mock_site, "user")
+        user.save_preferences(
+            {
+                "public_readlog": "yes",
+                "save": "Save",
+                "debug": "true",
+                "has_fulltext": "true",
+            }
+        )
+        prefs = user.preferences()
+        assert prefs.get("public_readlog") == "yes"
+        assert "save" not in prefs
+        assert "debug" not in prefs
+        assert "has_fulltext" not in prefs
+
+    def test_save_preferences_keeps_known_keys(self, mock_site):
+        user = models.User(mock_site, "user")
+        user.save_preferences({"updates": "yes", "pda": "pda", "rpd": "1", "yrg_banner_pref": "yrg26"})
+        prefs = user.preferences()
+        assert prefs["updates"] == "yes"
+        assert prefs["pda"] == "pda"
+        assert prefs["rpd"] == "1"
+        assert prefs["yrg_banner_pref"] == "yrg26"
 
 
 class TestGetAvatarUrl:


### PR DESCRIPTION
Closes #832

## Summary

`account_privacy` and `account_notifications` POST handlers save `web.input()` (the full form/query payload) into the user's preferences document via `User.save_preferences`. As #832 reports, that persists junk keys such as the `save` submit button, `debug`, or `has_fulltext` into `/people/{user}/preferences`.

This PR centralizes key validation in `User.save_preferences`: only keys the codebase actually reads or writes are merged into stored preferences; everything else is dropped.

Whitelist (from usages across the repo):
- `public_readlog`, `safe_mode` - privacy form
- `updates`, `update`, `notify` - notifications form and legacy defaults
- `pda`, `rpd` - print-disability helpers (`OpenLibraryAccount.update_pd`)
- `yrg_banner_pref` - banner dismissal persistence

`type` is managed internally and is forced to `preferences` after the merge, so it is intentionally not in the whitelist.

## Behavior

Unchanged for all legitimate flows: both forms submit only whitelisted fields, and backend callers (`update_pd`, hide-banner endpoint) use whitelisted keys. Unknown keys posted by clients are no longer persisted.

## Testing

- New unit tests in `openlibrary/plugins/upstream/tests/test_models.py`:
  - `test_save_preferences_ignores_unknown_keys` - reproduces the issue payload (`save`, `debug`, `has_fulltext`); fails without the fix, passes with it.
  - `test_save_preferences_keeps_known_keys` - guards the whitelisted keys.
- `pytest openlibrary/plugins/upstream/tests/test_models.py openlibrary/tests/fastapi/test_hide_banner.py openlibrary/tests/fastapi/test_account.py`: my new tests plus all hide-banner/account endpoint tests pass (54 passed, 1 xfailed when run with the related fastapi files; `test_models.py` standalone: 11 passed with 2 pre-existing ContextVar-ordering failures in `TestModels` that also fail on unmodified master in a standalone run).
- `ruff check` + `ruff format`, `codespell`, `auto-walrus`, `mypy` on the changed files: clean.

Pre-commit hooks were not run as a whole (no Python 3.14 on PATH on this machine); equivalent individual hooks were run directly.