### PR TITLE
fix(agentic): restore `id-token: write` — pr_autoresponder.yml is an invalid workflow file

### DIFF
--- a/.github/workflows/pr_autoresponder.yml
+++ b/.github/workflows/pr_autoresponder.yml
@@ -39,7 +39,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: read
+  # Must be `write`: GitHub accepts only `write` or `none` here, so `read` made the whole
+  # file unparseable, and `none` would break the OIDC fetch described above.
+  id-token: write
 
 concurrency:
   # `github.event.pull_request.number` is empty on workflow_dispatch, which collapsed


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

Hotfix. `.github/workflows/pr_autoresponder.yml` has been an invalid workflow file since #13262 merged on 2026-09-08, which takes down the PR auto-responder and puts a red X on every push and PR in the repo.

```
Invalid workflow file: .github/workflows/pr_autoresponder.yml#L42
(Line: 42, Col: 13): Unexpected value 'read'
```

`id-token` is the one `GITHUB_TOKEN` scope that does **not** accept `read` — GitHub allows only `write` or `none`. #13262 changed it from `write` to `read`, so the file no longer parses.

### Technical

`write` is what the file was always meant to have, and the header comment added in that same PR says so:

> Under `pull_request`, a fork-originated run gets a read-only GITHUB_TOKEN and cannot be granted `id-token: write` at all, so claude-code-action dies before doing anything: `Action failed with error: Could not fetch an OIDC token.`

`none` is not an option either, for the same reason — the action needs a real OIDC token. I added a short comment on the line so it doesn't get "least-privileged" back to `read` later.

Two consequences worth separating, because they look like one bug but aren't:

1. **The auto-responder no longer runs at all.** 107 runs since the merge, 107 failures, 0 successes. Not one first-touch comment has been posted in that window.
2. **The failure is charged to unrelated events.** Because the file can't be parsed, GitHub can't read its `on:` block either, so it reports the parse error against whatever event it saw. The workflow subscribes only to `pull_request_target` and `workflow_dispatch`, yet 69 of those 107 runs are `push` — including pushes straight to `master`. `push` had essentially never triggered this workflow before; the first one is at `2026-09-08T22:29Z`, minutes after the merge.

Each of those zero-job runs sends a "Run failed" email to whoever pushed. Over ~2 days that landed on 10 distinct actors:

| actor | failed runs |
|---|---|
| lokesh | 36 |
| RayBB | 28 |
| renovate[bot] | 20 |
| pre-commit-ci[bot] | 7 |
| mekarpeles | 7 |
| jimchamp | 3 |
| cdrini | 3 |
| Ved-sketch / Sanket17052006 / RsbhThakur | 1 each |

This is distinct from #13214. That bug made fork PRs fail *inside* the job (`Set up job` → `checkout` → `First-touch PR response` fails on the OIDC fetch); pre-2026-09-08 failed runs still show 1 job and 6 steps. Every run after the merge has **0 jobs** — nothing is dispatched. #13214's fork-PR fix is otherwise intact in this PR and I haven't touched it.

### Testing

```bash
git fetch upstream master && git show upstream/master:.github/workflows/pr_autoresponder.yml | sed -n '42p'
#   id-token: read

gh run list --repo internetarchive/openlibrary --workflow pr_autoresponder.yml --limit 100 \
  --json conclusion --jq '[.[].conclusion] | group_by(.) | map({(.[0]): length}) | add'
# {"failure":100}

gh api repos/internetarchive/openlibrary/actions/runs/34539227530/jobs --jq '.jobs | length'
# 0
```

On this branch the file parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr_autoresponder.yml'))"`), and `pre-commit run --files .github/workflows/pr_autoresponder.yml` passes, zizmor included.

The real confirmation is post-merge: the next push to `master` should stop producing a `pr_autoresponder.yml` run entirely, and the next fork PR should get a first-touch comment. Worth watching one of each before calling it done — if the auto-responder still posts nothing on a fork PR after this, that's #13214 resurfacing, not this fix failing.

### Stakeholders

@mekarpeles @RayBB
