### PR TITLE
refactor: pass request params as args to is_spam and Recaptcha (#13538)

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -32,15 +32,19 @@ class Recaptcha(web.form.Input):
         self.error = None
 
     def validate(self, value=None):
+        """web.py form Validator shim. Signup forms call this with the field value."""
+        i = web.input()
+        return self.validate_response(i.get("g-recaptcha-response"), web.ctx.ip)
+
+    def validate_response(self, response=None, remoteip=None):
         def accept_error(error_codes: list[str]) -> bool:
             return not any(error in INVALIDATING_ERRORS for error in error_codes)
 
-        i = web.input()
         url = config.get("recaptcha_url")
         params = {
             "secret": self._private_key,
-            "response": i.get("g-recaptcha-response"),
-            "remoteip": web.ctx.ip,
+            "response": response,
+            "remoteip": remoteip,
         }
 
         try:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -249,7 +249,7 @@ class addbook(delegate.page):
 
         if not accounts.get_current_user():
             recap = get_recaptcha()
-            if recap and not recap.validate():
+            if recap and not recap.validate_response(i.get("g-recaptcha-response"), web.ctx.ip):
                 return render_template(
                     "message.html",
                     "Recaptcha solution was incorrect",
@@ -813,12 +813,13 @@ class book_edit(delegate.page):
 
     def POST(self, key):
         i = web.input(v=None, work_key=None, _method="GET")
+        form_data = web.input()
 
-        if spamcheck.is_spam(allow_privileged_edits=True):
+        if spamcheck.is_spam(form_data, allow_privileged_edits=True):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
-        if recap and not recap.validate():
+        if recap and not recap.validate_response(form_data.get("g-recaptcha-response"), web.ctx.ip):
             return render_template(
                 "message.html",
                 "Recaptcha solution was incorrect",
@@ -876,13 +877,14 @@ class work_edit(delegate.page):
 
     def POST(self, key):
         i = web.input(v=None, _method="GET")
+        form_data = web.input()
 
-        if spamcheck.is_spam(allow_privileged_edits=True):
+        if spamcheck.is_spam(form_data, allow_privileged_edits=True):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
 
-        if recap and not recap.validate():
+        if recap and not recap.validate_response(form_data.get("g-recaptcha-response"), web.ctx.ip):
             return render_template(
                 "message.html",
                 "Recaptcha solution was incorrect",

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -84,7 +84,7 @@ class edit(core.edit):
             return core.edit.GET(self, key)
 
     def POST(self, key):
-        if re.compile("/(people/[^/]+)").match(key) and spamcheck.is_spam():
+        if re.compile("/(people/[^/]+)").match(key) and spamcheck.is_spam(web.input()):
             return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
         return core.edit.POST(self, key)
 

--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -1,8 +1,6 @@
 import re
 from collections.abc import Iterable
 
-import web
-
 from openlibrary.utils.request_context import site
 
 
@@ -32,7 +30,7 @@ def _update_spam_doc(**kwargs) -> None:
     site.get().store["spamwords"] = doc
 
 
-def is_spam(i=None, allow_privileged_edits: bool = False) -> bool:
+def is_spam(i, allow_privileged_edits: bool = False) -> bool:
     user = site.get().get_user()
 
     if user:
@@ -56,8 +54,6 @@ def is_spam(i=None, allow_privileged_edits: bool = False) -> bool:
         return True
 
     spamwords = get_spam_words()
-    if i is None:
-        i = web.input()
     text = str(dict(i)).lower()
     return any(re.search(w.lower(), text) for w in spamwords)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13538

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Part of #13536. Thread spam and captcha request data as explicit arguments so these helpers no longer hide `web.input()` / `web.ctx.ip` reads. Same behavior.

This is a second attempt after #13547. That PR renamed `Recaptcha.validate` so web.py forms passed the empty field value in as the Google token, which would fail every signup when reCAPTCHA is on. Ray's review asked to keep `validate(self, value=None)` as the form shim.

### Technical
- `spamcheck.is_spam(i, ...)` now requires `i`. The `web.input()` fallback is gone.
- `book_edit.POST` / `work_edit.POST` pass `web.input()` (full POST), not the GET-only `i`.
- `edit.POST` for people pages passes `web.input()`.
- `Recaptcha.validate(self, value=None)` stays registered as the `web.form.Validator` callback (signup `/account/create`).
- New `Recaptcha.validate_response(response, remoteip)` does the Google call with no web globals. Add/edit book call that.

### Testing
- `ruff check` / `ruff format` on the four files.
- `python3.14 -m py_compile` on the four files.
- Did not add tests (issue asks to run existing ones only). GitHub Actions should run `make test-py-uv`.
- Signup path is unchanged: still `Validator(..., self.validate)`, which still reads `g-recaptcha-response` from the request. I do not have recaptcha keys in local docker, so I could not screenshot a live signup.

### Screenshot
N/A — no UI change. Recaptcha markup is the same.

### Stakeholders
@RayBB